### PR TITLE
feat(core): add 20/200-depth parsers, order update types, and subscription builders

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -226,11 +226,92 @@ pub const FEED_REQUEST_FULL: u8 = 21;
 pub const FEED_UNSUBSCRIBE_FULL: u8 = 22;
 
 // ---------------------------------------------------------------------------
-// Market Depth
+// Market Depth — Standard (5-Level)
 // ---------------------------------------------------------------------------
 
 /// Number of market depth levels in full quote.
 pub const MARKET_DEPTH_LEVELS: usize = 5;
+
+// ---------------------------------------------------------------------------
+// Deep Depth Protocol — 20-Level & 200-Level WebSocket Feeds
+// Source: DhanHQ Python SDK (src/dhanhq/marketfeed.py), Dhan API docs.
+// Separate WebSocket endpoints from the standard feed.
+// Bid and ask sides arrive as SEPARATE binary packets.
+// ---------------------------------------------------------------------------
+
+/// 20-level depth: number of price levels per side.
+pub const TWENTY_DEPTH_LEVELS: usize = 20;
+
+/// 200-level depth: number of price levels per side.
+pub const TWO_HUNDRED_DEPTH_LEVELS: usize = 200;
+
+/// Deep depth header size in bytes.
+/// Format: msg_length(u16) + feed_response_code(u8) + exchange_segment(u8)
+///       + security_id(u32) + msg_sequence(u32) = 12 bytes.
+pub const DEEP_DEPTH_HEADER_SIZE: usize = 12;
+
+/// Deep depth level size in bytes.
+/// Format: price(f64) + quantity(u32) + orders(u32) = 16 bytes.
+pub const DEEP_DEPTH_LEVEL_SIZE: usize = 16;
+
+/// Feed response code indicating a BID-side depth packet.
+pub const DEEP_DEPTH_FEED_CODE_BID: u8 = 41;
+
+/// Feed response code indicating an ASK-side depth packet.
+pub const DEEP_DEPTH_FEED_CODE_ASK: u8 = 51;
+
+/// 20-level depth body size per side (20 levels × 16 bytes).
+pub const TWENTY_DEPTH_BODY_SIZE: usize = TWENTY_DEPTH_LEVELS * DEEP_DEPTH_LEVEL_SIZE;
+
+/// 20-level depth total packet size per side (header + body).
+pub const TWENTY_DEPTH_PACKET_SIZE: usize = DEEP_DEPTH_HEADER_SIZE + TWENTY_DEPTH_BODY_SIZE;
+
+/// 200-level depth body size per side (200 levels × 16 bytes).
+pub const TWO_HUNDRED_DEPTH_BODY_SIZE: usize = TWO_HUNDRED_DEPTH_LEVELS * DEEP_DEPTH_LEVEL_SIZE;
+
+/// 200-level depth total packet size per side (header + body).
+pub const TWO_HUNDRED_DEPTH_PACKET_SIZE: usize =
+    DEEP_DEPTH_HEADER_SIZE + TWO_HUNDRED_DEPTH_BODY_SIZE;
+
+/// Maximum instruments per 20-depth WebSocket connection (Dhan limit).
+pub const MAX_INSTRUMENTS_PER_TWENTY_DEPTH_CONNECTION: usize = 50;
+
+/// Maximum instruments per 200-depth WebSocket connection (Dhan limit: 1).
+pub const MAX_INSTRUMENTS_PER_TWO_HUNDRED_DEPTH_CONNECTION: usize = 1;
+
+/// Subscription request code for 20-level depth feed.
+pub const FEED_REQUEST_TWENTY_DEPTH: u8 = 23;
+
+/// Unsubscription request code for 20-level depth feed.
+pub const FEED_UNSUBSCRIBE_TWENTY_DEPTH: u8 = 24;
+
+// ---------------------------------------------------------------------------
+// Deep Depth Protocol — Header Byte Offsets
+// ---------------------------------------------------------------------------
+
+/// Message length (u16 LE) offset in deep depth header.
+pub const DEEP_DEPTH_HEADER_OFFSET_MSG_LENGTH: usize = 0;
+
+/// Feed response code (u8) offset in deep depth header.
+pub const DEEP_DEPTH_HEADER_OFFSET_FEED_CODE: usize = 2;
+
+/// Exchange segment (u8) offset in deep depth header.
+pub const DEEP_DEPTH_HEADER_OFFSET_EXCHANGE_SEGMENT: usize = 3;
+
+/// Security ID (u32 LE) offset in deep depth header.
+pub const DEEP_DEPTH_HEADER_OFFSET_SECURITY_ID: usize = 4;
+
+/// Message sequence number (u32 LE) offset in deep depth header.
+pub const DEEP_DEPTH_HEADER_OFFSET_MSG_SEQUENCE: usize = 8;
+
+// ---------------------------------------------------------------------------
+// Live Order Update WebSocket
+// Source: DhanHQ API docs, Python SDK.
+// Separate JSON-based WebSocket (NOT binary).
+// ---------------------------------------------------------------------------
+
+/// Message code for order update WebSocket login request.
+pub const ORDER_UPDATE_LOGIN_MSG_CODE: u16 = 42;
 
 // ---------------------------------------------------------------------------
 // SEBI Compliance
