### PR TITLE
test(coverage): add test coverage for common, api, and storage crates

### DIFF
--- a/crates/api/src/handlers/instruments.rs
+++ b/crates/api/src/handlers/instruments.rs
@@ -146,4 +146,24 @@ mod tests {
         assert!(!json.contains("derivative_count"));
         assert!(!json.contains("underlying_count"));
     }
+
+    #[test]
+    fn test_rebuild_guard_clears_flag_on_drop() {
+        let flag = AtomicBool::new(true);
+        {
+            let _guard = RebuildGuard { flag: &flag };
+            assert!(flag.load(Ordering::SeqCst));
+        }
+        // After guard is dropped, flag must be false
+        assert!(!flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_rebuild_guard_clears_flag_when_already_false() {
+        let flag = AtomicBool::new(false);
+        {
+            let _guard = RebuildGuard { flag: &flag };
+        }
+        assert!(!flag.load(Ordering::SeqCst));
+    }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -38,3 +38,73 @@ pub fn build_router(state: SharedAppState) -> Router {
         .layer(cors)
         .with_state(state)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use tower::ServiceExt;
+
+    fn test_state() -> SharedAppState {
+        use dhan_live_trader_common::config::{DhanConfig, InstrumentConfig, QuestDbConfig};
+
+        SharedAppState::new(
+            QuestDbConfig {
+                host: "test".to_string(),
+                http_port: 9000,
+                pg_port: 8812,
+                ilp_port: 9009,
+            },
+            DhanConfig {
+                websocket_url: "wss://test".to_string(),
+                rest_api_base_url: "https://test".to_string(),
+                auth_base_url: "https://test".to_string(),
+                instrument_csv_url: "https://test".to_string(),
+                instrument_csv_fallback_url: "https://test".to_string(),
+                max_instruments_per_connection: 5000,
+                max_websocket_connections: 5,
+            },
+            InstrumentConfig {
+                daily_download_time: "08:55:00".to_string(),
+                csv_cache_directory: "/tmp/dlt-cache".to_string(),
+                csv_cache_filename: "instruments.csv".to_string(),
+                csv_download_timeout_secs: 120,
+                build_window_start: "08:25:00".to_string(),
+                build_window_end: "08:55:00".to_string(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn test_build_router_health_returns_200() {
+        let app = build_router(test_state());
+        let req = axum::http::Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_build_router_portal_returns_200() {
+        let app = build_router(test_state());
+        let req = axum::http::Request::builder()
+            .uri("/portal")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_build_router_unknown_route_returns_404() {
+        let app = build_router(test_state());
+        let req = axum::http::Request::builder()
+            .uri("/nonexistent")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+}

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -116,4 +116,46 @@ mod tests {
         let state2 = state1.clone();
         assert_eq!(state2.questdb_config().host, "clone-test");
     }
+
+    #[test]
+    fn test_dhan_config_getter() {
+        let qdb = QuestDbConfig {
+            host: "test".to_string(),
+            http_port: 9000,
+            pg_port: 8812,
+            ilp_port: 9009,
+        };
+        let state = SharedAppState::new(qdb, test_dhan_config(), test_instrument_config());
+        assert_eq!(state.dhan_config().max_instruments_per_connection, 5000);
+        assert_eq!(state.dhan_config().max_websocket_connections, 5);
+    }
+
+    #[test]
+    fn test_instrument_config_getter() {
+        let qdb = QuestDbConfig {
+            host: "test".to_string(),
+            http_port: 9000,
+            pg_port: 8812,
+            ilp_port: 9009,
+        };
+        let state = SharedAppState::new(qdb, test_dhan_config(), test_instrument_config());
+        assert_eq!(state.instrument_config().csv_download_timeout_secs, 120);
+        assert_eq!(state.instrument_config().build_window_start, "08:25:00");
+    }
+
+    #[test]
+    fn test_rebuild_in_progress_getter() {
+        use std::sync::atomic::Ordering;
+
+        let qdb = QuestDbConfig {
+            host: "test".to_string(),
+            http_port: 9000,
+            pg_port: 8812,
+            ilp_port: 9009,
+        };
+        let state = SharedAppState::new(qdb, test_dhan_config(), test_instrument_config());
+        assert!(!state.rebuild_in_progress().load(Ordering::SeqCst));
+        state.rebuild_in_progress().store(true, Ordering::SeqCst);
+        assert!(state.rebuild_in_progress().load(Ordering::SeqCst));
+    }
 }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -800,24 +800,30 @@ mod tests {
 
     #[test]
     fn test_parsed_feed_mode_quote() {
-        let mut cfg = SubscriptionConfig::default();
-        cfg.feed_mode = "Quote".to_string();
+        let cfg = SubscriptionConfig {
+            feed_mode: "Quote".to_string(),
+            ..Default::default()
+        };
         let mode = cfg.parsed_feed_mode().unwrap();
         assert_eq!(mode, crate::types::FeedMode::Quote);
     }
 
     #[test]
     fn test_parsed_feed_mode_full() {
-        let mut cfg = SubscriptionConfig::default();
-        cfg.feed_mode = "Full".to_string();
+        let cfg = SubscriptionConfig {
+            feed_mode: "Full".to_string(),
+            ..Default::default()
+        };
         let mode = cfg.parsed_feed_mode().unwrap();
         assert_eq!(mode, crate::types::FeedMode::Full);
     }
 
     #[test]
     fn test_parsed_feed_mode_invalid_returns_error() {
-        let mut cfg = SubscriptionConfig::default();
-        cfg.feed_mode = "Invalid".to_string();
+        let cfg = SubscriptionConfig {
+            feed_mode: "Invalid".to_string(),
+            ..Default::default()
+        };
         let err = cfg.parsed_feed_mode().unwrap_err();
         assert!(err.to_string().contains("Invalid"));
     }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -775,4 +775,71 @@ mod tests {
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("build_window_start"));
     }
+
+    // --- SubscriptionConfig ---
+
+    #[test]
+    fn test_subscription_config_default_values() {
+        let cfg = SubscriptionConfig::default();
+        assert_eq!(cfg.feed_mode, "Ticker");
+        assert!(cfg.subscribe_index_derivatives);
+        assert!(cfg.subscribe_stock_derivatives);
+        assert!(cfg.subscribe_display_indices);
+        assert!(cfg.subscribe_stock_equities);
+        assert_eq!(cfg.stock_atm_strikes_above, 10);
+        assert_eq!(cfg.stock_atm_strikes_below, 10);
+        assert!(cfg.stock_default_atm_fallback_enabled);
+    }
+
+    #[test]
+    fn test_parsed_feed_mode_ticker() {
+        let cfg = SubscriptionConfig::default();
+        let mode = cfg.parsed_feed_mode().unwrap();
+        assert_eq!(mode, crate::types::FeedMode::Ticker);
+    }
+
+    #[test]
+    fn test_parsed_feed_mode_quote() {
+        let mut cfg = SubscriptionConfig::default();
+        cfg.feed_mode = "Quote".to_string();
+        let mode = cfg.parsed_feed_mode().unwrap();
+        assert_eq!(mode, crate::types::FeedMode::Quote);
+    }
+
+    #[test]
+    fn test_parsed_feed_mode_full() {
+        let mut cfg = SubscriptionConfig::default();
+        cfg.feed_mode = "Full".to_string();
+        let mode = cfg.parsed_feed_mode().unwrap();
+        assert_eq!(mode, crate::types::FeedMode::Full);
+    }
+
+    #[test]
+    fn test_parsed_feed_mode_invalid_returns_error() {
+        let mut cfg = SubscriptionConfig::default();
+        cfg.feed_mode = "Invalid".to_string();
+        let err = cfg.parsed_feed_mode().unwrap_err();
+        assert!(err.to_string().contains("Invalid"));
+    }
+
+    // --- NotificationConfig ---
+
+    #[test]
+    fn test_notification_config_default_values() {
+        let cfg = NotificationConfig::default();
+        assert_eq!(cfg.telegram_api_base_url, "https://api.telegram.org");
+        assert_eq!(cfg.send_timeout_ms, 10_000);
+        assert!(!cfg.sns_enabled);
+    }
+
+    // --- ObservabilityConfig ---
+
+    #[test]
+    fn test_observability_config_default_values() {
+        let cfg = ObservabilityConfig::default();
+        assert_eq!(cfg.metrics_port, 9091);
+        assert!(cfg.otlp_endpoint.contains("4317"));
+        assert!(cfg.metrics_enabled);
+        assert!(cfg.tracing_enabled);
+    }
 }

--- a/crates/common/src/sanitize.rs
+++ b/crates/common/src/sanitize.rs
@@ -288,6 +288,32 @@ mod tests {
     }
 
     #[test]
+    fn test_mixed_http_and_https_urls_both_redacted() {
+        // Covers the (Some(h), Some(hs)) => h.min(hs) branch in redact_urls
+        let input = "tried http://a.com/x?secret=123 then https://b.com/y?key=456";
+        let output = redact_url_params(input);
+        assert!(!output.contains("123"), "http param leaked: {output}");
+        assert!(!output.contains("456"), "https param leaked: {output}");
+        assert!(
+            output.contains("http://a.com/x?[REDACTED]"),
+            "http URL not redacted: {output}"
+        );
+        assert!(
+            output.contains("https://b.com/y?[REDACTED]"),
+            "https URL not redacted: {output}"
+        );
+    }
+
+    #[test]
+    fn test_https_before_http_both_redacted() {
+        // Ensures both orders work: https first, http second
+        let input = "first https://secure.com?a=1 second http://plain.com?b=2";
+        let output = redact_url_params(input);
+        assert!(!output.contains("a=1"), "https param leaked: {output}");
+        assert!(!output.contains("b=2"), "http param leaked: {output}");
+    }
+
+    #[test]
     fn test_dhan_auth_full_error_with_body() {
         let input = "Dhan authentication failed: generateAccessToken request failed: error sending request for url (https://auth.dhan.co/app/generateAccessToken?dhanClientId=1106656882&pin=785478&totp=772509)";
         let output = redact_url_params(input);

--- a/crates/storage/src/instrument_persistence.rs
+++ b/crates/storage/src/instrument_persistence.rs
@@ -2623,4 +2623,46 @@ mod tests {
         // persist_instrument_snapshot swallows errors and always returns Ok
         assert!(result.is_ok());
     }
+
+    // -----------------------------------------------------------------------
+    // ensure_instrument_tables — DDL + DEDUP success and failure paths
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_ensure_instrument_tables_success_with_mock_http() {
+        let port = spawn_mock_http_server(MOCK_HTTP_200).await;
+        let config = QuestDbConfig {
+            host: "127.0.0.1".to_string(),
+            http_port: port,
+            pg_port: port,
+            ilp_port: port,
+        };
+        // Exercises both DDL CREATE TABLE and DEDUP UPSERT KEY success paths.
+        ensure_instrument_tables(&config).await;
+    }
+
+    #[tokio::test]
+    async fn test_ensure_instrument_tables_non_success_with_mock_http() {
+        let port = spawn_mock_http_server(MOCK_HTTP_400).await;
+        let config = QuestDbConfig {
+            host: "127.0.0.1".to_string(),
+            http_port: port,
+            pg_port: port,
+            ilp_port: port,
+        };
+        // Exercises both DDL and DEDUP non-success response paths.
+        ensure_instrument_tables(&config).await;
+    }
+
+    #[tokio::test]
+    async fn test_ensure_instrument_tables_unreachable_host() {
+        let config = QuestDbConfig {
+            host: "127.0.0.1".to_string(),
+            http_port: 1,
+            pg_port: 1,
+            ilp_port: 1,
+        };
+        // Exercises the connection error path for DDL and DEDUP requests.
+        ensure_instrument_tables(&config).await;
+    }
 }


### PR DESCRIPTION
## Summary
- **test(common):** cover config defaults, parsed_feed_mode, and mixed-URL sanitize branch
- **test(api):** cover build_router, state getters, RebuildGuard drop
- **test(storage):** cover ensure_instrument_tables DDL + DEDUP paths
- **fix(common):** resolve clippy field_reassign_with_default in config tests

## Verification
- `cargo check` — clean
- `cargo test` — 969 passed, 0 failed
- `cargo clippy --all-targets` — zero warnings

## Test plan
- [x] All 969 tests pass
- [x] No clippy warnings
- [x] Clean compilation

https://claude.ai/code/session_01GNTa4HwfntQEQaLDpovGk1