### PR TITLE
fix(ide): recreate externalDependencies.xml with correct Rust plugin ID

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="com.jetbrains.rust" />
+  </component>
+</project>


### PR DESCRIPTION
## Summary
- PR #13 deleted externalDependencies.xml because it had wrong plugin IDs
- Recreated with correct plugin ID: com.jetbrains.rust (new official JetBrains Rust plugin)
- IntelliJ auto-prompts once to install the Rust plugin on first open — no per-file nagging

## What changed
- Created: .idea/externalDependencies.xml with com.jetbrains.rust

https://claude.ai/code/session_01Dvcp8yajCpyMTXRJS7YS1x