### PR TITLE
fix(hooks): pre-push dedup never triggers — check HEAD and HEAD~1

### DIFF
--- a/.claude/hooks/pre-push-gate.sh
+++ b/.claude/hooks/pre-push-gate.sh
@@ -55,8 +55,9 @@ FAILED=0
 # DEDUP CHECK: Did pre-commit gate already pass for this HEAD?
 # ─────────────────────────────────────────────
 STATE_FILE="$HOOKS_DIR/.last-quality-pass"
-# NOTE: pre-commit-gate writes HEAD *before* the commit runs (PreToolUse hook),
-# so the saved hash = parent of the new commit. We compare HEAD~1 to match.
+# NOTE: post-commit-state.sh updates saved hash to NEW HEAD after commit.
+# pre-commit-gate.sh writes OLD HEAD (parent) before commit.
+# We check both HEAD and HEAD~1 to handle either case.
 HEAD_CURRENT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 HEAD_PARENT=$(git rev-parse HEAD~1 2>/dev/null || echo "unknown")
 COMMIT_VERIFIED=false
@@ -67,7 +68,7 @@ if [ -f "$STATE_FILE" ]; then
   NOW=$(date +%s)
   AGE=$(( NOW - SAVED_TIME ))
 
-  if [ "$SAVED_HASH" = "$HEAD_PARENT" ] && [ "$AGE" -lt 300 ]; then
+  if { [ "$SAVED_HASH" = "$HEAD_CURRENT" ] || [ "$SAVED_HASH" = "$HEAD_PARENT" ]; } && [ "$AGE" -lt 300 ]; then
     COMMIT_VERIFIED=true
   fi
 fi


### PR DESCRIPTION
## Summary

- PR #155 introduced two contradicting fixes: `post-commit-state.sh` writes **NEW HEAD** to state file, but `pre-push-gate.sh` only compares against `HEAD~1` (parent)
- Since `NEW_HEAD != HEAD~1`, the dedup check **always fails**, causing every push to run the full 8-gate suite (cargo fmt + clippy + test + scans = 2-5 minutes)
- Fix: check both `HEAD_CURRENT` and `HEAD_PARENT` so dedup works regardless of whether `post-commit-state.sh` ran

## Test plan

- [ ] Commit a change then push — should see "PRE-PUSH (FAST — commit-verified Xs ago)" with gates 1-5 skipped
- [ ] Push without a fresh commit — should run full 8-gate suite (correct behavior)

https://claude.ai/code/session_01UDNmpyVvSNbLFNzmS8ofQS