### PR TITLE
fix(core): collapse nested if for clippy collapsible_if

### DIFF
--- a/crates/core/src/websocket/connection.rs
+++ b/crates/core/src/websocket/connection.rs
@@ -533,15 +533,15 @@ impl WebSocketConnection {
         let mut waited: u64 = 0;
         while waited < MAX_WAIT_SECS {
             let guard = self.token_handle.load();
-            if let Some(state) = guard.as_ref().as_ref() {
-                if state.is_valid() {
-                    info!(
-                        connection_id = self.connection_id,
-                        waited_secs = waited,
-                        "Valid token available — resuming reconnection"
-                    );
-                    return;
-                }
+            if let Some(state) = guard.as_ref().as_ref()
+                && state.is_valid()
+            {
+                info!(
+                    connection_id = self.connection_id,
+                    waited_secs = waited,
+                    "Valid token available — resuming reconnection"
+                );
+                return;
             }
             time::sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
             waited += POLL_INTERVAL_SECS;


### PR DESCRIPTION
## Summary
- Collapsed nested `if let` + `if` into a single let-chain in `wait_for_valid_token()` at `connection.rs:536`
- Fixes CI clippy failure (`collapsible_if` lint promoted to error via `-D warnings`)
- Rust 2024 edition supports let-chains natively

## Also done in this session
- Deleted all 20 stale `claude/*` remote branches — only `main` remains

https://claude.ai/code/session_01Q1GLvN59HDKUgVLFghq4ve