### PR TITLE
fix(ide): IntelliJ clone-ready — zero warnings on fresh open

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="org.rust.lang" />
+    <plugin id="org.toml.lang" />
+    <plugin id="com.github.niclasvoss.git.codeowners" />
+    <plugin id="com.wsdjeg.intellij.shellcheck" />
+  </component>
+</project>

--- a/.idea/kubernetes-settings.xml
+++ b/.idea/kubernetes-settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KubernetesSettings">
+    <option name="clusterSupport" value="false" />
+  </component>
+</project>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="PROJECT" dialect="PostgreSQL" />
+    <file url="file://$PROJECT_DIR$/scripts/questdb-verify-connection.sql" dialect="PostgreSQL" />
+  </component>
+</project>

--- a/http/health-checks.http
+++ b/http/health-checks.http
@@ -3,24 +3,25 @@
 ### =============================================================================
 ### Run any request: click the green play button next to it.
 ### All services must be running (Docker Up) before testing.
+### Environment: select "dev" from the dropdown (top-right) before running.
 ### =============================================================================
 
 ### ---- Application ----
 
 ### App Health Check
-GET http://localhost:3001/health
+GET {{app_host}}/health
 
 ###
 
 ### ---- Databases ----
 
 ### QuestDB Health (HTTP API)
-GET http://localhost:9000/exec?query=SELECT%201
+GET {{questdb_host}}/exec?query=SELECT%201
 
 ###
 
 ### QuestDB Show Tables
-GET http://localhost:9000/exec?query=SHOW%20TABLES
+GET {{questdb_host}}/exec?query=SHOW%20TABLES
 
 ###
 
@@ -32,51 +33,51 @@ GET http://localhost:9000/exec?query=SHOW%20TABLES
 ### ---- Monitoring ----
 
 ### Prometheus Health
-GET http://localhost:9090/-/healthy
+GET {{prometheus_host}}/-/healthy
 
 ###
 
 ### Prometheus Targets (check scrape status)
-GET http://localhost:9090/api/v1/targets
+GET {{prometheus_host}}/api/v1/targets
 
 ###
 
 ### Grafana Health
-GET http://localhost:3000/api/health
+GET {{grafana_host}}/api/health
 
 ###
 
 ### Jaeger Health
-GET http://localhost:16686/
+GET {{jaeger_host}}/
 
 ###
 
 ### Jaeger Services List
-GET http://localhost:16686/api/services
+GET {{jaeger_host}}/api/services
 
 ###
 
 ### Loki Ready
-GET http://localhost:3100/ready
+GET {{loki_host}}/ready
 
 ###
 
 ### Alloy UI
-GET http://localhost:12345
+GET {{alloy_host}}
 
 ###
 
 ### ---- Infrastructure ----
 
 ### LocalStack Health
-GET http://localhost:4566/_localstack/health
+GET {{localstack_host}}/_localstack/health
 
 ###
 
 ### LocalStack SSM — List Parameters
-GET http://localhost:4566/_aws/ssm/parameters
+GET {{localstack_host}}/_aws/ssm/parameters
 
 ###
 
 ### Traefik Dashboard API
-GET http://localhost:8080/api/rawdata
+GET {{traefik_host}}/api/rawdata

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,13 @@
+{
+  "dev": {
+    "app_host": "http://localhost:3001",
+    "questdb_host": "http://localhost:9000",
+    "prometheus_host": "http://localhost:9090",
+    "grafana_host": "http://localhost:3000",
+    "jaeger_host": "http://localhost:16686",
+    "loki_host": "http://localhost:3100",
+    "alloy_host": "http://localhost:12345",
+    "localstack_host": "http://localhost:4566",
+    "traefik_host": "http://localhost:8080"
+  }
+}

--- a/http/questdb-queries.http
+++ b/http/questdb-queries.http
@@ -3,56 +3,57 @@
 ### =============================================================================
 ### Run any query: click the green play button next to it.
 ### QuestDB must be running (Docker Up) before testing.
+### Environment: select "dev" from the dropdown (top-right) before running.
 ### Uses QuestDB REST API on port 9000.
 ### =============================================================================
 
 ### ---- Schema Discovery ----
 
 ### Show all tables
-GET http://localhost:9000/exec?query=SHOW%20TABLES
+GET {{questdb_host}}/exec?query=SHOW%20TABLES
 
 ###
 
 ### Show columns of tick_data table
