### PR TITLE
fix(test): remove unused variable — CI clippy fix

### DIFF
--- a/crates/core/src/instrument/subscription_planner.rs
+++ b/crates/core/src/instrument/subscription_planner.rs
@@ -1030,7 +1030,7 @@ mod tests {
     fn test_plan_stage2_nearest_expiry_prioritized() {
         // Universe with 2 expiry dates — Stage 2 should fill nearest first
         let mut universe = make_test_universe();
-        let near_expiry = NaiveDate::from_ymd_opt(2026, 3, 27).unwrap();
+        // near_expiry = 2026-03-27 is already in make_test_universe()
         let far_expiry = NaiveDate::from_ymd_opt(2026, 4, 24).unwrap();
 
         // Add RELIANCE contracts for far expiry (new security IDs)


### PR DESCRIPTION
## Summary
- Removes unused `near_expiry` variable in `test_plan_stage2_nearest_expiry_prioritized`
- CI clippy with `--all-targets` catches unused variables in test code
- The near expiry date (2026-03-27) is already in `make_test_universe()`

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::perf` — zero warnings
- [x] `cargo test --workspace` — 500 tests pass

https://claude.ai/code/session_01BVYydKkAbL63iMmKDDffKe