### PR TITLE
fix(lint): resolve all clippy warnings for clean CI

### DIFF
--- a/crates/common/src/instrument_registry.rs
+++ b/crates/common/src/instrument_registry.rs
@@ -405,7 +405,7 @@ mod tests {
         assert_eq!(grouped.get(&ExchangeSegment::IdxI).unwrap().len(), 1);
         assert_eq!(grouped.get(&ExchangeSegment::NseEquity).unwrap().len(), 1);
         assert_eq!(grouped.get(&ExchangeSegment::NseFno).unwrap().len(), 1);
-        assert!(grouped.get(&ExchangeSegment::BseFno).is_none());
+        assert!(!grouped.contains_key(&ExchangeSegment::BseFno));
     }
 
     #[test]

--- a/crates/core/src/instrument/subscription_planner.rs
+++ b/crates/core/src/instrument/subscription_planner.rs
@@ -653,8 +653,10 @@ mod tests {
     #[test]
     fn test_disable_stock_derivatives() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.subscribe_stock_derivatives = false;
+        let config = SubscriptionConfig {
+            subscribe_stock_derivatives: false,
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -666,8 +668,10 @@ mod tests {
     #[test]
     fn test_disable_display_indices() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.subscribe_display_indices = false;
+        let config = SubscriptionConfig {
+            subscribe_display_indices: false,
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -678,8 +682,10 @@ mod tests {
     #[test]
     fn test_disable_index_derivatives() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.subscribe_index_derivatives = false;
+        let config = SubscriptionConfig {
+            subscribe_index_derivatives: false,
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -691,8 +697,10 @@ mod tests {
     #[test]
     fn test_disable_stock_equities() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.subscribe_stock_equities = false;
+        let config = SubscriptionConfig {
+            subscribe_stock_equities: false,
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -748,8 +756,10 @@ mod tests {
     #[test]
     fn test_feed_mode_from_config() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.feed_mode = "Quote".to_string();
+        let config = SubscriptionConfig {
+            feed_mode: "Quote".to_string(),
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -763,8 +773,10 @@ mod tests {
     #[test]
     fn test_feed_mode_full() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.feed_mode = "Full".to_string();
+        let config = SubscriptionConfig {
+            feed_mode: "Full".to_string(),
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -775,8 +787,10 @@ mod tests {
     #[test]
     fn test_feed_mode_invalid_falls_back_to_ticker() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.feed_mode = "Invalid".to_string();
+        let config = SubscriptionConfig {
+            feed_mode: "Invalid".to_string(),
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -788,9 +802,11 @@ mod tests {
     #[test]
     fn test_atm_strike_range_narrow() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.stock_atm_strikes_above = 1;
-        config.stock_atm_strikes_below = 1;
+        let config = SubscriptionConfig {
+            stock_atm_strikes_above: 1,
+            stock_atm_strikes_below: 1,
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);
@@ -802,9 +818,11 @@ mod tests {
     #[test]
     fn test_atm_strike_range_zero() {
         let universe = make_test_universe();
-        let mut config = SubscriptionConfig::default();
-        config.stock_atm_strikes_above = 0;
-        config.stock_atm_strikes_below = 0;
+        let config = SubscriptionConfig {
+            stock_atm_strikes_above: 0,
+            stock_atm_strikes_below: 0,
+            ..Default::default()
+        };
         let today = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
 
         let plan = build_subscription_plan(&universe, &config, today);

--- a/crates/core/src/instrument/universe_builder.rs
+++ b/crates/core/src/instrument/universe_builder.rs
@@ -1096,9 +1096,9 @@ mod tests {
         let lookup = build_index_lookup(&rows);
 
         // Equities should not appear
-        assert!(lookup.get("RELIANCE").is_none());
+        assert!(!lookup.contains_key("RELIANCE"));
         // Derivatives should not appear
-        assert!(lookup.get("NIFTY-2026-03-30-FUT").is_none());
+        assert!(!lookup.contains_key("NIFTY-2026-03-30-FUT"));
     }
 
     #[test]
@@ -1136,8 +1136,8 @@ mod tests {
         let rows = build_test_rows();
         let lookup = build_equity_lookup(&rows);
 
-        assert!(lookup.get("NIFTY").is_none());
-        assert!(lookup.get("SENSEX").is_none());
+        assert!(!lookup.contains_key("NIFTY"));
+        assert!(!lookup.contains_key("SENSEX"));
     }
 
     #[test]
@@ -2064,7 +2064,7 @@ mod tests {
 
         // The BSE FUTSTK (security_id 80010) must NOT be in contracts
         assert!(
-            result.derivative_contracts.get(&80010).is_none(),
+            !result.derivative_contracts.contains_key(&80010),
             "BSE FUTSTK must be filtered from derivative contracts"
         );
     }
@@ -2088,7 +2088,7 @@ mod tests {
 
         // The BSE OPTSTK (security_id 80020) must NOT be in contracts
         assert!(
-            result.derivative_contracts.get(&80020).is_none(),
+            !result.derivative_contracts.contains_key(&80020),
             "BSE OPTSTK must be filtered from derivative contracts"
         );
     }
@@ -2102,19 +2102,19 @@ mod tests {
 
         // SENSEX future (security_id 60000) should be present
         assert!(
-            result.derivative_contracts.get(&60000).is_some(),
+            result.derivative_contracts.contains_key(&60000),
             "BSE FUTIDX (SENSEX) must be present in derivative contracts"
         );
 
         // BANKEX future (security_id 60001) should be present
         assert!(
-            result.derivative_contracts.get(&60001).is_some(),
+            result.derivative_contracts.contains_key(&60001),
             "BSE FUTIDX (BANKEX) must be present in derivative contracts"
         );
 
         // SENSEX50 future (security_id 60002) should be present
         assert!(
-            result.derivative_contracts.get(&60002).is_some(),
+            result.derivative_contracts.contains_key(&60002),
             "BSE FUTIDX (SENSEX50) must be present in derivative contracts"
         );
     }

--- a/crates/core/src/parser/dispatcher.rs
+++ b/crates/core/src/parser/dispatcher.rs
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn test_dispatch_previous_close() {
         let mut buf = make_minimal_packet(RESPONSE_CODE_PREVIOUS_CLOSE, PREVIOUS_CLOSE_PACKET_SIZE);
-        buf[8..12].copy_from_slice(&24300.50f32.to_le_bytes());
+        buf[8..12].copy_from_slice(&24_300.5_f32.to_le_bytes());
         buf[12..16].copy_from_slice(&120000u32.to_le_bytes());
         match dispatch_frame(&buf, 0).unwrap() {
             ParsedFrame::PreviousClose {
@@ -171,7 +171,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(security_id, 42);
-                assert!((previous_close - 24300.50).abs() < 0.01);
+                assert!((previous_close - 24_300.5).abs() < 0.01);
                 assert_eq!(previous_oi, 120000);
             }
             other => panic!("expected PreviousClose, got {other:?}"),

--- a/crates/core/src/parser/full_packet.rs
+++ b/crates/core/src/parser/full_packet.rs
@@ -134,6 +134,7 @@ mod tests {
     use dhan_live_trader_common::constants::EXCHANGE_SEGMENT_NSE_FNO;
 
     /// Builds a complete 162-byte Full packet.
+    #[allow(clippy::too_many_arguments)]
     fn make_full_packet(
         segment: u8,
         security_id: u32,
@@ -210,7 +211,7 @@ mod tests {
         let (buf, hdr) = make_full_packet(
             EXCHANGE_SEGMENT_NSE_FNO,
             13,
-            24500.50,
+            24_500.5,
             100,
             1740556500,
             24450.25,
@@ -230,7 +231,7 @@ mod tests {
 
         // Tick fields
         assert_eq!(tick.security_id, 13);
-        assert!((tick.last_traded_price - 24500.50).abs() < 0.01);
+        assert!((tick.last_traded_price - 24_500.5).abs() < 0.01);
         assert_eq!(tick.last_trade_quantity, 100);
         assert_eq!(tick.exchange_timestamp, 1740556500);
         assert_eq!(tick.received_at_nanos, 777);

--- a/crates/core/src/parser/previous_close.rs
+++ b/crates/core/src/parser/previous_close.rs
@@ -72,9 +72,9 @@ mod tests {
 
     #[test]
     fn test_parse_previous_close_valid() {
-        let (buf, hdr) = make_prev_close_packet(13, 24300.50, 120000);
+        let (buf, hdr) = make_prev_close_packet(13, 24_300.5, 120000);
         let data = parse_previous_close_packet(&buf, &hdr).unwrap();
-        assert!((data.previous_close - 24300.50).abs() < 0.01);
+        assert!((data.previous_close - 24_300.5).abs() < 0.01);
         assert_eq!(data.previous_oi, 120000);
     }
 

--- a/crates/core/src/parser/quote.rs
+++ b/crates/core/src/parser/quote.rs
@@ -89,6 +89,7 @@ mod tests {
     use dhan_live_trader_common::constants::EXCHANGE_SEGMENT_NSE_FNO;
 
     /// Builds a complete 50-byte Quote packet with all fields.
+    #[allow(clippy::too_many_arguments)]
     fn make_quote_packet(
         segment: u8,
         security_id: u32,
@@ -137,7 +138,7 @@ mod tests {
         let (buf, hdr) = make_quote_packet(
             EXCHANGE_SEGMENT_NSE_FNO,
             13,
-            24500.50,
+            24_500.5,
             100,
             1740556500,
             24450.25,
@@ -153,7 +154,7 @@ mod tests {
 
         assert_eq!(tick.security_id, 13);
         assert_eq!(tick.exchange_segment_code, EXCHANGE_SEGMENT_NSE_FNO);
-        assert!((tick.last_traded_price - 24500.50).abs() < 0.01);
+        assert!((tick.last_traded_price - 24_500.5).abs() < 0.01);
         assert_eq!(tick.last_trade_quantity, 100);
         assert_eq!(tick.exchange_timestamp, 1740556500);
         assert_eq!(tick.received_at_nanos, 888);

--- a/crates/core/src/websocket/types.rs
+++ b/crates/core/src/websocket/types.rs
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn test_connection_state_clone_and_copy() {
         let state = ConnectionState::Connected;
-        let cloned = state.clone();
+        let cloned = state;
         let copied = state; // Copy trait
         assert_eq!(state, cloned);
         assert_eq!(state, copied);
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn test_disconnect_code_clone_and_copy() {
         let code = DisconnectCode::AccessTokenExpired;
-        let cloned = code.clone();
+        let cloned = code;
         let copied = code; // Copy trait
         assert_eq!(code, cloned);
         assert_eq!(code, copied);

--- a/crates/storage/src/tick_persistence.rs
+++ b/crates/storage/src/tick_persistence.rs
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn test_tick_buffer_single_row() {
         let mut buffer = Buffer::new(ProtocolVersion::V1);
-        let tick = make_test_tick(13, 24500.50);
+        let tick = make_test_tick(13, 24_500.5);
 
         let ts_nanos = TimestampNanos::new(i64::from(tick.exchange_timestamp) * 1_000_000_000);
         let received_nanos = TimestampNanos::new(tick.received_at_nanos);
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn test_tick_buffer_contains_expected_fields() {
         let mut buffer = Buffer::new(ProtocolVersion::V1);
-        let tick = make_test_tick(13, 24500.50);
+        let tick = make_test_tick(13, 24_500.5);
 
         let ts_nanos = TimestampNanos::new(i64::from(tick.exchange_timestamp) * 1_000_000_000);
         let received_nanos = TimestampNanos::new(tick.received_at_nanos);


### PR DESCRIPTION
## Summary
- Fix 30 pre-existing clippy warnings that caused CI Stage 2 (Lint) to fail on main after the supply chain PR merge
- All warnings are in test code — zero changes to production logic
- `cargo fmt` + `cargo clippy -D warnings` + `cargo test` all pass clean

## Changes
| Lint | Files | Fix |
|---|---|---|
| `unnecessary_get_then_check` | instrument_registry.rs, universe_builder.rs | `.get(k).is_some/none()` → `contains_key()` |
| `field_reassign_with_default` | subscription_planner.rs | Struct init syntax with `..Default::default()` |
| `excessive_precision` | tick_persistence.rs, full_packet.rs, quote.rs, previous_close.rs | `24500.50` → `24_500.5` |
| `clone_on_copy` | websocket/types.rs | Remove `.clone()` on Copy types |
| `too_many_arguments` | full_packet.rs, quote.rs | `#[allow]` on test helpers |

## Test plan
- [x] `cargo fmt --check` — zero diffs
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — 463 tests pass, 0 failures

https://claude.ai/code/session_01Dvcp8yajCpyMTXRJS7YS1x