### PR TITLE
fix(hooks): wire pre-PR and pre-merge gates + block gh api bypass

### DIFF
--- a/.claude/hooks/pre-merge-gate.sh
+++ b/.claude/hooks/pre-merge-gate.sh
@@ -13,9 +13,20 @@ set -uo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Only gate commands that START with gh pr merge (not mentioned in commit messages)
-if ! echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+merge'; then
+# Gate: gh pr merge OR gh api calls that hit /pulls/*/merge endpoint
+IS_GH_PR_MERGE=$(echo "$COMMAND" | grep -cE '^\s*gh\s+pr\s+merge' || true)
+IS_GH_API_MERGE=$(echo "$COMMAND" | grep -cE 'gh\s+api.*pulls/[0-9]+/merge' || true)
+
+if [ "$IS_GH_PR_MERGE" -eq 0 ] && [ "$IS_GH_API_MERGE" -eq 0 ]; then
   exit 0
+fi
+
+if [ "$IS_GH_API_MERGE" -gt 0 ]; then
+  echo "╔══════════════════════════════════════════════╗" >&2
+  echo "║  BLOCKED: gh api merge bypass detected        ║" >&2
+  echo "║  Use 'gh pr merge' so CI gates are enforced   ║" >&2
+  echo "╚══════════════════════════════════════════════╝" >&2
+  exit 2
 fi
 
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')

--- a/.claude/hooks/pre-pr-gate.sh
+++ b/.claude/hooks/pre-pr-gate.sh
@@ -15,10 +15,20 @@ set -uo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Only gate commands that START with gh pr create (not mentioned in commit messages)
-# Use ^gh or leading whitespace to avoid matching commit message text containing "gh pr create"
-if ! echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+create'; then
+# Gate: gh pr create OR gh api calls that create PRs
+IS_GH_PR_CREATE=$(echo "$COMMAND" | grep -cE '^\s*gh\s+pr\s+create' || true)
+IS_GH_API_PR=$(echo "$COMMAND" | grep -cE 'gh\s+api.*repos/.*/pulls\s' || true)
+
+if [ "$IS_GH_PR_CREATE" -eq 0 ] && [ "$IS_GH_API_PR" -eq 0 ]; then
   exit 0
+fi
+
+if [ "$IS_GH_API_PR" -gt 0 ]; then
+  echo "╔══════════════════════════════════════════════╗" >&2
+  echo "║  BLOCKED: gh api PR bypass detected           ║" >&2
+  echo "║  Use 'gh pr create' so quality gates run      ║" >&2
+  echo "╚══════════════════════════════════════════════╝" >&2
+  exit 2
 fi
 
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,6 +77,19 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-env-files.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-pr-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-merge-gate.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary
- Wired existing `pre-pr-gate.sh` and `pre-merge-gate.sh` into `PreToolUse` Bash matcher in settings.json — they were never triggered before
- Updated `pre-merge-gate.sh` to block `gh api .../pulls/*/merge` calls that bypass CI checks
- Updated `pre-pr-gate.sh` to block `gh api .../pulls` calls that bypass quality gates

## Why
Claude Code bypassed both gates by using raw `gh api` calls instead of `gh pr create` / `gh pr merge`. This closes that loophole.

## Test plan
- [ ] Verify `gh api -X PUT repos/.../pulls/*/merge` is blocked by pre-merge-gate
- [ ] Verify `gh api repos/.../pulls` is blocked by pre-pr-gate
- [ ] Verify `gh pr create` still triggers quality gates (fmt, clippy, tests)
- [ ] Verify `gh pr merge` still triggers CI status check

https://claude.ai/code/session_01Q1GLvN59HDKUgVLFghq4ve