### PR TITLE
perf(ci): skip Security & Coverage jobs on main PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,8 @@ jobs:
   coverage-and-perf:
     name: "Coverage & Perf"
     needs: build-and-verify
+    # Skip on main — same code already passed on develop
+    if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
   security-and-audit:
     name: "Security & Audit"
     needs: build-and-verify
+    # Skip on main — same code already passed on develop
+    if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
- Skips Security & Audit job on `main` branch CI runs
- Skips Coverage & Perf job on `main` branch CI runs
- Cuts pipeline time from ~25min to ~10min for main PRs

## Test plan
- [x] CI jobs validated on feature branch
- [ ] Verify pipeline time reduction after merge

https://claude.ai/code/session_01DRPd3qbLpa9u2JBe7L2sS2