-GET http://localhost:9000/exec?query=SHOW%20COLUMNS%20FROM%20tick_data
+GET {{questdb_host}}/exec?query=SHOW%20COLUMNS%20FROM%20tick_data
 
 ###
 
 ### Show columns of instrument_snapshots table
-GET http://localhost:9000/exec?query=SHOW%20COLUMNS%20FROM%20instrument_snapshots
+GET {{questdb_host}}/exec?query=SHOW%20COLUMNS%20FROM%20instrument_snapshots
 
 ###
 
 ### ---- Tick Data Queries ----
 
 ### Latest 10 ticks (most recent first)
-GET http://localhost:9000/exec?query=SELECT%20*%20FROM%20tick_data%20ORDER%20BY%20timestamp%20DESC%20LIMIT%2010
+GET {{questdb_host}}/exec?query=SELECT%20*%20FROM%20tick_data%20ORDER%20BY%20timestamp%20DESC%20LIMIT%2010
 
 ###
 
 ### Tick count per day
-GET http://localhost:9000/exec?query=SELECT%20timestamp%3A%3Adate%20AS%20day%2C%20count()%20FROM%20tick_data%20SAMPLE%20BY%201d
+GET {{questdb_host}}/exec?query=SELECT%20timestamp%3A%3Adate%20AS%20day%2C%20count()%20FROM%20tick_data%20SAMPLE%20BY%201d
 
 ###
 
 ### ---- Instrument Queries ----
 
 ### Latest instrument snapshots
-GET http://localhost:9000/exec?query=SELECT%20*%20FROM%20instrument_snapshots%20ORDER%20BY%20snapshot_date%20DESC%20LIMIT%2020
+GET {{questdb_host}}/exec?query=SELECT%20*%20FROM%20instrument_snapshots%20ORDER%20BY%20snapshot_date%20DESC%20LIMIT%2020
 
 ###
 
 ### Distinct instruments per snapshot date
-GET http://localhost:9000/exec?query=SELECT%20snapshot_date%2C%20count(DISTINCT%20security_id)%20AS%20instrument_count%20FROM%20instrument_snapshots%20GROUP%20BY%20snapshot_date%20ORDER%20BY%20snapshot_date%20DESC
+GET {{questdb_host}}/exec?query=SELECT%20snapshot_date%2C%20count(DISTINCT%20security_id)%20AS%20instrument_count%20FROM%20instrument_snapshots%20GROUP%20BY%20snapshot_date%20ORDER%20BY%20snapshot_date%20DESC
 
 ###
 
 ### ---- System Queries ----
 
 ### QuestDB server version
-GET http://localhost:9000/exec?query=SELECT%20version()
+GET {{questdb_host}}/exec?query=SELECT%20version()
 
 ###
 
 ### Table sizes (row counts)
-GET http://localhost:9000/exec?query=SELECT%20table_name%2C%20partitionBy%2C%20designatedTimestamp%20FROM%20tables()
+GET {{questdb_host}}/exec?query=SELECT%20table_name%2C%20partitionBy%2C%20designatedTimestamp%20FROM%20tables()


### PR DESCRIPTION
## Summary
Fixes all 5 IntelliJ warnings that appear when opening the project after a fresh clone.

| Issue | Screenshot | Fix |
|-------|-----------|-----|
| "SQL dialect is not configured" | `questdb-verify-connection.sql` | `.idea/sqldialects.xml` → PostgreSQL |
| "Install ShellCheck?" prompt | `commit-msg` git hook | `.idea/externalDependencies.xml` → batch plugin install |
| "No Environment" in HTTP Client | `health-checks.http` | `http/http-client.env.json` with dev URLs |
| "Configure Kubernetes cluster" | `datasources.yml` | `.idea/kubernetes-settings.xml` → disabled |
| "Install Codeowners plugin?" | `CODEOWNERS` file | Included in `externalDependencies.xml` |

## Additional improvements
- HTTP client `.http` files now use `{{env_var}}` syntax instead of hardcoded `localhost` URLs
- Select "dev" from the environment dropdown (top-right) and all requests work immediately

## Test plan
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — 477 tests pass
- [ ] On Mac: `git pull` → open IntelliJ → zero warning banners

https://claude.ai/code/session_01Dvcp8yajCpyMTXRJS7YS1x