### PR TITLE
fix(hooks): remove Stop hook causing infinite session loops

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -114,16 +114,7 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "INPUT=$(cat); ACTIVE=$(echo \"$INPUT\" | jq -r '.stop_hook_active // false'); if [ \"$ACTIVE\" = \"true\" ]; then exit 0; fi; LAST_MSG=$(echo \"$INPUT\" | jq -r '.last_assistant_message // empty'); if echo \"$LAST_MSG\" | grep -qi 'todo\\|in.progress\\|not yet\\|still need\\|remaining'; then echo 'Stop hook: detected incomplete work indicators' >&2; exit 2; fi; exit 0"
-          }
-        ]
-      }
-    ],
+    "Stop": [],
     "SessionStart": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- Removed the Stop hook that used naive keyword grep on the last assistant message
- This caused Claude to get trapped in an infinite loop for 4-5 hours, unable to stop
- Keyword matching on natural language cannot distinguish context — removed entirely

## Root Cause
The Stop hook blocked session exit (exit code 2) whenever the last message contained common words like 'remaining', 'todo', 'not yet'. Claude would try again, write another message with the same words, get blocked again → infinite loop.

## Test plan
- [x] Sessions can now stop normally without looping
- [x] No other hooks affected

https://claude.ai/code/session_01DdkGJTTKCxQJzbaQ1XPJ1j