### PR TITLE
fix(prometheus): replace invalid humanizeBytes with humanize1024

### DIFF
--- a/deploy/docker/prometheus/rules/dlt-alerts.yml
+++ b/deploy/docker/prometheus/rules/dlt-alerts.yml
@@ -47,7 +47,7 @@ groups:
           severity: warning
         annotations:
           summary: "Prometheus RSS > 1GB"
-          description: "Prometheus is using {{ $value | humanizeBytes }} of memory."
+          description: "Prometheus is using {{ $value | humanize1024 }}B of memory."
 
       - alert: PrometheusTSDBCompactionsFailing
         expr: increase(prometheus_tsdb_compactions_failed_total[1h]) > 0
@@ -65,7 +65,7 @@ groups:
           severity: warning
         annotations:
           summary: "Loki ingestion rate > 10MB/s"
-          description: "Loki is ingesting {{ $value | humanizeBytes }}/s, which may cause ingestion limits to be hit."
+          description: "Loki is ingesting {{ $value | humanize1024 }}B/s, which may cause ingestion limits to be hit."
 
   - name: dlt-application-alerts
     rules:


### PR DESCRIPTION
## Summary
- Replace non-existent `humanizeBytes` template function with valid `humanize1024` in Prometheus alert rules
- Fixes Prometheus v3.9.1 crash-loop caused by template validation at rule load time
- Unblocks IntelliJ `_Ensure Ready` → `Run App` / `Test All` run configurations

## Root Cause
`humanizeBytes` was never a Prometheus template function. Prometheus v3.x validates templates at rule load time (v2.x was lazy), causing:
1. Prometheus crash-loop → never passes healthcheck
2. Grafana blocked (`depends_on: service_healthy`)
3. `ensure-ready.sh` final `all_running` check fails (2/8 containers missing)
4. IntelliJ "Before launch" exits 1

## Changes
- `deploy/docker/prometheus/rules/dlt-alerts.yml`: lines 50, 68 — `humanizeBytes` → `humanize1024` + `B` suffix

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --workspace` passes
- [ ] `docker compose up -d` — Prometheus starts without crash-loop
- [ ] `./scripts/ensure-ready.sh` exits 0
- [ ] IntelliJ `_Ensure Ready` / `Run App` / `Test All` work

https://claude.ai/code/session_01NYoEz2PuyUXByEu17FQ6AS