@@ -845,6 +926,18 @@ const _: () = assert!(
 const _: () = assert!(
     ORDER_EVENT_RING_BUFFER_CAPACITY.is_power_of_two(),
     "ORDER_EVENT_RING_BUFFER_CAPACITY must be power of 2"
+);
+
+// Sanity: deep depth packet sizes are consistent.
+const _: () = assert!(
+    TWENTY_DEPTH_PACKET_SIZE
+        == DEEP_DEPTH_HEADER_SIZE + TWENTY_DEPTH_LEVELS * DEEP_DEPTH_LEVEL_SIZE,
+    "TWENTY_DEPTH_PACKET_SIZE mismatch"
+);
+const _: () = assert!(
+    TWO_HUNDRED_DEPTH_PACKET_SIZE
+        == DEEP_DEPTH_HEADER_SIZE + TWO_HUNDRED_DEPTH_LEVELS * DEEP_DEPTH_LEVEL_SIZE,
+    "TWO_HUNDRED_DEPTH_PACKET_SIZE mismatch"
 );
 
 // Sanity: dedup ring buffer power must be in range [8, 24].

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -16,6 +16,7 @@ pub mod constants;
 pub mod error;
 pub mod instrument_registry;
 pub mod instrument_types;
+pub mod order_types;
 pub mod sanitize;
 pub mod tick_types;
 pub mod types;

--- a/crates/common/src/order_types.rs
+++ b/crates/common/src/order_types.rs
@@ -1,0 +1,508 @@
+//! Order-related types for the Dhan trading system.
+//!
+//! Types for order status, transaction type, product type, order type,
+//! validity, and the live order update WebSocket message format.
+//! Used by the order update parser and the OMS state machine.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Order Status
+// ---------------------------------------------------------------------------
+
+/// Order lifecycle status as reported by Dhan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderStatus {
+    /// Order in transit to exchange.
+    Transit,
+    /// Pending at exchange.
+    Pending,
+    /// Confirmed/open in exchange order book.
+    Confirmed,
+    /// Fully executed.
+    Traded,
+    /// Cancelled by user or system.
+    Cancelled,
+    /// Rejected by exchange or RMS.
+    Rejected,
+    /// Expired at end of validity.
+    Expired,
+}
+
+impl OrderStatus {
+    /// Returns the canonical string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Transit => "TRANSIT",
+            Self::Pending => "PENDING",
+            Self::Confirmed => "CONFIRMED",
+            Self::Traded => "TRADED",
+            Self::Cancelled => "CANCELLED",
+            Self::Rejected => "REJECTED",
+            Self::Expired => "EXPIRED",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transaction Type
+// ---------------------------------------------------------------------------
+
+/// Buy or sell side of an order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransactionType {
+    /// Buy order.
+    Buy,
+    /// Sell order.
+    Sell,
+}
+
+impl TransactionType {
+    /// Returns the canonical string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Buy => "BUY",
+            Self::Sell => "SELL",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Product Type
+// ---------------------------------------------------------------------------
+
+/// Trading product type determining margin and settlement rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ProductType {
+    /// Cash & Carry — delivery-based equity holding.
+    Cnc,
+    /// Intraday — squared off same day.
+    Intraday,
+    /// Margin — leveraged delivery.
+    Margin,
+    /// Margin Trading Facility — broker-funded leverage.
+    Mtf,
+    /// Cover Order — with stop-loss.
+    Co,
+    /// Bracket Order — with target + stop-loss.
+    Bo,
+}
+
+impl ProductType {
+    /// Returns the canonical string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Cnc => "CNC",
+            Self::Intraday => "INTRADAY",
+            Self::Margin => "MARGIN",
+            Self::Mtf => "MTF",
+            Self::Co => "CO",
+            Self::Bo => "BO",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Order Type
+// ---------------------------------------------------------------------------
+
+/// Order execution type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderType {
+    /// Limit order — price specified.
+    Limit,
+    /// Market order — best available price.
+    Market,
+    /// Stop-loss order — triggers at stop price, then limit.
+    StopLoss,
+    /// Stop-loss market — triggers at stop price, then market.
+    StopLossMarket,
+}
+
+impl OrderType {
+    /// Returns the canonical string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Limit => "LIMIT",
+            Self::Market => "MARKET",
+            Self::StopLoss => "STOP_LOSS",
+            Self::StopLossMarket => "STOP_LOSS_MARKET",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Order Validity
+// ---------------------------------------------------------------------------
+
+/// Order time-in-force validity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderValidity {
+    /// Valid for the trading day.
+    Day,
+    /// Immediate or Cancel.
+    Ioc,
+}
+
+impl OrderValidity {
+    /// Returns the canonical string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Day => "DAY",
+            Self::Ioc => "IOC",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Order Update — Live WebSocket message
+// ---------------------------------------------------------------------------
+
+/// A live order update received from the Dhan order update WebSocket.
+///
+/// Field names use PascalCase to match Dhan's WebSocket JSON format.
+/// This struct is deserialized from the `"Data"` wrapper in the WebSocket message.
+///
+/// Note: This is NOT Copy because it contains String fields (cold path only).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct OrderUpdate {
+    /// Exchange name ("NSE", "BSE").
+    #[serde(default)]
+    pub exchange: String,
+    /// Segment code ("E" = Equity, "D" = Derivative).
+    #[serde(default)]
+    pub segment: String,
+    /// Dhan security identifier.
+    #[serde(default)]
+    pub security_id: String,
+    /// Dhan client identifier.
+    #[serde(default)]
+    pub client_id: String,
+    /// Dhan order number.
+    #[serde(default)]
+    pub order_no: String,
+    /// Exchange order number.
+    #[serde(default)]
+    pub exch_order_no: String,
+    /// Product type code ("C" = CNC, etc.).
+    #[serde(default)]
+    pub product: String,
+    /// Transaction type ("B" = Buy, "S" = Sell).
+    #[serde(default)]
+    pub txn_type: String,
+    /// Order type ("LMT", "MKT", etc.).
+    #[serde(default)]
+    pub order_type: String,
+    /// Validity ("DAY", "IOC").
+    #[serde(default)]
+    pub validity: String,
+    /// Total order quantity.
+    #[serde(default)]
+    pub quantity: i64,
+    /// Filled/traded quantity.
+    #[serde(default)]
+    pub traded_qty: i64,
+    /// Remaining unfilled quantity.
+    #[serde(default)]
+    pub remaining_quantity: i64,
+    /// Order price.
+    #[serde(default)]
+    pub price: f64,
+    /// Trigger price for stop-loss orders.
+    #[serde(default)]
+    pub trigger_price: f64,
+    /// Last traded price of the fill.
+    #[serde(default)]
+    pub traded_price: f64,
+    /// Average traded price across all fills.
+    #[serde(default)]
+    pub avg_traded_price: f64,
+    /// Order status string ("TRANSIT", "PENDING", "TRADED", etc.).
+    #[serde(default)]
+    pub status: String,
+    /// Trading symbol.
+    #[serde(default)]
+    pub symbol: String,
+    /// Display-friendly instrument name.
+    #[serde(default)]
+    pub display_name: String,
+    /// User-supplied correlation ID for idempotency.
+    #[serde(default)]
+    pub correlation_id: String,
+    /// User-supplied remarks.
+    #[serde(default)]
+    pub remarks: String,
+    /// Reason description ("CONFIRMED", rejection reason, etc.).
+    #[serde(default)]
+    pub reason_description: String,
+    /// Order creation datetime ("YYYY-MM-DD HH:MM:SS").
+    #[serde(default)]
+    pub order_date_time: String,
+    /// Exchange order timestamp.
+    #[serde(default)]
+    pub exch_order_time: String,
+    /// Last update timestamp.
+    #[serde(default)]
+    pub last_updated_time: String,
+    /// Instrument type ("EQUITY", "OPTIDX", etc.).
+    #[serde(default)]
+    pub instrument: String,
+    /// Lot size.
+    #[serde(default)]
+    pub lot_size: i64,
+    /// Strike price (derivatives only).
+    #[serde(default)]
+    pub strike_price: f64,
+    /// Expiry date string (derivatives only).
+    #[serde(default)]
+    pub expiry_date: String,
+    /// Option type ("CE", "PE", "XX").
+    #[serde(default)]
+    pub opt_type: String,
+    /// ISIN code.
+    #[serde(default)]
+    pub isin: String,
+    /// Disclosed quantity.
+    #[serde(default)]
+    pub disc_quantity: i64,
+    /// Disclosed quantity remaining.
+    #[serde(default)]
+    pub disc_qty_rem: i64,
+    /// Leg number.
+    #[serde(default)]
+    pub leg_no: i64,
+    /// Product name ("CNC", "INTRADAY", etc.).
+    #[serde(default)]
+    pub product_name: String,
+    /// Reference LTP.
+    #[serde(default, rename = "refLtp")]
+    pub ref_ltp: f64,
+    /// Tick size.
+    #[serde(default, rename = "tickSize")]
+    pub tick_size: f64,
+}
+
+/// Wrapper for the Dhan order update WebSocket message.
+///
+/// The WebSocket sends JSON with a top-level `"Data"` key containing the order fields.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct OrderUpdateMessage {
+    /// The order update payload.
+    pub data: OrderUpdate,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- OrderStatus ---
+
+    #[test]
+    fn test_order_status_as_str() {
+        assert_eq!(OrderStatus::Transit.as_str(), "TRANSIT");
+        assert_eq!(OrderStatus::Pending.as_str(), "PENDING");
+        assert_eq!(OrderStatus::Confirmed.as_str(), "CONFIRMED");
+        assert_eq!(OrderStatus::Traded.as_str(), "TRADED");
+        assert_eq!(OrderStatus::Cancelled.as_str(), "CANCELLED");
+        assert_eq!(OrderStatus::Rejected.as_str(), "REJECTED");
+        assert_eq!(OrderStatus::Expired.as_str(), "EXPIRED");
+    }
+
+    #[test]
+    fn test_order_status_serde_roundtrip() {
+        let original = OrderStatus::Traded;
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, "\"TRADED\"");
+        let deserialized: OrderStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    // --- TransactionType ---
+
+    #[test]
+    fn test_transaction_type_as_str() {
+        assert_eq!(TransactionType::Buy.as_str(), "BUY");
+        assert_eq!(TransactionType::Sell.as_str(), "SELL");
+    }
+
+    #[test]
+    fn test_transaction_type_serde_roundtrip() {
+        let original = TransactionType::Buy;
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: TransactionType = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    // --- ProductType ---
+
+    #[test]
+    fn test_product_type_as_str_all_variants() {
+        assert_eq!(ProductType::Cnc.as_str(), "CNC");
+        assert_eq!(ProductType::Intraday.as_str(), "INTRADAY");
+        assert_eq!(ProductType::Margin.as_str(), "MARGIN");
+        assert_eq!(ProductType::Mtf.as_str(), "MTF");
+        assert_eq!(ProductType::Co.as_str(), "CO");
+        assert_eq!(ProductType::Bo.as_str(), "BO");
+    }
+
+    // --- OrderType ---
+
+    #[test]
+    fn test_order_type_as_str_all_variants() {
+        assert_eq!(OrderType::Limit.as_str(), "LIMIT");
+        assert_eq!(OrderType::Market.as_str(), "MARKET");
+        assert_eq!(OrderType::StopLoss.as_str(), "STOP_LOSS");
+        assert_eq!(OrderType::StopLossMarket.as_str(), "STOP_LOSS_MARKET");
+    }
+
+    // --- OrderValidity ---
+
+    #[test]
+    fn test_order_validity_as_str() {
+        assert_eq!(OrderValidity::Day.as_str(), "DAY");
+        assert_eq!(OrderValidity::Ioc.as_str(), "IOC");
+    }
+
+    // --- OrderUpdate deserialization ---
+
+    #[test]
+    fn test_order_update_deserialize_full_message() {
+        let json = r#"{
+            "Data": {
+                "Exchange": "NSE",
+                "Segment": "D",
+                "SecurityId": "52432",
+                "ClientId": "1000000001",
+                "OrderNo": "1234567890",
+                "ExchOrderNo": "NSE-1234567",
+                "Product": "I",
+                "TxnType": "B",
+                "OrderType": "LMT",
+                "Validity": "DAY",
+                "Quantity": 50,
+                "TradedQty": 50,
+                "RemainingQuantity": 0,
+                "Price": 245.50,
+                "TriggerPrice": 0.0,
+                "TradedPrice": 245.50,
+                "AvgTradedPrice": 245.50,
+                "Status": "TRADED",
+                "Symbol": "NIFTY",
+                "DisplayName": "NIFTY 27MAR 24500 CE",
+                "CorrelationId": "uuid-123",
+                "Remarks": "",
+                "ReasonDescription": "CONFIRMED",
+                "OrderDateTime": "2026-03-15 10:30:45",
+                "ExchOrderTime": "2026-03-15 10:30:45",
+                "LastUpdatedTime": "2026-03-15 10:30:46",
+                "Instrument": "OPTIDX",
+                "LotSize": 50,
+                "StrikePrice": 24500.0,
+                "ExpiryDate": "2026-03-27",
+                "OptType": "CE",
+                "Isin": "",
+                "DiscQuantity": 0,
+                "DiscQtyRem": 0,
+                "LegNo": 0,
+                "ProductName": "INTRADAY",
+                "refLtp": 245.0,
+                "tickSize": 0.05
+            }
+        }"#;
+
+        let msg: OrderUpdateMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.data.exchange, "NSE");
+        assert_eq!(msg.data.security_id, "52432");
+        assert_eq!(msg.data.order_no, "1234567890");
+        assert_eq!(msg.data.txn_type, "B");
+        assert_eq!(msg.data.status, "TRADED");
+        assert_eq!(msg.data.quantity, 50);
+        assert_eq!(msg.data.traded_qty, 50);
+        assert!((msg.data.price - 245.50).abs() < f64::EPSILON);
+        assert!((msg.data.avg_traded_price - 245.50).abs() < f64::EPSILON);
+        assert_eq!(msg.data.symbol, "NIFTY");
+        assert_eq!(msg.data.opt_type, "CE");
+        assert!((msg.data.strike_price - 24500.0).abs() < f64::EPSILON);
+        assert!((msg.data.ref_ltp - 245.0).abs() < f64::EPSILON);
+        assert!((msg.data.tick_size - 0.05).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_order_update_deserialize_minimal_fields() {
+        let json = r#"{
+            "Data": {
+                "OrderNo": "999",
+                "Status": "PENDING"
+            }
+        }"#;
+
+        let msg: OrderUpdateMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.data.order_no, "999");
+        assert_eq!(msg.data.status, "PENDING");
+        assert_eq!(msg.data.exchange, "");
+        assert_eq!(msg.data.quantity, 0);
+        assert_eq!(msg.data.price, 0.0);
+    }
+
+    #[test]
+    fn test_order_update_serialize_roundtrip() {
+        let update = OrderUpdate {
+            exchange: "NSE".to_owned(),
+            segment: "D".to_owned(),
+            security_id: "52432".to_owned(),
+            client_id: "100".to_owned(),
+            order_no: "123".to_owned(),
+            exch_order_no: "NSE-123".to_owned(),
+            product: "I".to_owned(),
+            txn_type: "B".to_owned(),
+            order_type: "LMT".to_owned(),
+            validity: "DAY".to_owned(),
+            quantity: 50,
+            traded_qty: 25,
+            remaining_quantity: 25,
+            price: 245.50,
+            trigger_price: 0.0,
+            traded_price: 245.50,
+            avg_traded_price: 245.50,
+            status: "PENDING".to_owned(),
+            symbol: "NIFTY".to_owned(),
+            display_name: "NIFTY CE".to_owned(),
+            correlation_id: "uuid-1".to_owned(),
+            remarks: String::new(),
+            reason_description: "CONFIRMED".to_owned(),
+            order_date_time: "2026-03-15 10:30:45".to_owned(),
+            exch_order_time: "2026-03-15 10:30:45".to_owned(),
+            last_updated_time: "2026-03-15 10:30:46".to_owned(),
+            instrument: "OPTIDX".to_owned(),
+            lot_size: 50,
+            strike_price: 24500.0,
+            expiry_date: "2026-03-27".to_owned(),
+            opt_type: "CE".to_owned(),
+            isin: String::new(),
+            disc_quantity: 0,
+            disc_qty_rem: 0,
+            leg_no: 0,
+            product_name: "INTRADAY".to_owned(),
+            ref_ltp: 245.0,
+            tick_size: 0.05,
+        };
+
+        let msg = OrderUpdateMessage {
+            data: update.clone(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let deserialized: OrderUpdateMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, deserialized);
+    }
+}

