### PR TITLE
feat(ide): Bootstrap run config — one-click setup in IntelliJ

### DIFF
--- a/.idea/runConfigurations/Bootstrap.xml
+++ b/.idea/runConfigurations/Bootstrap.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Bootstrap (First-Time Setup)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="./scripts/bootstrap.sh" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="false" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="-c" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Seed_Secrets.xml
+++ b/.idea/runConfigurations/Seed_Secrets.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Seed Secrets (AWS → LocalStack)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="./scripts/setup-secrets.sh" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="false" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="-c" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
## Summary
- Add **Bootstrap (First-Time Setup)** IntelliJ run configuration — one click, zero terminal
- Add **Seed Secrets (AWS → LocalStack)** run configuration — re-seed anytime

## Actor Vijay Experience
1. Clone repo
2. Open IntelliJ
3. Click **Bootstrap (First-Time Setup)** from the run dropdown
4. Everything auto-configures: Docker images, services, secrets, QuestDB, Telegram
5. Start acting

## Test plan
- [ ] Open IntelliJ → Run dropdown shows "Bootstrap (First-Time Setup)"
- [ ] Click it → bootstrap runs in IntelliJ terminal panel
- [ ] All 8 steps complete automatically

https://claude.ai/code/session_01Dvcp8yajCpyMTXRJS7YS1x