### PR TITLE
docs: fix rustdoc warnings — bare URLs, HTML tags, unresolved links

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -295,7 +295,7 @@ pub const TELEGRAM_CHAT_ID_SECRET: &str = "chat-id";
 pub const SSM_SNS_SERVICE: &str = "sns";
 
 /// SSM key for the phone number to send SNS SMS alerts to.
-/// Value must be in E.164 format: +<country_code><number> (e.g., "+919876543210").
+/// Value must be in E.164 format: `+<country_code><number>` (e.g., "+919876543210").
 pub const SNS_PHONE_NUMBER_SECRET: &str = "phone-number";
 
 // ---------------------------------------------------------------------------
@@ -551,11 +551,11 @@ pub const TOTP_SKEW: u8 = 1;
 // ---------------------------------------------------------------------------
 
 /// Path for initial token generation (appended to auth_base_url).
-/// Endpoint: POST https://auth.dhan.co/app/generateAccessToken
+/// Endpoint: POST <https://auth.dhan.co/app/generateAccessToken>
 pub const DHAN_GENERATE_TOKEN_PATH: &str = "/app/generateAccessToken";
 
 /// Path for token renewal (appended to rest_api_base_url).
-/// Endpoint: GET https://api.dhan.co/v2/RenewToken
+/// Endpoint: GET <https://api.dhan.co/v2/RenewToken>
 pub const DHAN_RENEW_TOKEN_PATH: &str = "/RenewToken";
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/instrument/mod.rs
+++ b/crates/core/src/instrument/mod.rs
@@ -1,7 +1,7 @@
 //! Master instrument download, parsing, and F&O universe building.
 //!
 //! Downloads Dhan's instrument master CSV daily, parses it, runs a 5-pass
-//! mapping algorithm, and produces a complete [`FnoUniverse`] with all lookup
+//! mapping algorithm, and produces a complete `FnoUniverse` with all lookup
 //! maps ready for downstream consumption.
 //!
 //! # Boot Sequence Position


### PR DESCRIPTION
## Summary
- Wrap E.164 format angle brackets in backticks (fixes unclosed HTML tag warning)
- Wrap bare URLs in angle brackets (fixes rustdoc::bare_urls warning)
- Remove intra-doc link brackets from FnoUniverse (fixes unresolved link warning)

These fix CI Stage 2 "Check docs compile (warnings = errors)" failure.

## Test plan
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` passes

https://claude.ai/code/session_014XKQJkxj5YPiSpmXLP5go6