--- a/crates/common/src/tick_types.rs
+++ b/crates/common/src/tick_types.rs
@@ -100,6 +100,27 @@ pub struct MarketDepthLevel {
 }
 
 // ---------------------------------------------------------------------------
+// Deep Depth Level — from 20-level / 200-level depth feeds
+// ---------------------------------------------------------------------------
+
+/// A single level of market depth from the 20-level or 200-level depth feed.
+///
+/// These feeds use f64 prices (unlike the standard 5-level feed which uses f32)
+/// and send bid/ask sides as separate packets. Each level contains
+/// price, quantity, and order count for one side only.
+///
+/// Wire format per level: price(f64 LE, 8 bytes) + quantity(u32 LE, 4 bytes) + orders(u32 LE, 4 bytes) = 16 bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct DeepDepthLevel {
+    /// Price at this level (rupees, f64 — higher precision than 5-level f32).
+    pub price: f64,
+    /// Quantity at this level.
+    pub quantity: u32,
+    /// Number of orders at this level.
+    pub orders: u32,
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -142,5 +163,38 @@ mod tests {
         assert_eq!(level.ask_orders, 0);
         assert_eq!(level.bid_price, 0.0);
         assert_eq!(level.ask_price, 0.0);
+    }
+
+    // --- DeepDepthLevel ---
+
+    #[test]
+    fn test_deep_depth_level_default() {
+        let level = DeepDepthLevel::default();
+        assert_eq!(level.price, 0.0);
+        assert_eq!(level.quantity, 0);
+        assert_eq!(level.orders, 0);
+    }
+
+    #[test]
+    fn test_deep_depth_level_is_copy() {
+        let level = DeepDepthLevel {
+            price: 24500.50,
+            quantity: 1000,
+            orders: 42,
+        };
+        let copy = level; // Copy, not move
+        assert_eq!(level.price, copy.price);
+        assert_eq!(level.quantity, copy.quantity);
+        assert_eq!(level.orders, copy.orders);
+    }
+
+    #[test]
+    fn test_deep_depth_level_f64_precision() {
+        let level = DeepDepthLevel {
+            price: 24500.123456789,
+            quantity: 1,
+            orders: 1,
+        };
+        assert!((level.price - 24500.123456789).abs() < 1e-9);
     }
 }

