### PR TITLE
fix(merge): remove duplicate Severity enum

### DIFF
--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -30,26 +30,6 @@ pub enum Severity {
     Critical,
 }
 
-/// Alert severity level — determines which notification channels fire.
-///
-/// `Critical` and `High` → Telegram + SNS SMS.
-/// `Medium`, `Low`, `Info` → Telegram only.
-///
-/// Ordered for comparison: `Info < Low < Medium < High < Critical`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Severity {
-    /// Lifecycle events — startup complete, shutdown complete.
-    Info,
-    /// Normal operations — auth success, token renewed, WS connected.
-    Low,
-    /// Notable state changes — WS reconnected, shutdown initiated.
-    Medium,
-    /// Degraded state — WS disconnected, custom alerts.
-    High,
-    /// System cannot trade — auth failure, token renewal exhausted.
-    Critical,
-}
-
 /// All events that produce a Telegram alert.
 ///
 /// Adding a new event: add a variant here, add its message arm in


### PR DESCRIPTION
## Summary
- Removes duplicate `Severity` enum in `events.rs` from main→develop auto-merge
- Both branches independently added the same enum; git merged both copies

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 563 tests pass

https://claude.ai/code/session_01XvTHGi2EyfqH8jsZ3apHGY