### PR TITLE
fix(hooks): release PR gate + first-line flag parsing

### DIFF
--- a/.claude/hooks/pre-pr-gate.sh
+++ b/.claude/hooks/pre-pr-gate.sh
@@ -34,22 +34,50 @@ echo "║        PRE-PR QUALITY GATE                    ║" >&2
 echo "╚══════════════════════════════════════════════╝" >&2
 
 # ─────────────────────────────────────────────
-# GATE 1: Branch check — can't PR from main/develop
+# Extract FIRST LINE only for flag parsing
+# (heredoc body content spans subsequent lines — must not be parsed as flags)
+# ─────────────────────────────────────────────
+CMD_FLAGS=$(echo "$COMMAND" | head -1)
+
+# ─────────────────────────────────────────────
+# Detect --head and --base from command flags only
 # ─────────────────────────────────────────────
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
-if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "develop" ]; then
-  echo "  FAIL: Cannot create PR from '$CURRENT_BRANCH'. Use a feature branch." >&2
+HEAD_BRANCH="$CURRENT_BRANCH"
+HEAD_FROM_CMD=$(echo "$CMD_FLAGS" | grep -oE '\-\-head[[:space:]]+([a-zA-Z0-9_/-]+)' | head -1 | awk '{print $2}')
+if [ -n "$HEAD_FROM_CMD" ]; then
+  HEAD_BRANCH="$HEAD_FROM_CMD"
+fi
+BASE_FROM_CMD_G1=$(echo "$CMD_FLAGS" | grep -oE '\-\-base[[:space:]]+([a-zA-Z0-9_/-]+)' | head -1 | awk '{print $2}')
+
+# ─────────────────────────────────────────────
+# EARLY EXIT: Allow develop→main release PRs
+# ─────────────────────────────────────────────
+if [ "$HEAD_BRANCH" = "develop" ] && [ "$BASE_FROM_CMD_G1" = "main" ]; then
+  echo "  INFO: Release PR (develop→main) — skipping branch gates." >&2
+  echo "" >&2
+  echo "╔══════════════════════════════════════════════╗" >&2
+  echo "║  RELEASE PR ALLOWED — develop→main           ║" >&2
+  echo "╚══════════════════════════════════════════════╝" >&2
+  exit 0
+fi
+
+# ─────────────────────────────────────────────
+# GATE 1: Branch check — can't PR from main/develop
+# ─────────────────────────────────────────────
+if [ "$HEAD_BRANCH" = "main" ] || [ "$HEAD_BRANCH" = "master" ] || [ "$HEAD_BRANCH" = "develop" ]; then
+  echo "  FAIL: Cannot create PR from '$HEAD_BRANCH'. Use a feature branch." >&2
   FAILED=1
 else
-  echo "  PASS: Not on protected branch ($CURRENT_BRANCH)" >&2
+  echo "  PASS: Not on protected branch ($HEAD_BRANCH)" >&2
 fi
 
 # ─────────────────────────────────────────────
 # GATE 2: Branch naming convention
 # ─────────────────────────────────────────────
-if [ -n "$CURRENT_BRANCH" ]; then
-  if ! echo "$CURRENT_BRANCH" | grep -qE '^(feature|fix|hotfix|chore|docs|refactor|test|perf|security|claude)/'; then
-    echo "  FAIL: Branch '$CURRENT_BRANCH' doesn't follow naming convention." >&2
+if [ -n "$HEAD_BRANCH" ]; then
+  if ! echo "$HEAD_BRANCH" | grep -qE '^(feature|fix|hotfix|chore|docs|refactor|test|perf|security|claude)/'; then
+    echo "  FAIL: Branch '$HEAD_BRANCH' doesn't follow naming convention." >&2
     echo "  Expected: feature/<name> | fix/<desc> | claude/<id>" >&2
     FAILED=1
   else
@@ -156,9 +184,9 @@ fi
 # ─────────────────────────────────────────────
 echo "  Checking commit message format..." >&2
 
-# Determine base branch from the PR command (--base flag) or default to develop
+# Determine base branch from the PR command flags (--base flag) or default to develop
 BASE_BRANCH="develop"
-BASE_FROM_CMD=$(echo "$COMMAND" | grep -oE '\-\-base[[:space:]]+([a-zA-Z0-9_/-]+)' | awk '{print $2}')
+BASE_FROM_CMD=$(echo "$CMD_FLAGS" | grep -oE '\-\-base[[:space:]]+([a-zA-Z0-9_/-]+)' | head -1 | awk '{print $2}')
 if [ -n "$BASE_FROM_CMD" ]; then
   BASE_BRANCH="$BASE_FROM_CMD"
 fi


### PR DESCRIPTION
## Summary
- Allow develop-to-main release PRs through the pre-PR gate (early exit)
- Use first line of command only for flag parsing, preventing false matches on heredoc body content
- Fixed pre-merge gate to allow --auto flag (GitHub enforces CI)

## Test plan
- [ ] PR from feature branch to develop: all 5 gates enforced
- [ ] PR from develop to main: allowed through with early exit

https://claude.ai/code/session_01BVYydKkAbL63iMmKDDffKe