### PR TITLE
fix(ci): split audit into yanked-block + advisory-warn, handle network failures

### DIFF
--- a/.claude/hooks/pre-push-gate.sh
+++ b/.claude/hooks/pre-push-gate.sh
@@ -108,13 +108,16 @@ fi
 # Gate 6: cargo audit (CVEs + yanked — required if installed)
 echo "  [6/8] cargo audit (CVEs + yanked)..." >&2
 if command -v cargo-audit > /dev/null 2>&1; then
-  AUDIT_OUT=$(cargo audit --deny warnings --deny yanked 2>&1)
-  if [ $? -ne 0 ]; then
+  AUDIT_OUT=$(cargo audit --deny yanked 2>&1)
+  AUDIT_EXIT=$?
+  if echo "$AUDIT_OUT" | grep -q "couldn't fetch advisory database"; then
+    echo "  SKIP: Cannot reach advisory database (network issue)" >&2
+  elif [ "$AUDIT_EXIT" -ne 0 ]; then
     echo "  FAIL: cargo audit found issues:" >&2
     echo "$AUDIT_OUT" | tail -15 >&2
     FAILED=1
   else
-    echo "  PASS: cargo audit (no CVEs, no yanked crates)" >&2
+    echo "  PASS: cargo audit (no yanked crates)" >&2
   fi
 else
   echo "  SKIP: cargo-audit not installed (install with: cargo install cargo-audit)" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,5 +292,12 @@ jobs:
         with:
           tool: cargo-audit
 
-      - name: Audit (CVEs + yanked crates)
-        run: cargo audit --deny warnings --deny yanked
+      - name: Audit (yanked crates — hard block)
+        run: cargo audit --deny yanked
+
+      - name: Audit advisories (warn only — CVEs already checked by cargo deny in Stage 4)
+        run: |
+          cargo audit 2>&1 | tee /tmp/audit.txt || true
+          if grep -q 'warning\|vulnerability' /tmp/audit.txt; then
+            echo "::warning::Security advisories found — review and update dependencies"
+          fi


### PR DESCRIPTION
## Summary
- CI Stage 7: Split audit into yanked-block (hard fail) + advisory-warn (annotations only)
- Pre-push hook: Handle network failures gracefully (skip when advisory DB unreachable)
- CVEs already checked by cargo deny in Stage 4; audit stage focuses on yanked crates

https://claude.ai/code/session_014XKQJkxj5YPiSpmXLP5go6