### PR TITLE
fix(ide): delete externalDependencies.xml — stops plugin nag dialog

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ExternalDependencies">
-    <plugin id="org.rust.lang" />
-    <plugin id="org.toml.lang" />
-    <plugin id="com.github.niclasvoss.git.codeowners" />
-    <plugin id="com.wsdjeg.intellij.shellcheck" />
-  </component>
-</project>


### PR DESCRIPTION
## Summary
- Delete `.idea/externalDependencies.xml` — plugin IDs were wrong
- `org.rust.lang` is deprecated (new plugin is `com.jetbrains.rust`)
- `com.wsdjeg.intellij.shellcheck` doesn't exist
- ShellCheck is built into IntelliJ since 2019.2
- All needed plugins already installed — no nag dialog needed

https://claude.ai/code/session_01Dvcp8yajCpyMTXRJS7YS1x