### PR TITLE
security(auth): redact credentials + infinite boot retry

### DIFF
--- a/config/base.toml
+++ b/config/base.toml
@@ -48,7 +48,7 @@ reconnect_max_attempts = 10
 subscription_batch_size = 100
 
 [network]
-request_timeout_ms = 5000
+request_timeout_ms = 10000
 websocket_connect_timeout_ms = 10000
 retry_initial_delay_ms = 100
 retry_max_delay_ms = 30000

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -116,26 +116,19 @@ async fn main() -> Result<()> {
     let notifier = NotificationService::initialize(&config.notification).await;
 
     // -----------------------------------------------------------------------
-    // Step 4: Authenticate with Dhan API (best-effort for development)
+    // Step 4: Authenticate with Dhan API (infinite retry for transient errors)
     // -----------------------------------------------------------------------
     info!("authenticating with Dhan API via SSM → TOTP → JWT");
 
     let token_manager =
-        match TokenManager::initialize(&config.dhan, &config.token, &config.network).await {
-            Ok(manager) => {
-                info!("authentication successful — token acquired");
-                notifier.notify(NotificationEvent::AuthenticationSuccess);
-                Some(manager)
-            }
+        match TokenManager::initialize(&config.dhan, &config.token, &config.network, &notifier)
+            .await
+        {
+            Ok(manager) => manager,
             Err(err) => {
-                warn!(
-                    error = %err,
-                    "authentication failed — starting in offline mode (no live data)"
-                );
-                notifier.notify(NotificationEvent::AuthenticationFailed {
-                    reason: err.to_string(),
-                });
-                None
+                // Only reaches here on permanent auth error or Ctrl+C.
+                error!(error = %err, "authentication failed permanently — exiting");
+                return Ok(());
             }
         };
 
@@ -226,53 +219,53 @@ async fn main() -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 7: Build WebSocket connection pool (only if authenticated + plan ready)
     // -----------------------------------------------------------------------
-    let (frame_receiver, ws_handles) =
-        if let (Some(tm), Some(plan)) = (&token_manager, &subscription_plan) {
-            info!("building WebSocket connection pool");
+    let (frame_receiver, ws_handles) = if let Some(plan) = &subscription_plan {
+        let tm = &token_manager;
+        info!("building WebSocket connection pool");
 
-            let token_handle = tm.token_handle();
-            let client_id = {
-                let credentials = secret_manager::fetch_dhan_credentials()
-                    .await
-                    .context("failed to fetch Dhan client ID for WebSocket")?;
-                credentials.client_id.expose_secret().to_string()
-            };
-
-            // Convert registry instruments → WebSocket subscription entries
-            let instruments: Vec<InstrumentSubscription> = plan
-                .registry
-                .iter()
-                .map(|inst| InstrumentSubscription::new(inst.exchange_segment, inst.security_id))
-                .collect();
-
-            let feed_mode = plan.summary.feed_mode;
-            let instrument_count = instruments.len();
-
-            let mut pool = WebSocketConnectionPool::new(
-                token_handle,
-                client_id,
-                config.dhan.clone(),
-                config.websocket.clone(),
-                instruments,
-                feed_mode,
-            )
-            .context("failed to create WebSocket connection pool")?;
-
-            let receiver = pool.take_frame_receiver();
-            let handles = pool.spawn_all();
-
-            info!(
-                connections = handles.len(),
-                instruments = instrument_count,
-                feed_mode = %feed_mode,
-                "WebSocket pool started"
-            );
-
-            (Some(receiver), handles)
-        } else {
-            warn!("WebSocket pool skipped — running in offline mode");
-            (None, Vec::new())
+        let token_handle = tm.token_handle();
+        let client_id = {
+            let credentials = secret_manager::fetch_dhan_credentials()
+                .await
+                .context("failed to fetch Dhan client ID for WebSocket")?;
+            credentials.client_id.expose_secret().to_string()
         };
+
+        // Convert registry instruments → WebSocket subscription entries
+        let instruments: Vec<InstrumentSubscription> = plan
+            .registry
+            .iter()
+            .map(|inst| InstrumentSubscription::new(inst.exchange_segment, inst.security_id))
+            .collect();
+
+        let feed_mode = plan.summary.feed_mode;
+        let instrument_count = instruments.len();
+
+        let mut pool = WebSocketConnectionPool::new(
+            token_handle,
+            client_id,
+            config.dhan.clone(),
+            config.websocket.clone(),
+            instruments,
+            feed_mode,
+        )
+        .context("failed to create WebSocket connection pool")?;
+
+        let receiver = pool.take_frame_receiver();
+        let handles = pool.spawn_all();
+
+        info!(
+            connections = handles.len(),
+            instruments = instrument_count,
+            feed_mode = %feed_mode,
+            "WebSocket pool started"
+        );
+
+        (Some(receiver), handles)
+    } else {
+        warn!("WebSocket pool skipped — running in offline mode");
+        (None, Vec::new())
+    };
 
     // -----------------------------------------------------------------------
     // Step 8: Spawn tick processor (pure capture — parse → filter → persist)
@@ -320,24 +313,15 @@ async fn main() -> Result<()> {
     });
 
     // -----------------------------------------------------------------------
-    // Step 10: Spawn token renewal background task (only if authenticated)
+    // Step 10: Spawn token renewal background task
     // -----------------------------------------------------------------------
-    let renewal_handle = if let Some(ref tm) = token_manager {
-        let handle = tm.spawn_renewal_task();
-        info!("token renewal task started");
-        Some(handle)
-    } else {
-        None
-    };
+    let renewal_handle = token_manager.spawn_renewal_task();
+    info!("token renewal task started");
 
     // -----------------------------------------------------------------------
     // Step 11: Await shutdown signal
     // -----------------------------------------------------------------------
-    let mode = if token_manager.is_some() {
-        "LIVE"
-    } else {
-        "OFFLINE"
-    };
+    let mode = "LIVE";
     info!(
         mode,
         "system ready — press Ctrl+C to stop\n\
@@ -358,9 +342,7 @@ async fn main() -> Result<()> {
     notifier.notify(NotificationEvent::ShutdownInitiated);
 
     // Cancel background tasks
-    if let Some(handle) = renewal_handle {
-        handle.abort();
-    }
+    renewal_handle.abort();
     if let Some(handle) = processor_handle {
         handle.abort();
     }

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -580,6 +580,18 @@ pub const TOKEN_RENEWAL_CIRCUIT_BREAKER_THRESHOLD: u32 = 3;
 /// Circuit breaker reset timeout in seconds (try again after this).
 pub const TOKEN_RENEWAL_CIRCUIT_BREAKER_RESET_SECS: u64 = 60;
 
+/// Dhan `generateAccessToken` cooldown in seconds.
+///
+/// Dhan enforces an undocumented 2-minute cooldown between token generation
+/// requests. We use 125 seconds (2 min + 5 sec safety margin) to ensure
+/// we never hit the rate limit on retry.
+pub const DHAN_TOKEN_GENERATION_COOLDOWN_SECS: u64 = 125;
+
+/// Maximum backoff delay for boot-time auth retry in seconds.
+///
+/// Exponential backoff is capped at this value to prevent unbounded waits.
+pub const AUTH_RETRY_MAX_BACKOFF_SECS: u64 = 300;
+
 // ---------------------------------------------------------------------------
 // Dhan WebSocket V2 — Binary Packet Byte Offsets
 // Source: SDK struct.unpack format strings, verified against Python SDK.

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -8,5 +8,6 @@ pub mod constants;
 pub mod error;
 pub mod instrument_registry;
 pub mod instrument_types;
+pub mod sanitize;
 pub mod tick_types;
 pub mod types;

--- a/crates/common/src/sanitize.rs
+++ b/crates/common/src/sanitize.rs
@@ -1,0 +1,294 @@
+//! Credential redaction for error messages and notifications.
+//!
+//! Prevents accidental leakage of secrets (client IDs, PINs, TOTP codes)
+//! in log files, Telegram notifications, and SNS messages.
+//!
+//! # How It Works
+//!
+//! `redact_url_params` strips URL query parameters and known credential
+//! patterns from arbitrary strings. It is regex-free — uses only
+//! `str::find` and character scanning.
+//!
+//! # Usage
+//!
+//! Apply at error-creation sites (token_manager.rs) and at notification
+//! boundaries (events.rs) for defense-in-depth.
+
+/// Redacts URL query parameters and known credential patterns from a string.
+///
+/// Replaces query parameters in URLs (`?key=val&...`) with `?[REDACTED]`.
+/// Also catches standalone `dhanClientId=`, `pin=`, `totp=` patterns
+/// outside of URLs.
+///
+/// # Performance
+///
+/// Auth is cold path. String allocation is acceptable.
+///
+/// # Examples
+///
+/// ```
+/// use dhan_live_trader_common::sanitize::redact_url_params;
+///
+/// let raw = "error for url (https://auth.dhan.co/app/gen?dhanClientId=123&pin=456)";
+/// let safe = redact_url_params(raw);
+/// assert!(!safe.contains("123"));
+/// assert!(!safe.contains("456"));
+/// assert!(safe.contains("?[REDACTED]"));
+/// ```
+pub fn redact_url_params(input: &str) -> String {
+    if input.is_empty() {
+        return String::new();
+    }
+
+    let mut result = redact_urls(input);
+    result = redact_param_value(&result, "dhanClientId=");
+    result = redact_param_value(&result, "pin=");
+    result = redact_param_value(&result, "totp=");
+    result
+}
+
+/// Replaces query parameters in URLs with `[REDACTED]`.
+///
+/// Scans for `https://` or `http://` prefixes, finds the `?` delimiter,
+/// and replaces everything from `?` to the next whitespace, `)`, or
+/// end-of-string with `?[REDACTED]`.
+fn redact_urls(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        // Look for URL start: "http://" or "https://"
+        if i + 7 < len && &input[i..i + 7] == "http://" {
+            // Found http:// — find the `?` and redact
+            let url_start = i;
+            i = copy_url_and_redact_params(input, url_start, &mut result);
+        } else if i + 8 < len && &input[i..i + 8] == "https://" {
+            let url_start = i;
+            i = copy_url_and_redact_params(input, url_start, &mut result);
+        } else {
+            result.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+
+    result
+}
+
+/// Copies a URL up to `?`, then replaces query params with `[REDACTED]`.
+/// Returns the index after the URL ends.
+fn copy_url_and_redact_params(input: &str, start: usize, result: &mut String) -> usize {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut i = start;
+
+    // Copy everything up to `?` or end-of-URL
+    while i < len {
+        let ch = bytes[i] as char;
+        if ch == '?' {
+            // Found query string — redact everything after `?`
+            result.push_str("?[REDACTED]");
+            i += 1;
+            // Skip until whitespace, `)`, or end-of-string
+            while i < len {
+                let skip_ch = bytes[i] as char;
+                if skip_ch.is_whitespace() || skip_ch == ')' {
+                    break;
+                }
+                i += 1;
+            }
+            return i;
+        }
+        if ch.is_whitespace() || ch == ')' {
+            // End of URL without query params — nothing to redact
+            return i;
+        }
+        result.push(ch);
+        i += 1;
+    }
+
+    i
+}
+
+/// Redacts the value portion of a `key=value` pattern.
+///
+/// Replaces `key=<value>` with `key=[REDACTED]` where `<value>` extends
+/// to the next `&`, whitespace, `)`, or end-of-string.
+fn redact_param_value(input: &str, key: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut search_from = 0;
+
+    while let Some(pos) = input[search_from..].find(key) {
+        let abs_pos = search_from + pos;
+        // Copy everything before this match
+        result.push_str(&input[search_from..abs_pos]);
+        result.push_str(key);
+        result.push_str("[REDACTED]");
+
+        // Skip past the value
+        let value_start = abs_pos + key.len();
+        let mut value_end = value_start;
+        let bytes = input.as_bytes();
+        while value_end < bytes.len() {
+            let ch = bytes[value_end] as char;
+            if ch == '&' || ch.is_whitespace() || ch == ')' || ch == '\n' {
+                break;
+            }
+            value_end += 1;
+        }
+        search_from = value_end;
+    }
+
+    // Copy any remaining text after the last match
+    result.push_str(&input[search_from..]);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_string() {
+        assert_eq!(redact_url_params(""), "");
+    }
+
+    #[test]
+    fn test_no_url_no_params() {
+        let input = "some plain error message";
+        assert_eq!(redact_url_params(input), input);
+    }
+
+    #[test]
+    fn test_url_without_query_params() {
+        let input = "error for url (https://auth.dhan.co/app/generateAccessToken)";
+        assert_eq!(redact_url_params(input), input);
+    }
+
+    #[test]
+    fn test_url_with_query_params_redacted() {
+        let input = "error sending request for url (https://auth.dhan.co/app/generateAccessToken?dhanClientId=1106656882&pin=785478&totp=782561)";
+        let output = redact_url_params(input);
+        assert!(
+            !output.contains("1106656882"),
+            "client ID must not appear: {output}"
+        );
+        assert!(!output.contains("785478"), "PIN must not appear: {output}");
+        assert!(!output.contains("782561"), "TOTP must not appear: {output}");
+        assert!(
+            output.contains("?[REDACTED]"),
+            "must contain redaction marker: {output}"
+        );
+        assert!(
+            output.contains("generateAccessToken"),
+            "URL path must be preserved: {output}"
+        );
+    }
+
+    #[test]
+    fn test_exact_reqwest_error_format() {
+        // This is the exact format from the Telegram screenshot
+        let input = "generateAccessToken request failed: error sending request for url (https://auth.dhan.co/app/generateAccessToken?dhanClientId=1106656882&pin=785478&totp=772509)";
+        let output = redact_url_params(input);
+        assert!(!output.contains("1106656882"));
+        assert!(!output.contains("785478"));
+        assert!(!output.contains("772509"));
+        assert!(output.contains("generateAccessToken request failed"));
+        assert!(output.contains("?[REDACTED]"));
+    }
+
+    #[test]
+    fn test_multiple_urls_all_redacted() {
+        let input = "tried https://a.com/x?secret=123 then https://b.com/y?key=456";
+        let output = redact_url_params(input);
+        assert!(!output.contains("123"), "first URL param leaked: {output}");
+        assert!(!output.contains("456"), "second URL param leaked: {output}");
+    }
+
+    #[test]
+    fn test_url_at_end_of_string() {
+        let input = "error at https://api.com/path?token=secret123";
+        let output = redact_url_params(input);
+        assert!(
+            !output.contains("secret123"),
+            "param at end leaked: {output}"
+        );
+        assert!(output.contains("?[REDACTED]"));
+    }
+
+    #[test]
+    fn test_http_url_also_redacted() {
+        let input = "url (http://insecure.com/api?key=abc123)";
+        let output = redact_url_params(input);
+        assert!(
+            !output.contains("abc123"),
+            "http URL param leaked: {output}"
+        );
+    }
+
+    #[test]
+    fn test_standalone_dhan_client_id_redacted() {
+        let input = "response contained dhanClientId=1106656882 in body";
+        let output = redact_url_params(input);
+        assert!(
+            !output.contains("1106656882"),
+            "standalone client ID leaked: {output}"
+        );
+        assert!(output.contains("dhanClientId=[REDACTED]"));
+    }
+
+    #[test]
+    fn test_standalone_pin_redacted() {
+        let input = "error: pin=785478 was invalid";
+        let output = redact_url_params(input);
+        assert!(
+            !output.contains("785478"),
+            "standalone PIN leaked: {output}"
+        );
+        assert!(output.contains("pin=[REDACTED]"));
+    }
+
+    #[test]
+    fn test_standalone_totp_redacted() {
+        let input = "TOTP rejected: totp=772509";
+        let output = redact_url_params(input);
+        assert!(
+            !output.contains("772509"),
+            "standalone TOTP leaked: {output}"
+        );
+        assert!(output.contains("totp=[REDACTED]"));
+    }
+
+    #[test]
+    fn test_preserves_url_path() {
+        let input = "error for url (https://auth.dhan.co/app/generateAccessToken?dhanClientId=123)";
+        let output = redact_url_params(input);
+        assert!(
+            output.contains("/app/generateAccessToken"),
+            "URL path lost: {output}"
+        );
+    }
+
+    #[test]
+    fn test_preserves_surrounding_text() {
+        let input = "prefix https://x.com/a?b=c suffix";
+        let output = redact_url_params(input);
+        assert!(output.starts_with("prefix "), "prefix lost: {output}");
+        assert!(output.ends_with(" suffix"), "suffix lost: {output}");
+    }
+
+    #[test]
+    fn test_dhan_auth_full_error_with_body() {
+        let input = "Dhan authentication failed: generateAccessToken request failed: error sending request for url (https://auth.dhan.co/app/generateAccessToken?dhanClientId=1106656882&pin=785478&totp=772509)";
+        let output = redact_url_params(input);
+        assert!(!output.contains("1106656882"));
+        assert!(!output.contains("785478"));
+        assert!(!output.contains("772509"));
+        assert!(output.contains("Dhan authentication failed"));
+    }
+}

--- a/crates/core/src/auth/token_manager.rs
+++ b/crates/core/src/auth/token_manager.rs
@@ -20,12 +20,18 @@ use secrecy::ExposeSecret;
 use tracing::{error, info, instrument, warn};
 
 use dhan_live_trader_common::config::{DhanConfig, NetworkConfig, TokenConfig};
-use dhan_live_trader_common::constants::{DHAN_GENERATE_TOKEN_PATH, DHAN_RENEW_TOKEN_PATH};
+use dhan_live_trader_common::constants::{
+    AUTH_RETRY_MAX_BACKOFF_SECS, DHAN_GENERATE_TOKEN_PATH, DHAN_RENEW_TOKEN_PATH,
+    DHAN_TOKEN_GENERATION_COOLDOWN_SECS,
+};
 use dhan_live_trader_common::error::ApplicationError;
+use dhan_live_trader_common::sanitize::redact_url_params;
 
 use super::secret_manager;
 use super::totp_generator::generate_totp_code;
 use super::types::{DhanCredentials, DhanGenerateTokenResponse, TokenState};
+use crate::notification::events::NotificationEvent;
+use crate::notification::service::NotificationService;
 
 // ---------------------------------------------------------------------------
 // Token Handle (shared with downstream consumers)
@@ -68,25 +74,29 @@ pub struct TokenManager {
 
     /// Network retry configuration.
     network_config: NetworkConfig,
+
+    /// Notification service for Telegram/SNS alerts on auth events.
+    notifier: Arc<NotificationService>,
 }
 
 impl TokenManager {
     /// Creates a new `TokenManager` and performs initial authentication.
     ///
-    /// 1. Fetches credentials from AWS SSM Parameter Store
-    /// 2. Generates TOTP code
-    /// 3. Calls `generateAccessToken` to acquire JWT
+    /// 1. Fetches credentials from AWS SSM Parameter Store (3 retries)
+    /// 2. Calls `generateAccessToken` with infinite retry for transient errors
+    /// 3. Fails fast on permanent errors (wrong PIN, invalid TOTP, blocked)
     /// 4. Stores token in ArcSwap for O(1) reads
     ///
     /// # Errors
     ///
-    /// Returns error if SSM retrieval, TOTP generation, or Dhan API call fails.
-    /// This is a fatal error — the system cannot start without authentication.
+    /// Returns error only for permanent credential failures or shutdown (Ctrl+C).
+    /// Transient errors (network, timeout, rate limit) are retried indefinitely.
     #[instrument(skip_all)]
     pub async fn initialize(
         dhan_config: &DhanConfig,
         token_config: &TokenConfig,
         network_config: &NetworkConfig,
+        notifier: &Arc<NotificationService>,
     ) -> Result<Arc<Self>, ApplicationError> {
         info!("initializing authentication — fetching credentials from SSM");
 
@@ -108,7 +118,25 @@ impl TokenManager {
             });
         }
 
-        let credentials = secret_manager::fetch_dhan_credentials().await?;
+        // SSM credential fetch with retry (3 attempts, exponential backoff).
+        let credentials = {
+            let mut attempt = 0u32;
+            loop {
+                attempt += 1;
+                match secret_manager::fetch_dhan_credentials().await {
+                    Ok(creds) => break creds,
+                    Err(err) if attempt >= 3 => return Err(err),
+                    Err(err) => {
+                        warn!(
+                            attempt,
+                            error = %err,
+                            "SSM credential fetch failed, retrying"
+                        );
+                        tokio::time::sleep(Duration::from_secs(u64::from(2u32.pow(attempt)))).await;
+                    }
+                }
+            }
+        };
 
         let http_client = reqwest::Client::builder()
             .timeout(Duration::from_millis(network_config.request_timeout_ms))
@@ -127,17 +155,82 @@ impl TokenManager {
             http_client,
             token_config: token_config.clone(),
             network_config: network_config.clone(),
+            notifier: Arc::clone(notifier),
         });
 
-        // Perform initial authentication
-        manager.acquire_token().await?;
+        // Infinite retry for transient errors, fail fast for permanent errors.
+        let mut attempt = 0u32;
+        let mut delay = Duration::from_millis(network_config.retry_initial_delay_ms);
+        let max_delay = Duration::from_secs(AUTH_RETRY_MAX_BACKOFF_SECS);
 
-        info!(
-            expires_at = %manager.current_expiry_display(),
-            "initial authentication successful"
-        );
+        loop {
+            attempt += 1;
+            match manager.acquire_token().await {
+                Ok(()) => {
+                    info!(
+                        attempt,
+                        expires_at = %manager.current_expiry_display(),
+                        "initial authentication successful"
+                    );
+                    notifier.notify(NotificationEvent::AuthenticationSuccess);
+                    return Ok(manager);
+                }
+                Err(err) => {
+                    let reason = err.to_string();
 
-        Ok(manager)
+                    // Permanent errors — fail fast with clear notification.
+                    if is_permanent_auth_error(&reason) {
+                        error!(attempt, error = %reason, "permanent auth error — cannot retry");
+                        notifier.notify(NotificationEvent::AuthenticationFailed {
+                            reason: format!("PERMANENT: {reason} — check SSM credentials"),
+                        });
+                        return Err(err);
+                    }
+
+                    // Dhan rate limit — use the 125-second cooldown.
+                    let wait_duration = if is_dhan_rate_limited(&reason) {
+                        warn!(
+                            attempt,
+                            "Dhan rate limit hit — waiting {} seconds",
+                            DHAN_TOKEN_GENERATION_COOLDOWN_SECS
+                        );
+                        Duration::from_secs(DHAN_TOKEN_GENERATION_COOLDOWN_SECS)
+                    } else {
+                        warn!(
+                            attempt,
+                            error = %reason,
+                            delay_secs = delay.as_secs(),
+                            "auth attempt failed (transient) — retrying"
+                        );
+                        delay
+                    };
+
+                    // Notify on each transient failure.
+                    notifier.notify(NotificationEvent::AuthenticationFailed {
+                        reason: format!(
+                            "attempt {attempt}: {reason} — retrying in {}s",
+                            wait_duration.as_secs()
+                        ),
+                    });
+
+                    // Sleep with Ctrl+C awareness.
+                    tokio::select! {
+                        () = tokio::time::sleep(wait_duration) => {}
+                        _ = tokio::signal::ctrl_c() => {
+                            info!("shutdown signal received during auth retry");
+                            return Err(ApplicationError::AuthenticationFailed {
+                                reason: "shutdown during auth retry".to_string(),
+                            });
+                        }
+                    }
+
+                    // Exponential backoff (capped), skip if we used rate-limit delay.
+                    if !is_dhan_rate_limited(&reason) {
+                        delay = (delay * 2).min(max_delay);
+                    }
+                }
+            }
+        }
     }
 
     /// Returns a `TokenHandle` for O(1) atomic token reads.
@@ -188,7 +281,10 @@ impl TokenManager {
             .send()
             .await
             .map_err(|err| ApplicationError::AuthenticationFailed {
-                reason: format!("generateAccessToken request failed: {err}"),
+                reason: format!(
+                    "generateAccessToken request failed: {}",
+                    redact_url_params(&err.to_string())
+                ),
             })?;
 
         let status = response.status();
@@ -196,7 +292,10 @@ impl TokenManager {
 
         if !status.is_success() {
             return Err(ApplicationError::AuthenticationFailed {
-                reason: format!("generateAccessToken HTTP {status}: {body_text}"),
+                reason: format!(
+                    "generateAccessToken HTTP {status}: {}",
+                    redact_url_params(&body_text)
+                ),
             });
         }
 
@@ -214,13 +313,14 @@ impl TokenManager {
             });
         }
 
-        let body: DhanGenerateTokenResponse =
-            serde_json::from_str(&body_text)
-                .map_err(|err| ApplicationError::AuthenticationFailed {
-                    reason: format!(
-                        "failed to parse auth response (HTTP {status}): {err}\nResponse body: {body_text}"
-                    ),
-                })?;
+        let body: DhanGenerateTokenResponse = serde_json::from_str(&body_text).map_err(|err| {
+            ApplicationError::AuthenticationFailed {
+                reason: format!(
+                    "failed to parse auth response (HTTP {status}): {err}\nResponse body: {}",
+                    redact_url_params(&body_text)
+                ),
+            }
+        })?;
 
         if body.access_token.is_empty() {
             return Err(ApplicationError::AuthenticationFailed {
@@ -260,7 +360,10 @@ impl TokenManager {
             .await
             .map_err(|err| ApplicationError::TokenRenewalFailed {
                 attempts: 0,
-                reason: format!("RenewToken request failed: {err}"),
+                reason: format!(
+                    "RenewToken request failed: {}",
+                    redact_url_params(&err.to_string())
+                ),
             })?;
 
         let status = response.status();
@@ -268,7 +371,10 @@ impl TokenManager {
             let body_text = response.text().await.unwrap_or_default();
             return Err(ApplicationError::TokenRenewalFailed {
                 attempts: 0,
-                reason: format!("RenewToken HTTP {status}: {body_text}"),
+                reason: format!(
+                    "RenewToken HTTP {status}: {}",
+                    redact_url_params(&body_text)
+                ),
             });
         }
 
@@ -279,7 +385,10 @@ impl TokenManager {
                 .await
                 .map_err(|err| ApplicationError::TokenRenewalFailed {
                     attempts: 0,
-                    reason: format!("failed to parse renewal response (HTTP {status}): {err}"),
+                    reason: format!(
+                        "failed to parse renewal response (HTTP {status}): {}",
+                        redact_url_params(&err.to_string())
+                    ),
                 })?;
 
         if body.access_token.is_empty() {
@@ -368,10 +477,12 @@ impl TokenManager {
             if !succeeded {
                 error!(
                     attempts,
-                    "ALL token renewal attempts exhausted — system should halt"
+                    "ALL token renewal attempts exhausted — token may expire"
                 );
-                // Future: trigger Telegram alert + SNS (Block 13)
-                // For now: log CRITICAL and sleep before retrying the entire cycle
+                self.notifier.notify(NotificationEvent::TokenRenewalFailed {
+                    attempts,
+                    reason: "all renewal attempts exhausted — token may expire".to_string(),
+                });
                 tokio::time::sleep(Duration::from_secs(
                     dhan_live_trader_common::constants::TOKEN_RENEWAL_CIRCUIT_BREAKER_RESET_SECS,
                 ))
@@ -401,6 +512,29 @@ impl TokenManager {
             None => "no token".to_string(),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Error Classification
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the auth error is permanent (retrying won't help).
+///
+/// Permanent errors indicate wrong credentials in SSM or a blocked account.
+/// The system should notify the user and exit, not retry indefinitely.
+fn is_permanent_auth_error(reason: &str) -> bool {
+    let lower = reason.to_lowercase();
+    lower.contains("invalid pin")
+        || lower.contains("invalid client")
+        || lower.contains("totp") && (lower.contains("invalid") || lower.contains("failed"))
+        || lower.contains("blocked")
+        || lower.contains("suspended")
+        || lower.contains("disabled")
+}
+
+/// Returns `true` if the error is Dhan's token generation rate limit.
+fn is_dhan_rate_limited(reason: &str) -> bool {
+    reason.contains("every 2 minutes") || reason.contains("once every")
 }
 
 // ---------------------------------------------------------------------------
@@ -693,5 +827,63 @@ mod tests {
             guard_after_clear.as_ref().is_none(),
             "storing None must clear the token state"
         );
+    }
+
+    // -- Error classification tests --
+
+    #[test]
+    fn test_invalid_pin_is_permanent() {
+        assert!(is_permanent_auth_error("Dhan auth error: Invalid Pin"));
+    }
+
+    #[test]
+    fn test_invalid_client_is_permanent() {
+        assert!(is_permanent_auth_error(
+            "Dhan auth error: Invalid Client ID"
+        ));
+    }
+
+    #[test]
+    fn test_totp_invalid_is_permanent() {
+        assert!(is_permanent_auth_error("TOTP verification failed"));
+        assert!(is_permanent_auth_error("Dhan auth error: Invalid TOTP"));
+    }
+
+    #[test]
+    fn test_blocked_account_is_permanent() {
+        assert!(is_permanent_auth_error("account blocked"));
+        assert!(is_permanent_auth_error("account suspended"));
+        assert!(is_permanent_auth_error("account disabled"));
+    }
+
+    #[test]
+    fn test_network_error_is_not_permanent() {
+        assert!(!is_permanent_auth_error(
+            "generateAccessToken request failed: error sending request"
+        ));
+    }
+
+    #[test]
+    fn test_timeout_is_not_permanent() {
+        assert!(!is_permanent_auth_error("operation timed out"));
+    }
+
+    #[test]
+    fn test_rate_limit_is_not_permanent() {
+        assert!(!is_permanent_auth_error(
+            "Token can be generated once every 2 minutes"
+        ));
+    }
+
+    #[test]
+    fn test_rate_limit_detected() {
+        assert!(is_dhan_rate_limited(
+            "Dhan auth error: Token can be generated once every 2 minutes"
+        ));
+    }
+
+    #[test]
+    fn test_network_error_not_rate_limited() {
+        assert!(!is_dhan_rate_limited("error sending request"));
     }
 }

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -3,6 +3,12 @@
 //! Every system event that should produce a Telegram alert is represented
 //! here. Callers pass events to `NotificationService::notify` — message
 //! formatting lives in this module, not at callsites.
+//!
+//! Defense-in-depth: `to_message()` redacts URL query parameters from
+//! `AuthenticationFailed` and `TokenRenewalFailed` reasons to prevent
+//! credential leaks in Telegram even if callers pass unsanitized strings.
+
+use dhan_live_trader_common::sanitize::redact_url_params;
 
 /// Alert severity level — determines which notification channels fire.
 ///
@@ -100,11 +106,17 @@ impl NotificationEvent {
             }
             Self::AuthenticationSuccess => "<b>Auth OK</b> — Dhan JWT acquired".to_string(),
             Self::AuthenticationFailed { reason } => {
-                format!("<b>Auth FAILED</b> — offline mode\n{reason}")
+                format!(
+                    "<b>Auth FAILED</b> — offline mode\n{}",
+                    redact_url_params(reason)
+                )
             }
             Self::TokenRenewed => "<b>Token renewed</b>".to_string(),
             Self::TokenRenewalFailed { attempts, reason } => {
-                format!("<b>Token renewal FAILED</b> (attempt {attempts})\n{reason}")
+                format!(
+                    "<b>Token renewal FAILED</b> (attempt {attempts})\n{}",
+                    redact_url_params(reason)
+                )
             }
             Self::WebSocketConnected { connection_index } => {
                 format!("<b>WebSocket #{connection_index} connected</b>")
@@ -201,6 +213,30 @@ mod tests {
         let msg = event.to_message();
         assert!(msg.contains("HTTP 401 Unauthorized"));
         assert!(msg.contains("FAILED"));
+    }
+
+    #[test]
+    fn test_auth_failed_redacts_credentials_in_url() {
+        let event = NotificationEvent::AuthenticationFailed {
+            reason: "generateAccessToken request failed: error sending request for url (https://auth.dhan.co/app/generateAccessToken?dhanClientId=1106656882&pin=785478&totp=772509)".to_string(),
+        };
+        let msg = event.to_message();
+        assert!(!msg.contains("1106656882"), "client ID leaked: {msg}");
+        assert!(!msg.contains("785478"), "PIN leaked: {msg}");
+        assert!(!msg.contains("772509"), "TOTP leaked: {msg}");
+        assert!(msg.contains("FAILED"));
+        assert!(msg.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_token_renewal_failed_redacts_credentials() {
+        let event = NotificationEvent::TokenRenewalFailed {
+            attempts: 3,
+            reason: "request for url (https://auth.dhan.co/app/generateAccessToken?pin=123456&totp=654321)".to_string(),
+        };
+        let msg = event.to_message();
+        assert!(!msg.contains("123456"), "PIN leaked: {msg}");
+        assert!(!msg.contains("654321"), "TOTP leaked: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **SECURITY**: Telegram notifications leaked dhanClientId, pin, and totp in plain text via reqwest error Display. Added regex-free redact_url_params() at error creation + notification boundary (defense-in-depth).
- **RELIABILITY**: TokenManager::initialize() had zero retries. Now uses infinite retry with smart error classification.
- **Renewal alerts**: Wired up TokenRenewalFailed Telegram notification (was TODO).

## Test plan
- [x] cargo check/test/clippy all pass (563 tests, 0 failures)

https://claude.ai/code/session_01XvTHGi2EyfqH8jsZ3apHGY