--- a/crates/core/src/parser/deep_depth.rs
+++ b/crates/core/src/parser/deep_depth.rs
@@ -1,0 +1,567 @@
+//! Deep depth parser for 20-level and 200-level market depth feeds.
+//!
+//! These feeds use a SEPARATE WebSocket endpoint from the standard feed:
+//! - 20-depth: `wss://depth-api-feed.dhan.co/twentydepth`
+//! - 200-depth: `wss://full-depth-api.dhan.co/twohundreddepth`
+//!
+//! # Protocol differences from standard feed
+//! - 12-byte header (vs 8-byte standard feed header)
+//! - Bid and ask sides arrive as SEPARATE binary packets (feed codes 41/51)
+//! - Prices are f64 (vs f32 in standard feed)
+//! - Per-level format: price(f64) + quantity(u32) + orders(u32) = 16 bytes
+//!
+//! # Performance
+//! All parsing is O(1) — fixed number of reads per packet.
+
+use dhan_live_trader_common::constants::{
+    DEEP_DEPTH_FEED_CODE_ASK, DEEP_DEPTH_FEED_CODE_BID, DEEP_DEPTH_HEADER_OFFSET_EXCHANGE_SEGMENT,
+    DEEP_DEPTH_HEADER_OFFSET_FEED_CODE, DEEP_DEPTH_HEADER_OFFSET_MSG_LENGTH,
+    DEEP_DEPTH_HEADER_OFFSET_MSG_SEQUENCE, DEEP_DEPTH_HEADER_OFFSET_SECURITY_ID,
+    DEEP_DEPTH_HEADER_SIZE, DEEP_DEPTH_LEVEL_SIZE, TWENTY_DEPTH_LEVELS, TWENTY_DEPTH_PACKET_SIZE,
+    TWO_HUNDRED_DEPTH_LEVELS, TWO_HUNDRED_DEPTH_PACKET_SIZE,
+};
+use dhan_live_trader_common::tick_types::DeepDepthLevel;
+
+use super::types::ParseError;
+
+// ---------------------------------------------------------------------------
+// Deep Depth Header
+// ---------------------------------------------------------------------------
+
+/// Parsed header from a 20-level or 200-level depth binary packet.
+///
+/// 12 bytes: msg_length(u16) + feed_code(u8) + exchange_segment(u8) + security_id(u32) + msg_sequence(u32).
+#[derive(Debug, Clone, Copy)]
+pub struct DeepDepthHeader {
+    /// Total message length in bytes.
+    pub message_length: u16,
+    /// Feed response code (41 = Bid, 51 = Ask).
+    pub feed_code: u8,
+    /// Binary exchange segment code (1=NSE_EQ, 2=NSE_FNO, etc.).
+    pub exchange_segment_code: u8,
+    /// Dhan security identifier.
+    pub security_id: u32,
+    /// Message sequence number (for ordering/gap detection).
+    pub message_sequence: u32,
+}
+
+/// Which side of the order book this packet represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthSide {
+    /// Bid (buy) side — feed code 41.
+    Bid,
+    /// Ask (sell) side — feed code 51.
+    Ask,
+}
+
+// ---------------------------------------------------------------------------
+// Byte reading helpers
+// ---------------------------------------------------------------------------
+
+/// Reads a little-endian u16 from a byte slice at the given offset.
+#[allow(clippy::arithmetic_side_effects)] // APPROVED: caller validates buffer length before invoking
+#[inline(always)]
+fn read_u16_le(raw: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes([raw[offset], raw[offset + 1]])
+}
+
+/// Reads a little-endian u32 from a byte slice at the given offset.
+#[allow(clippy::arithmetic_side_effects)] // APPROVED: caller validates buffer length before invoking
+#[inline(always)]
+fn read_u32_le(raw: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        raw[offset],
+        raw[offset + 1],
+        raw[offset + 2],
+        raw[offset + 3],
+    ])
+}
+
+/// Reads a little-endian f64 from a byte slice at the given offset.
+#[allow(clippy::arithmetic_side_effects)] // APPROVED: caller validates buffer length before invoking
+#[inline(always)]
+fn read_f64_le(raw: &[u8], offset: usize) -> f64 {
+    f64::from_le_bytes([
+        raw[offset],
+        raw[offset + 1],
+        raw[offset + 2],
+        raw[offset + 3],
+        raw[offset + 4],
+        raw[offset + 5],
+        raw[offset + 6],
+        raw[offset + 7],
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// Header parser
+// ---------------------------------------------------------------------------
+
+/// Parses the 12-byte deep depth header.
+///
+/// # Errors
+/// Returns `ParseError::InsufficientBytes` if `raw.len() < 12`.
+pub fn parse_deep_depth_header(raw: &[u8]) -> Result<DeepDepthHeader, ParseError> {
+    if raw.len() < DEEP_DEPTH_HEADER_SIZE {
+        return Err(ParseError::InsufficientBytes {
+            expected: DEEP_DEPTH_HEADER_SIZE,
+            actual: raw.len(),
+        });
+    }
+
+    Ok(DeepDepthHeader {
+        message_length: read_u16_le(raw, DEEP_DEPTH_HEADER_OFFSET_MSG_LENGTH),
+        feed_code: raw[DEEP_DEPTH_HEADER_OFFSET_FEED_CODE],
+        exchange_segment_code: raw[DEEP_DEPTH_HEADER_OFFSET_EXCHANGE_SEGMENT],
+        security_id: read_u32_le(raw, DEEP_DEPTH_HEADER_OFFSET_SECURITY_ID),
+        message_sequence: read_u32_le(raw, DEEP_DEPTH_HEADER_OFFSET_MSG_SEQUENCE),
+    })
+}
+
+/// Determines the depth side from the feed code.
+///
+/// # Errors
+/// Returns `ParseError::UnknownResponseCode` if feed_code is neither 41 nor 51.
+pub fn feed_code_to_side(feed_code: u8) -> Result<DepthSide, ParseError> {
+    match feed_code {
+        DEEP_DEPTH_FEED_CODE_BID => Ok(DepthSide::Bid),
+        DEEP_DEPTH_FEED_CODE_ASK => Ok(DepthSide::Ask),
+        code => Err(ParseError::UnknownResponseCode(code)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Level parsers
+// ---------------------------------------------------------------------------
+
+/// Parses N levels of deep depth from a byte slice starting after the header.
+///
+/// Each level is 16 bytes: price(f64 LE) + quantity(u32 LE) + orders(u32 LE).
+///
+/// # Arguments
+/// * `raw` — Full packet bytes (including header).
+/// * `level_count` — Number of levels to parse (20 or 200).
+///
+/// # Returns
+/// Vec of `DeepDepthLevel`. Not Copy-based array due to variable size (20 vs 200).
+///
+/// # Performance
+/// O(N) where N is level_count — fixed, known at call site.
+#[allow(clippy::arithmetic_side_effects)] // APPROVED: constant offsets bounded by packet size check
+fn parse_deep_depth_levels(
+    raw: &[u8],
+    level_count: usize,
+    expected_packet_size: usize,
+) -> Result<Vec<DeepDepthLevel>, ParseError> {
+    // O(1) EXEMPT: begin — allocation for depth levels, bounded by level_count (20 or 200)
+    if raw.len() < expected_packet_size {
+        return Err(ParseError::InsufficientBytes {
+            expected: expected_packet_size,
+            actual: raw.len(),
+        });
+    }
+
+    let mut levels = Vec::with_capacity(level_count);
+    for i in 0..level_count {
+        let base = DEEP_DEPTH_HEADER_SIZE + i * DEEP_DEPTH_LEVEL_SIZE;
+        levels.push(DeepDepthLevel {
+            price: read_f64_le(raw, base),
+            quantity: read_u32_le(raw, base + 8),
+            orders: read_u32_le(raw, base + 12),
+        });
+    }
+
+    Ok(levels)
+    // O(1) EXEMPT: end
+}
+
+// ---------------------------------------------------------------------------
+// Public parsing functions
+// ---------------------------------------------------------------------------
+
+/// Parsed result from a deep depth packet (one side: bid or ask).
+#[derive(Debug)]
+pub struct ParsedDeepDepth {
+    /// Parsed 12-byte header.
+    pub header: DeepDepthHeader,
+    /// Which side this packet represents (Bid or Ask).
+    pub side: DepthSide,
+    /// Depth levels for this side.
+    pub levels: Vec<DeepDepthLevel>,
+    /// Local receive timestamp in nanoseconds since Unix epoch.
+    pub received_at_nanos: i64,
+}
+
+/// Parses a 20-level depth packet (one side: bid or ask).
+///
+/// Expected packet size: 332 bytes (12 header + 20 × 16 body).
+///
+/// # Performance
+/// O(1) — fixed 20 level reads.
+pub fn parse_twenty_depth_packet(
+    raw: &[u8],
+    received_at_nanos: i64,
+) -> Result<ParsedDeepDepth, ParseError> {
+    let header = parse_deep_depth_header(raw)?;
+    let side = feed_code_to_side(header.feed_code)?;
+    let levels = parse_deep_depth_levels(raw, TWENTY_DEPTH_LEVELS, TWENTY_DEPTH_PACKET_SIZE)?;
+
+    Ok(ParsedDeepDepth {
+        header,
+        side,
+        levels,
+        received_at_nanos,
+    })
+}
+
+/// Parses a 200-level depth packet (one side: bid or ask).
+///
+/// Expected packet size: 3212 bytes (12 header + 200 × 16 body).
+///
+/// # Performance
+/// O(1) — fixed 200 level reads.
+pub fn parse_two_hundred_depth_packet(
+    raw: &[u8],
+    received_at_nanos: i64,
+) -> Result<ParsedDeepDepth, ParseError> {
+    let header = parse_deep_depth_header(raw)?;
+    let side = feed_code_to_side(header.feed_code)?;
+    let levels =
+        parse_deep_depth_levels(raw, TWO_HUNDRED_DEPTH_LEVELS, TWO_HUNDRED_DEPTH_PACKET_SIZE)?;
+
+    Ok(ParsedDeepDepth {
+        header,
+        side,
+        levels,
+        received_at_nanos,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::arithmetic_side_effects)] // APPROVED: test helpers use constant offsets for packet construction
+mod tests {
+    use super::*;
+
+    /// Builds a deep depth packet for testing.
+    fn make_deep_depth_packet(
+        feed_code: u8,
+        exchange_segment: u8,
+        security_id: u32,
+        msg_sequence: u32,
+        level_count: usize,
+        level_data: Option<&[(f64, u32, u32)]>,
+    ) -> Vec<u8> {
+        let packet_size = DEEP_DEPTH_HEADER_SIZE + level_count * DEEP_DEPTH_LEVEL_SIZE;
+        let mut buf = vec![0u8; packet_size];
+
+        // Header
+        buf[0..2].copy_from_slice(&(packet_size as u16).to_le_bytes());
+        buf[2] = feed_code;
+        buf[3] = exchange_segment;
+        buf[4..8].copy_from_slice(&security_id.to_le_bytes());
+        buf[8..12].copy_from_slice(&msg_sequence.to_le_bytes());
+
+        // Levels
+        if let Some(data) = level_data {
+            for (i, (price, qty, orders)) in data.iter().enumerate() {
+                if i >= level_count {
+                    break;
+                }
+                let base = DEEP_DEPTH_HEADER_SIZE + i * DEEP_DEPTH_LEVEL_SIZE;
+                buf[base..base + 8].copy_from_slice(&price.to_le_bytes());
+                buf[base + 8..base + 12].copy_from_slice(&qty.to_le_bytes());
+                buf[base + 12..base + 16].copy_from_slice(&orders.to_le_bytes());
+            }
+        }
+
+        buf
+    }
+
+    // --- Header parsing ---
+
+    #[test]
+    fn test_parse_deep_depth_header_valid() {
+        let buf = make_deep_depth_packet(41, 2, 52432, 100, 20, None);
+        let header = parse_deep_depth_header(&buf).unwrap();
+        assert_eq!(header.feed_code, 41);
+        assert_eq!(header.exchange_segment_code, 2);
+        assert_eq!(header.security_id, 52432);
+        assert_eq!(header.message_sequence, 100);
+    }
+
+    #[test]
+    fn test_parse_deep_depth_header_too_short() {
+        let buf = [0u8; 11]; // One byte short
+        let err = parse_deep_depth_header(&buf).unwrap_err();
+        match err {
+            ParseError::InsufficientBytes {
+                expected: 12,
+                actual: 11,
+            } => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_deep_depth_header_empty() {
+        let err = parse_deep_depth_header(&[]).unwrap_err();
+        match err {
+            ParseError::InsufficientBytes {
+                expected: 12,
+                actual: 0,
+            } => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // --- Feed code → side ---
+
+    #[test]
+    fn test_feed_code_to_side_bid() {
+        assert_eq!(feed_code_to_side(41).unwrap(), DepthSide::Bid);
+    }
+
+    #[test]
+    fn test_feed_code_to_side_ask() {
+        assert_eq!(feed_code_to_side(51).unwrap(), DepthSide::Ask);
+    }
+
+    #[test]
+    fn test_feed_code_to_side_unknown() {
+        let err = feed_code_to_side(99).unwrap_err();
+        assert!(matches!(err, ParseError::UnknownResponseCode(99)));
+    }
+
+    // --- 20-depth parsing ---
+
+    #[test]
+    fn test_parse_twenty_depth_bid_packet() {
+        let level_data: Vec<(f64, u32, u32)> = (0..20)
+            .map(|i| {
+                let i_f64 = f64::from(i);
+                (
+                    24500.0 - i_f64 * 0.05,
+                    (1000 - i * 50) as u32,
+                    (100 - i * 5) as u32,
+                )
+            })
+            .collect();
+
+        let buf = make_deep_depth_packet(41, 2, 52432, 1, 20, Some(&level_data));
+        let result = parse_twenty_depth_packet(&buf, 999).unwrap();
+
+        assert_eq!(result.side, DepthSide::Bid);
+        assert_eq!(result.header.security_id, 52432);
+        assert_eq!(result.header.exchange_segment_code, 2);
+        assert_eq!(result.header.message_sequence, 1);
+        assert_eq!(result.received_at_nanos, 999);
+        assert_eq!(result.levels.len(), 20);
+
+        // Verify first level
+        assert!((result.levels[0].price - 24500.0).abs() < 1e-9);
+        assert_eq!(result.levels[0].quantity, 1000);
+        assert_eq!(result.levels[0].orders, 100);
+
+        // Verify last level
+        assert!((result.levels[19].price - 24499.05).abs() < 1e-9);
+        assert_eq!(result.levels[19].quantity, 50);
+        assert_eq!(result.levels[19].orders, 5);
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_ask_packet() {
+        let level_data: Vec<(f64, u32, u32)> = (0..20)
+            .map(|i| {
+                let i_f64 = f64::from(i);
+                (
+                    24500.05 + i_f64 * 0.05,
+                    500 + i as u32 * 25,
+                    50 + i as u32 * 3,
+                )
+            })
+            .collect();
+
+        let buf = make_deep_depth_packet(51, 2, 52432, 2, 20, Some(&level_data));
+        let result = parse_twenty_depth_packet(&buf, 888).unwrap();
+
+        assert_eq!(result.side, DepthSide::Ask);
+        assert_eq!(result.levels.len(), 20);
+        assert!((result.levels[0].price - 24500.05).abs() < 1e-9);
+        assert_eq!(result.levels[0].quantity, 500);
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_truncated() {
+        let mut buf = vec![0u8; TWENTY_DEPTH_PACKET_SIZE - 1];
+        buf[2] = DEEP_DEPTH_FEED_CODE_BID; // Valid feed code so we hit the size check
+        let err = parse_twenty_depth_packet(&buf, 0).unwrap_err();
+        match err {
+            ParseError::InsufficientBytes { expected, actual } => {
+                assert_eq!(expected, TWENTY_DEPTH_PACKET_SIZE);
+                assert_eq!(actual, TWENTY_DEPTH_PACKET_SIZE - 1);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_unknown_feed_code() {
+        let buf = make_deep_depth_packet(99, 2, 52432, 1, 20, None);
+        let err = parse_twenty_depth_packet(&buf, 0).unwrap_err();
+        assert!(matches!(err, ParseError::UnknownResponseCode(99)));
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_zero_levels() {
+        let buf = make_deep_depth_packet(41, 2, 52432, 1, 20, None);
+        let result = parse_twenty_depth_packet(&buf, 0).unwrap();
+        for level in &result.levels {
+            assert_eq!(level.price, 0.0);
+            assert_eq!(level.quantity, 0);
+            assert_eq!(level.orders, 0);
+        }
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_extra_bytes_ignored() {
+        let mut buf = make_deep_depth_packet(41, 1, 2885, 5, 20, None);
+        buf.extend_from_slice(&[0xFF; 100]); // extra garbage
+        let result = parse_twenty_depth_packet(&buf, 0).unwrap();
+        assert_eq!(result.levels.len(), 20);
+        assert_eq!(result.header.security_id, 2885);
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_max_security_id() {
+        let buf = make_deep_depth_packet(41, 2, u32::MAX, 1, 20, None);
+        let result = parse_twenty_depth_packet(&buf, 0).unwrap();
+        assert_eq!(result.header.security_id, u32::MAX);
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_nan_price() {
+        let level_data = [(f64::NAN, 100, 10)];
+        let buf = make_deep_depth_packet(41, 2, 1, 1, 20, Some(&level_data));
+        let result = parse_twenty_depth_packet(&buf, 0).unwrap();
+        assert!(result.levels[0].price.is_nan());
+    }
+
+    #[test]
+    fn test_parse_twenty_depth_infinity_price() {
+        let level_data = [(f64::INFINITY, 100, 10)];
+        let buf = make_deep_depth_packet(51, 2, 1, 1, 20, Some(&level_data));
+        let result = parse_twenty_depth_packet(&buf, 0).unwrap();
+        assert!(result.levels[0].price.is_infinite());
+    }
+
+    // --- 200-depth parsing ---
+
+    #[test]
+    fn test_parse_two_hundred_depth_bid_packet() {
+        let level_data: Vec<(f64, u32, u32)> = (0..200)
+            .map(|i| {
+                let i_f64 = f64::from(i);
+                (24500.0 - i_f64 * 0.05, 100 + i as u32, 10 + i as u32)
+            })
+            .collect();
+
+        let buf = make_deep_depth_packet(41, 2, 13, 1, 200, Some(&level_data));
+        let result = parse_two_hundred_depth_packet(&buf, 777).unwrap();
+
+        assert_eq!(result.side, DepthSide::Bid);
+        assert_eq!(result.levels.len(), 200);
+        assert!((result.levels[0].price - 24500.0).abs() < 1e-9);
+        assert_eq!(result.levels[0].quantity, 100);
+        assert_eq!(result.levels[0].orders, 10);
+        assert_eq!(result.received_at_nanos, 777);
+
+        // Verify level 199
+        assert!((result.levels[199].price - (24500.0 - 199.0 * 0.05)).abs() < 1e-9);
+        assert_eq!(result.levels[199].quantity, 299);
+        assert_eq!(result.levels[199].orders, 209);
+    }
+
+    #[test]
+    fn test_parse_two_hundred_depth_ask_packet() {
+        let buf = make_deep_depth_packet(51, 1, 2885, 42, 200, None);
+        let result = parse_two_hundred_depth_packet(&buf, 0).unwrap();
+        assert_eq!(result.side, DepthSide::Ask);
+        assert_eq!(result.levels.len(), 200);
+        assert_eq!(result.header.security_id, 2885);
+        assert_eq!(result.header.message_sequence, 42);
+    }
+
+    #[test]
+    fn test_parse_two_hundred_depth_truncated() {
+        let mut buf = vec![0u8; TWO_HUNDRED_DEPTH_PACKET_SIZE - 1];
+        buf[2] = DEEP_DEPTH_FEED_CODE_ASK; // Valid feed code so we hit the size check
+        let err = parse_two_hundred_depth_packet(&buf, 0).unwrap_err();
+        match err {
+            ParseError::InsufficientBytes { expected, actual } => {
+                assert_eq!(expected, TWO_HUNDRED_DEPTH_PACKET_SIZE);
+                assert_eq!(actual, TWO_HUNDRED_DEPTH_PACKET_SIZE - 1);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_two_hundred_depth_unknown_feed_code() {
+        let buf = make_deep_depth_packet(0, 2, 1, 1, 200, None);
+        let err = parse_two_hundred_depth_packet(&buf, 0).unwrap_err();
+        assert!(matches!(err, ParseError::UnknownResponseCode(0)));
+    }
+
+    #[test]
+    fn test_parse_two_hundred_depth_packet_size_constants() {
+        assert_eq!(TWENTY_DEPTH_PACKET_SIZE, 12 + 20 * 16);
+        assert_eq!(TWO_HUNDRED_DEPTH_PACKET_SIZE, 12 + 200 * 16);
+    }
+
+    // --- Stacked packets ---
+
+    #[test]
+    fn test_stacked_twenty_depth_bid_ask_parsing() {
+        let bid_buf = make_deep_depth_packet(41, 2, 52432, 1, 20, None);
+        let ask_buf = make_deep_depth_packet(51, 2, 52432, 2, 20, None);
+
+        // Simulate stacked packets in one WS message
+        let mut stacked = Vec::with_capacity(bid_buf.len() + ask_buf.len());
+        stacked.extend_from_slice(&bid_buf);
+        stacked.extend_from_slice(&ask_buf);
+
+        // Parse first packet (bid)
+        let bid_result =
+            parse_twenty_depth_packet(&stacked[..TWENTY_DEPTH_PACKET_SIZE], 0).unwrap();
+        assert_eq!(bid_result.side, DepthSide::Bid);
+        assert_eq!(bid_result.header.security_id, 52432);
+
+        // Parse second packet (ask)
+        let ask_result =
+            parse_twenty_depth_packet(&stacked[TWENTY_DEPTH_PACKET_SIZE..], 0).unwrap();
+        assert_eq!(ask_result.side, DepthSide::Ask);
+        assert_eq!(ask_result.header.security_id, 52432);
+    }
+
+    // --- Header field edge cases ---
+
+    #[test]
+    fn test_deep_depth_header_all_exchange_segments() {
+        for segment in 0..=8 {
+            let buf = make_deep_depth_packet(41, segment, 1, 1, 20, None);
+            let header = parse_deep_depth_header(&buf).unwrap();
+            assert_eq!(header.exchange_segment_code, segment);
+        }
+    }
+
+    #[test]
+    fn test_deep_depth_header_max_msg_sequence() {
+        let buf = make_deep_depth_packet(51, 2, 1, u32::MAX, 20, None);
+        let header = parse_deep_depth_header(&buf).unwrap();
+        assert_eq!(header.message_sequence, u32::MAX);
+    }
+}

--- a/crates/core/src/parser/mod.rs
+++ b/crates/core/src/parser/mod.rs
@@ -13,6 +13,7 @@
 //! - Full (162 bytes, code 8) — Quote + OI + 5-level depth
 //! - Disconnect (10 bytes, code 50) — disconnect reason code
 
+pub mod deep_depth;
 pub mod disconnect;
 pub mod dispatcher;
 pub mod full_packet;
@@ -20,11 +21,17 @@ pub mod header;
 pub mod market_depth;
 pub mod market_status;
 pub mod oi;
+pub mod order_update;
 pub mod previous_close;
 pub mod quote;
 pub mod ticker;
 pub mod types;
 
 // Re-export the main entry point and types for convenient use.
+pub use deep_depth::{
+    DeepDepthHeader, DepthSide, ParsedDeepDepth, parse_twenty_depth_packet,
+    parse_two_hundred_depth_packet,
+};
 pub use dispatcher::dispatch_frame;
+pub use order_update::{OrderUpdateParseError, build_order_update_login, parse_order_update};
 pub use types::{PacketHeader, ParseError, ParsedFrame};

--- a/crates/core/src/parser/order_update.rs
+++ b/crates/core/src/parser/order_update.rs
@@ -1,0 +1,230 @@
+//! Order update parser for the Dhan live order update WebSocket.
+//!
+//! The order update WebSocket (`wss://api-order-update.dhan.co`) sends JSON messages
+//! (NOT binary) with a `"Data"` wrapper containing order fields in PascalCase.
+//!
+//! This module provides:
+//! - `parse_order_update` — Deserializes a JSON string into an `OrderUpdate`.
+//! - `build_order_update_login` — Builds the login JSON message.
+//!
+//! # Protocol
+//! After connecting, the client sends a login message:
+//! ```json
+//! {
+//!   "LoginReq": { "MsgCode": 42, "ClientId": "..." , "Token": "..." },
+//!   "UserType": "SELF"
+//! }
+//! ```
+//! Then order updates arrive automatically as JSON with a `"Data"` key.
+
+use dhan_live_trader_common::constants::ORDER_UPDATE_LOGIN_MSG_CODE;
+use dhan_live_trader_common::order_types::{OrderUpdate, OrderUpdateMessage};
+
+/// Error type for order update parsing.
+#[derive(Debug, thiserror::Error)]
+pub enum OrderUpdateParseError {
+    /// JSON deserialization failed.
+    #[error("failed to parse order update JSON: {0}")]
+    JsonError(#[from] serde_json::Error),
+}
+
+/// Parses a JSON order update message from the Dhan order update WebSocket.
+///
+/// Expects JSON with a top-level `"Data"` key containing order fields.
+///
+/// # Arguments
+/// * `json_str` — Raw JSON string from the WebSocket.
+///
+/// # Returns
+/// The parsed `OrderUpdate` struct.
+///
+/// # Errors
+/// Returns `OrderUpdateParseError::JsonError` if deserialization fails.
+pub fn parse_order_update(json_str: &str) -> Result<OrderUpdate, OrderUpdateParseError> {
+    let message: OrderUpdateMessage = serde_json::from_str(json_str)?;
+    Ok(message.data)
+}
+
+/// Builds the login JSON message for the order update WebSocket.
+///
+/// Must be sent immediately after WebSocket connection is established.
+///
+/// # Arguments
+/// * `client_id` — Dhan client identifier.
+/// * `access_token` — JWT access token.
+///
+/// # Returns
+/// Serialized JSON string ready to send over WebSocket.
+pub fn build_order_update_login(client_id: &str, access_token: &str) -> String {
+    // O(1) EXEMPT: begin — login message built once at connect time
+    serde_json::json!({
+        "LoginReq": {
+            "MsgCode": ORDER_UPDATE_LOGIN_MSG_CODE,
+            "ClientId": client_id,
+            "Token": access_token
+        },
+        "UserType": "SELF"
+    })
+    .to_string()
+    // O(1) EXEMPT: end
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_order_update_full_message() {
+        let json = r#"{
+            "Data": {
+                "Exchange": "NSE",
+                "Segment": "D",
+                "SecurityId": "52432",
+                "ClientId": "1000000001",
+                "OrderNo": "1234567890",
+                "ExchOrderNo": "NSE-1234567",
+                "Product": "I",
+                "TxnType": "B",
+                "OrderType": "LMT",
+                "Validity": "DAY",
+                "Quantity": 50,
+                "TradedQty": 50,
+                "RemainingQuantity": 0,
+                "Price": 245.50,
+                "TriggerPrice": 0.0,
+                "TradedPrice": 245.50,
+                "AvgTradedPrice": 245.50,
+                "Status": "TRADED",
+                "Symbol": "NIFTY",
+                "DisplayName": "NIFTY 27MAR 24500 CE",
+                "CorrelationId": "uuid-123",
+                "Remarks": "",
+                "ReasonDescription": "CONFIRMED",
+                "OrderDateTime": "2026-03-15 10:30:45",
+                "ExchOrderTime": "2026-03-15 10:30:45",
+                "LastUpdatedTime": "2026-03-15 10:30:46",
+                "Instrument": "OPTIDX",
+                "LotSize": 50,
+                "StrikePrice": 24500.0,
+                "ExpiryDate": "2026-03-27",
+                "OptType": "CE",
+                "Isin": "",
+                "DiscQuantity": 0,
+                "DiscQtyRem": 0,
+                "LegNo": 0,
+                "ProductName": "INTRADAY",
+                "refLtp": 245.0,
+                "tickSize": 0.05
+            }
+        }"#;
+
+        let update = parse_order_update(json).unwrap();
+        assert_eq!(update.exchange, "NSE");
+        assert_eq!(update.order_no, "1234567890");
+        assert_eq!(update.txn_type, "B");
+        assert_eq!(update.status, "TRADED");
+        assert_eq!(update.quantity, 50);
+        assert!((update.price - 245.50).abs() < f64::EPSILON);
+        assert_eq!(update.symbol, "NIFTY");
+        assert_eq!(update.opt_type, "CE");
+    }
+
+    #[test]
+    fn test_parse_order_update_minimal() {
+        let json = r#"{"Data": {"OrderNo": "999", "Status": "PENDING"}}"#;
+        let update = parse_order_update(json).unwrap();
+        assert_eq!(update.order_no, "999");
+        assert_eq!(update.status, "PENDING");
+        assert_eq!(update.exchange, "");
+        assert_eq!(update.quantity, 0);
+    }
+
+    #[test]
+    fn test_parse_order_update_invalid_json() {
+        let err = parse_order_update("not json").unwrap_err();
+        assert!(matches!(err, OrderUpdateParseError::JsonError(_)));
+    }
+
+    #[test]
+    fn test_parse_order_update_missing_data_key() {
+        let err = parse_order_update(r#"{"OrderNo": "123"}"#).unwrap_err();
+        assert!(matches!(err, OrderUpdateParseError::JsonError(_)));
+    }
+
+    #[test]
+    fn test_parse_order_update_empty_data() {
+        let update = parse_order_update(r#"{"Data": {}}"#).unwrap();
+        assert_eq!(update.order_no, "");
+        assert_eq!(update.status, "");
+    }
+
+    #[test]
+    fn test_build_order_update_login() {
+        let msg = build_order_update_login("1000000001", "jwt-token-123");
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+
+        assert_eq!(parsed["LoginReq"]["MsgCode"], 42);
+        assert_eq!(parsed["LoginReq"]["ClientId"], "1000000001");
+        assert_eq!(parsed["LoginReq"]["Token"], "jwt-token-123");
+        assert_eq!(parsed["UserType"], "SELF");
+    }
+
+    #[test]
+    fn test_build_order_update_login_empty_credentials() {
+        let msg = build_order_update_login("", "");
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(parsed["LoginReq"]["ClientId"], "");
+        assert_eq!(parsed["LoginReq"]["Token"], "");
+    }
+
+    #[test]
+    fn test_parse_order_update_rejected_order() {
+        let json = r#"{
+            "Data": {
+                "OrderNo": "555",
+                "Status": "REJECTED",
+                "ReasonDescription": "Insufficient margin",
+                "TxnType": "B",
+                "Quantity": 100,
+                "Price": 500.0,
+                "TradedQty": 0,
+                "RemainingQuantity": 100
+            }
+        }"#;
+
+        let update = parse_order_update(json).unwrap();
+        assert_eq!(update.status, "REJECTED");
+        assert_eq!(update.reason_description, "Insufficient margin");
+        assert_eq!(update.traded_qty, 0);
+        assert_eq!(update.remaining_quantity, 100);
+    }
+
+    #[test]
+    fn test_parse_order_update_cancelled_order() {
+        let json = r#"{
+            "Data": {
+                "OrderNo": "666",
+                "Status": "Cancelled",
+                "Quantity": 50,
+                "TradedQty": 25,
+                "RemainingQuantity": 25
+            }
+        }"#;
+
+        let update = parse_order_update(json).unwrap();
+        assert_eq!(update.status, "Cancelled");
+        assert_eq!(update.traded_qty, 25);
+        assert_eq!(update.remaining_quantity, 25);
+    }
+
+    #[test]
+    fn test_order_update_parse_error_display() {
+        let err = parse_order_update("invalid").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("failed to parse order update JSON"));
+    }
+}

--- a/crates/core/src/websocket/subscription_builder.rs
+++ b/crates/core/src/websocket/subscription_builder.rs
@@ -118,6 +118,74 @@ pub fn build_disconnect_message() -> String {
     .to_string() // O(1) EXEMPT: disconnect message — once at shutdown
 }
 
+/// Builds subscription JSON messages for the 20-level depth WebSocket feed.
+///
+/// Uses RequestCode 23. The 20-depth feed has a limit of 50 instruments per connection.
+/// Each subscription message is batched to at most `batch_size` instruments (Dhan limit: 100).
+///
+/// # Arguments
+/// * `instruments` — List of instruments to subscribe for 20-level depth.
+/// * `batch_size` — Max instruments per message (use config value, max 100).
+///
+/// # Returns
+/// Vec of serialized JSON strings, each ready to send over WebSocket.
+pub fn build_twenty_depth_subscription_messages(
+    instruments: &[InstrumentSubscription],
+    batch_size: usize,
+) -> Vec<String> {
+    // O(1) EXEMPT: begin — subscription building runs once at connect time
+    if instruments.is_empty() {
+        return Vec::new();
+    }
+
+    let effective_batch = batch_size.clamp(1, SUBSCRIPTION_BATCH_SIZE);
+    let request_code = dhan_live_trader_common::constants::FEED_REQUEST_TWENTY_DEPTH;
+
+    #[allow(clippy::expect_used)] // APPROVED: SubscriptionRequest is infallible to serialize
+    instruments
+        .chunks(effective_batch)
+        .map(|chunk| {
+            let request = SubscriptionRequest {
+                request_code,
+                instrument_count: chunk.len(),
+                instrument_list: chunk.to_vec(),
+            };
+            serde_json::to_string(&request).expect("SubscriptionRequest serialization cannot fail") // APPROVED: infallible serialize
+        })
+        .collect()
+    // O(1) EXEMPT: end
+}
+
+/// Builds unsubscription JSON messages for the 20-level depth WebSocket feed.
+///
+/// Uses RequestCode 24 (= 23 + 1).
+pub fn build_twenty_depth_unsubscription_messages(
+    instruments: &[InstrumentSubscription],
+    batch_size: usize,
+) -> Vec<String> {
+    // O(1) EXEMPT: begin — unsubscription building runs once at disconnect time
+    if instruments.is_empty() {
+        return Vec::new();
+    }
+
+    let effective_batch = batch_size.clamp(1, SUBSCRIPTION_BATCH_SIZE);
+    let unsubscribe_code = dhan_live_trader_common::constants::FEED_UNSUBSCRIBE_TWENTY_DEPTH;
+
+    #[allow(clippy::expect_used)] // APPROVED: SubscriptionRequest is infallible to serialize
+    instruments
+        .chunks(effective_batch)
+        .map(|chunk| {
+            let request = SubscriptionRequest {
+                request_code: unsubscribe_code,
+                instrument_count: chunk.len(),
+                instrument_list: chunk.to_vec(),
+            };
+            serde_json::to_string(&request).expect("SubscriptionRequest serialization cannot fail") // APPROVED: infallible serialize
+        })
+        .collect()
+    // O(1) EXEMPT: end
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -340,5 +408,54 @@ mod tests {
         assert_eq!(parsed["RequestCode"], 21);
         assert_eq!(parsed["InstrumentCount"], 3);
         assert_eq!(parsed["InstrumentList"].as_array().unwrap().len(), 3);
+    }
+
+    // --- 20-depth subscription ---
+
+    #[test]
+    fn test_twenty_depth_subscription_request_code_23() {
+        let instruments = make_instruments(1);
+        let messages = build_twenty_depth_subscription_messages(&instruments, 100);
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].contains("\"RequestCode\":23"));
+    }
+
+    #[test]
+    fn test_twenty_depth_subscription_empty() {
+        let messages = build_twenty_depth_subscription_messages(&[], 100);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_twenty_depth_subscription_batching() {
+        let instruments = make_instruments(150);
+        let messages = build_twenty_depth_subscription_messages(&instruments, 100);
+        assert_eq!(messages.len(), 2);
+        assert!(messages[0].contains("\"InstrumentCount\":100"));
+        assert!(messages[1].contains("\"InstrumentCount\":50"));
+    }
+
+    #[test]
+    fn test_twenty_depth_unsubscription_request_code_24() {
+        let instruments = make_instruments(3);
+        let messages = build_twenty_depth_unsubscription_messages(&instruments, 100);
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].contains("\"RequestCode\":24"));
+    }
+
+    #[test]
+    fn test_twenty_depth_unsubscription_empty() {
+        let messages = build_twenty_depth_unsubscription_messages(&[], 100);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_twenty_depth_subscription_valid_json() {
+        let instruments = make_instruments(5);
+        let messages = build_twenty_depth_subscription_messages(&instruments, 100);
+        let parsed: serde_json::Value = serde_json::from_str(&messages[0]).unwrap();
+        assert_eq!(parsed["RequestCode"], 23);
+        assert_eq!(parsed["InstrumentCount"], 5);
+        assert_eq!(parsed["InstrumentList"].as_array().unwrap().len(), 5);
     }
 }

--- a/docs/phases/PHASE_1_LIVE_TRADING.md
+++ b/docs/phases/PHASE_1_LIVE_TRADING.md
@@ -521,76 +521,82 @@ If server doesn't receive ping within 40 seconds → disconnects (code 806)
 | Parameter | Value |
 |-----------|-------|
 | Endpoint | `wss://depth-api-feed.dhan.co/twentydepth` (from config) |
-| Auth | Same as live feed (access-token + client-id headers) |
-| Max connections | 5 |
-| Max instruments per connection | 5,000 |
+| Auth | Token + client ID as URL query params (`?token=<JWT>&clientId=<id>&authType=2`) |
+| Max connections | 5 (shared limit with standard feed) |
+| Max instruments per connection | 50 |
 | Protocol | Binary, Little Endian |
+| Segments | NSE Equity and NSE Derivatives ONLY |
 
-**Subscription request:** Same JSON format as live feed but with `RequestCode: 21`.
+**Subscription request:** Same JSON format as live feed but with `RequestCode: 23`.
+
+```json
+{
+  "RequestCode": 23,
+  "InstrumentCount": 1,
+  "InstrumentList": [
+    {"ExchangeSegment": "NSE_EQ", "SecurityId": "2885"}
+  ]
+}
+```
 
 **Response packet structure:**
 
-20-Level Depth Header:
+Bid and Ask sides arrive as **SEPARATE** binary packets (unlike the standard 5-level feed which combines them). Each packet has feed code 41 (Bid) or 51 (Ask).
+
+12-Byte Deep Depth Header:
 ```
-Bytes 0-1:   Message Length (i16 LE) — total packet size
-Byte 2:      Exchange Segment code (u8)
-Bytes 3-6:   Security ID (i32 LE)
+Bytes 0-1:   Message Length (u16 LE) — total packet size
+Byte 2:      Feed Response Code (u8) — 41=Bid, 51=Ask
+Byte 3:      Exchange Segment code (u8)
+Bytes 4-7:   Security ID (u32 LE)
+Bytes 8-11:  Message Sequence (u32 LE)
 ```
 
-Note: The 20-level depth has a DIFFERENT header layout than the live feed — only 7 bytes, no response_code byte.
-
-20-Level Depth Body:
+Body (per side):
 ```
-Each level = 20 bytes (same as 5-level depth format):
-  Bid Quantity (i32 LE)
-  Bid Orders (i16 LE)
-  Bid Price (f32 LE — divide by 100)
-  Ask Price (f32 LE — divide by 100)
-  Ask Quantity (i32 LE)
-  Ask Orders (i16 LE)
+Each level = 16 bytes:
+  Price (f64 LE — 8 bytes, rupees, NO division needed)
+  Quantity (u32 LE — 4 bytes)
+  Orders (u32 LE — 4 bytes)
 
-20 levels × 20 bytes = 400 bytes
-Total packet: 7 (header) + 400 (body) = 407 bytes
+20 levels × 16 bytes = 320 bytes
+Total per-side packet: 12 (header) + 320 (body) = 332 bytes
 ```
+
+**Stacking:** When multiple instruments are subscribed, packets are stacked sequentially in a single WebSocket message. Parse by splitting on message length boundaries: instrument1-bid, instrument1-ask, instrument2-bid, instrument2-ask, etc.
+
+**Key differences from 5-level depth:**
+- Separate WebSocket endpoint (not `api-feed.dhan.co`)
+- 12-byte header (vs 8-byte standard header)
+- Bid/Ask arrive as separate packets (feed codes 41/51)
+- Prices are f64 (double, 8 bytes) instead of f32 (4 bytes)
+- Per-level layout differs: `price(f64) + qty(u32) + orders(u32)` = 16 bytes vs `bid_qty(u32) + ask_qty(u32) + bid_orders(u16) + ask_orders(u16) + bid_price(f32) + ask_price(f32)` = 20 bytes
 
 ### 200-Level Depth WebSocket
 
 | Parameter | Value |
 |-----------|-------|
 | Endpoint | `wss://full-depth-api.dhan.co/twohundreddepth` (from config) |
-| Auth | Same as live feed |
-| Max connections | 5 |
-| Max instruments per connection | 5,000 |
+| Auth | Token + client ID as URL query params (same as 20-depth) |
+| Max connections | 5 (shared limit) |
+| Max instruments per connection | **1** (critical limitation) |
+| Segments | NSE Equity and NSE Derivatives ONLY |
 
 **Response packet structure:**
 
-200-Level Depth Header:
+Identical format to 20-level depth, but with 200 levels per side instead of 20.
+
+12-Byte Header: Same as 20-depth (feed codes 41/51).
+
+Body (per side):
 ```
-Bytes 0-1:   Message Length (i16 LE)
-Byte 2:      Exchange Segment code (u8)
-Bytes 3-6:   Security ID (i32 LE)
-Bytes 7-10:  Last Traded Price (f32 LE — divide by 100)
-Bytes 11-14: Last Traded Time (i32 LE — Unix epoch)
-Bytes 15-18: Last Traded Quantity (i32 LE)
-Bytes 19:    Number of Bid Levels (u8)
-Bytes 20:    Number of Ask Levels (u8)
+200 levels × 16 bytes = 3,200 bytes
+Total per-side packet: 12 (header) + 3,200 (body) = 3,212 bytes
 ```
 
-200-Level Bid/Ask entries (variable count):
-```
-Each bid entry = 12 bytes:
-  Bid Price (f32 LE — divide by 100)
-  Bid Quantity (i32 LE)
-  Bid Orders (i32 LE)
+**Limitation:** No total volume traded data in the 200-depth feed — only price, quantity, and orders per level.
 
-Each ask entry = 12 bytes:
-  Ask Price (f32 LE — divide by 100)
-  Ask Quantity (i32 LE)
-  Ask Orders (i32 LE)
-
-Max: 200 bid levels + 200 ask levels
-Max packet size: 21 + (200 × 12) + (200 × 12) = 4,821 bytes
-```
+**NOTE:** 200-depth is limited to **1 instrument per connection**. To monitor N instruments at 200-level depth, N WebSocket connections are required.
 
 ---
 
@@ -914,35 +920,71 @@ Authorization: <access_token>
 |-----------|-------|
 | Endpoint | `wss://api-order-update.dhan.co` (from config) |
 | Protocol | JSON (NOT binary — different from market feed) |
-| Auth | Same headers (access-token + client-id) |
+| Auth | Login message sent after connection (NOT URL params) |
 | Purpose | Real-time order status updates pushed by Dhan |
 
-### Subscription
+### Authentication
 
-No subscription message needed. Upon connection with valid auth, Dhan automatically pushes all order updates for the authenticated account.
-
-### Order Update Message Format
+After connecting, send a JSON login message:
 
 ```json
 {
-    "type": "order_update",
-    "data": {
-        "orderId": "1234567890",
-        "orderStatus": "TRADED",
-        "exchangeSegment": "NSE_FNO",
-        "transactionType": "BUY",
-        "productType": "INTRADAY",
-        "securityId": "52432",
-        "quantity": 50,
-        "price": 245.50,
-        "tradedQuantity": 50,
-        "tradedPrice": 245.50,
-        "averageTradePrice": 245.50,
-        "remainingQuantity": 0,
-        "exchangeOrderId": "NSE-1234567",
-        "exchangeTime": "2026-03-15T10:30:45",
-        "updateTime": "2026-03-15T10:30:45",
-        "rejectionReason": ""
+    "LoginReq": {
+        "MsgCode": 42,
+        "ClientId": "1000000001",
+        "Token": "JWT_ACCESS_TOKEN"
+    },
+    "UserType": "SELF"
+}
+```
+
+Upon successful login, Dhan automatically pushes all order updates for the authenticated account. No subscription message needed.
+
+### Order Update Message Format
+
+Messages arrive as JSON with a `"Data"` wrapper. Fields use **PascalCase** (unlike REST API which uses camelCase).
+
+```json
+{
+    "Data": {
+        "Exchange": "NSE",
+        "Segment": "D",
+        "SecurityId": "52432",
+        "ClientId": "1000000001",
+        "OrderNo": "1234567890",
+        "ExchOrderNo": "NSE-1234567",
+        "Product": "I",
+        "TxnType": "B",
+        "OrderType": "LMT",
+        "Validity": "DAY",
+        "Quantity": 50,
+        "TradedQty": 50,
+        "RemainingQuantity": 0,
+        "Price": 245.50,
+        "TriggerPrice": 0.0,
+        "TradedPrice": 245.50,
+        "AvgTradedPrice": 245.50,
+        "Status": "TRADED",
+        "Symbol": "NIFTY",
+        "DisplayName": "NIFTY 27MAR 24500 CE",
+        "CorrelationId": "uuid-123",
+        "Remarks": "",
+        "ReasonDescription": "CONFIRMED",
+        "OrderDateTime": "2026-03-15 10:30:45",
+        "ExchOrderTime": "2026-03-15 10:30:45",
+        "LastUpdatedTime": "2026-03-15 10:30:46",
+        "Instrument": "OPTIDX",
+        "LotSize": 50,
+        "StrikePrice": 24500.0,
+        "ExpiryDate": "2026-03-27",
+        "OptType": "CE",
+        "Isin": "",
+        "DiscQuantity": 0,
+        "DiscQtyRem": 0,
+        "LegNo": 0,
+        "ProductName": "INTRADAY",
+        "refLtp": 245.0,
+        "tickSize": 0.05
     }
 }
 ```


### PR DESCRIPTION
## Summary
- Add binary parsers for 20-level and 200-level market depth (deep depth) WebSocket protocol with O(1) fixed-byte parsing, f64 prices, 16-byte levels, and 12-byte headers
- Add order update type system and JSON parser for the live order update WebSocket with PascalCase serde and `"Data"` wrapper
- Add subscription/unsubscription message builders for 20-depth feed (RequestCode 23/24) with 50-instrument batching
- Correct phase doc Section 6 (Full Market Depth) and Section 10 (Live Order Update) to match actual DhanHQ protocol specs

## Changes
- **`crates/common/src/constants.rs`** — 20+ new constants for deep depth protocol (header offsets, feed codes, packet sizes, instrument limits)
- **`crates/common/src/tick_types.rs`** — `DeepDepthLevel` type (f64 price, u32 qty, u32 orders)
- **`crates/common/src/order_types.rs`** — NEW: Complete order update type system (enums + `OrderUpdate` struct + `OrderUpdateMessage` wrapper)
- **`crates/core/src/parser/deep_depth.rs`** — NEW: Binary parser for 20/200-depth packets
- **`crates/core/src/parser/order_update.rs`** — NEW: JSON parser + login message builder for order updates
- **`crates/core/src/parser/mod.rs`** — Register new modules and re-exports
- **`crates/core/src/websocket/subscription_builder.rs`** — 20-depth subscribe/unsubscribe builders
- **`docs/phases/PHASE_1_LIVE_TRADING.md`** — Protocol corrections for Sections 6 & 10

## Test plan
- [x] All 1265 tests pass (`cargo test --workspace --lib`)
- [x] `cargo clippy --workspace --all-targets` — 0 warnings
- [x] `cargo fmt --check` — clean
- [x] Deep depth parser tests: bid/ask parsing, truncated packets, unknown feed codes, zero levels, extra bytes, max values, NaN/Infinity, stacked packets
- [x] Order update tests: full message, minimal, invalid JSON, missing Data key, empty data, login builder, rejected/cancelled orders
- [x] Subscription builder tests: 20-depth subscribe/unsubscribe, batching, empty input

https://claude.ai/code/session_01H5kR5UbJbZQFmUHZKNBLr1