### PR TITLE
perf(ci): run Coverage & Perf only on push to main

### DIFF
--- a/.claude/hooks/pre-merge-gate.sh
+++ b/.claude/hooks/pre-merge-gate.sh
@@ -13,9 +13,20 @@ set -uo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Only gate commands that START with gh pr merge (not mentioned in commit messages)
-if ! echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+merge'; then
+# Gate: gh pr merge OR gh api calls that hit /pulls/*/merge endpoint
+IS_GH_PR_MERGE=$(echo "$COMMAND" | grep -cE '^\s*gh\s+pr\s+merge' || true)
+IS_GH_API_MERGE=$(echo "$COMMAND" | grep -cE 'gh\s+api.*pulls/[0-9]+/merge' || true)
+
+if [ "$IS_GH_PR_MERGE" -eq 0 ] && [ "$IS_GH_API_MERGE" -eq 0 ]; then
   exit 0
+fi
+
+if [ "$IS_GH_API_MERGE" -gt 0 ]; then
+  echo "╔══════════════════════════════════════════════╗" >&2
+  echo "║  BLOCKED: gh api merge bypass detected        ║" >&2
+  echo "║  Use 'gh pr merge' so CI gates are enforced   ║" >&2
+  echo "╚══════════════════════════════════════════════╝" >&2
+  exit 2
 fi
 
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')

--- a/.claude/hooks/pre-pr-gate.sh
+++ b/.claude/hooks/pre-pr-gate.sh
@@ -15,10 +15,20 @@ set -uo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Only gate commands that START with gh pr create (not mentioned in commit messages)
-# Use ^gh or leading whitespace to avoid matching commit message text containing "gh pr create"
-if ! echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+create'; then
+# Gate: gh pr create OR gh api calls that create PRs
+IS_GH_PR_CREATE=$(echo "$COMMAND" | grep -cE '^\s*gh\s+pr\s+create' || true)
+IS_GH_API_PR=$(echo "$COMMAND" | grep -cE 'gh\s+api.*repos/.*/pulls\s' || true)
+
+if [ "$IS_GH_PR_CREATE" -eq 0 ] && [ "$IS_GH_API_PR" -eq 0 ]; then
   exit 0
+fi
+
+if [ "$IS_GH_API_PR" -gt 0 ]; then
+  echo "╔══════════════════════════════════════════════╗" >&2
+  echo "║  BLOCKED: gh api PR bypass detected           ║" >&2
+  echo "║  Use 'gh pr create' so quality gates run      ║" >&2
+  echo "╚══════════════════════════════════════════════╝" >&2
+  exit 2
 fi
 
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,6 +77,19 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-env-files.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-pr-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-merge-gate.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,15 @@
 # Runs on every push to main and every PR — but ONLY for code changes.
 # All checks must pass. Failure = build is RED. No merging.
 #
-# Cost optimization: Heavy jobs (Build, Security, Coverage) SKIP on draft PRs.
+# Cost optimization: Heavy jobs (Build, Security) SKIP on draft PRs.
+# Coverage & Perf runs ONLY on push to main (post-merge) to save CI minutes.
 # Mark PR as "Ready for Review" to trigger full CI before merge.
 # Commit Lint always runs on PRs (lightweight).
 #
 # Jobs:
 #   1. Build & Verify — compile + fmt + clippy + docs + typos + machete + test
 #   2. Security & Audit — cargo deny + cargo audit (parallel after Job 1)
-#   3. Coverage & Perf — llvm-cov + bench + DHAT (parallel after Job 1)
+#   3. Coverage & Perf — llvm-cov + bench + DHAT (push to main only)
 #   + Commit Lint (PR only, lightweight, parallel)
 #
 # Checks preserved (all 14):
@@ -215,11 +216,11 @@ jobs:
             echo "::warning::Security advisories found — review and update dependencies"
           fi
 
-  # ---- Job 3: Coverage & Performance (parallel after build-and-verify) ----
+  # ---- Job 3: Coverage & Performance (push to main only — saves ~10 min per PR) ----
   coverage-and-perf:
     name: "Coverage & Perf"
     needs: build-and-verify
-    if: github.event.pull_request.draft != true
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Types:    feat, fix, refactor, test, docs, chore, perf, security
 ```
 
 Every commit compiles + passes tests. One logical change per commit.
-No branch protection or required checks until production deployment.
+Branch protection ON: Build & Verify, Security & Audit, Commit Lint, Secret Scan must pass before merge. Enforced for admins. No direct pushes to main.
 
 ## CARGO
 


### PR DESCRIPTION
## Summary
- Coverage & Perf job (~10 min) was running on every PR push despite not being a required merge check
- Changed to run only on `push` to `main` (post-merge), saving ~10 min of GitHub Actions billing per PR
- Coverage data still collected on every merge to main

## Test plan
- [ ] Verify PR CI only runs: Commit Lint, Build & Verify, Security & Audit, Secret Scan
- [ ] Verify Coverage & Perf is skipped on PR
- [ ] After merge, verify Coverage & Perf runs on push to main

https://claude.ai/code/session_01Q1GLvN59HDKUgVLFghq4ve