### PR TITLE
feat(core): market depth parsers, order update types, subscription builders

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -233,6 +233,30 @@ pub const FEED_UNSUBSCRIBE_FULL: u8 = 22;
 pub const MARKET_DEPTH_LEVELS: usize = 5;
 
 // ---------------------------------------------------------------------------
+// Market Depth — Per-Level Field Offsets (within a single 20-byte level)
+// Source: Dhan Python SDK `<IIHHff>` format string.
+// Used in Full (code 8) and Market Depth standalone (code 3) packets.
+// ---------------------------------------------------------------------------
+
+/// Bid quantity (u32 LE) offset within a depth level.
+pub const DEPTH_LEVEL_OFFSET_BID_QTY: usize = 0;
+
+/// Ask quantity (u32 LE) offset within a depth level.
+pub const DEPTH_LEVEL_OFFSET_ASK_QTY: usize = 4;
+
+/// Bid orders count (u16 LE) offset within a depth level.
+pub const DEPTH_LEVEL_OFFSET_BID_ORDERS: usize = 8;
+
+/// Ask orders count (u16 LE) offset within a depth level.
+pub const DEPTH_LEVEL_OFFSET_ASK_ORDERS: usize = 10;
+
+/// Bid price (f32 LE) offset within a depth level.
+pub const DEPTH_LEVEL_OFFSET_BID_PRICE: usize = 12;
+
+/// Ask price (f32 LE) offset within a depth level.
+pub const DEPTH_LEVEL_OFFSET_ASK_PRICE: usize = 16;
+
+// ---------------------------------------------------------------------------
 // Deep Depth Protocol — 20-Level & 200-Level WebSocket Feeds
 // Source: DhanHQ Python SDK (src/dhanhq/marketfeed.py), Dhan API docs.
 // Separate WebSocket endpoints from the standard feed.
@@ -253,6 +277,20 @@ pub const DEEP_DEPTH_HEADER_SIZE: usize = 12;
 /// Deep depth level size in bytes.
 /// Format: price(f64) + quantity(u32) + orders(u32) = 16 bytes.
 pub const DEEP_DEPTH_LEVEL_SIZE: usize = 16;
+
+// ---------------------------------------------------------------------------
+// Deep Depth — Per-Level Field Offsets (within a single 16-byte level)
+// Source: Dhan Python SDK `<dII>` format string in fulldepth.py.
+// ---------------------------------------------------------------------------
+
+/// Price (f64 LE) offset within a deep depth level.
+pub const DEEP_DEPTH_LEVEL_OFFSET_PRICE: usize = 0;
+
+/// Quantity (u32 LE) offset within a deep depth level.
+pub const DEEP_DEPTH_LEVEL_OFFSET_QUANTITY: usize = 8;
+
+/// Orders count (u32 LE) offset within a deep depth level.
+pub const DEEP_DEPTH_LEVEL_OFFSET_ORDERS: usize = 12;
 
 /// Feed response code indicating a BID-side depth packet.
 pub const DEEP_DEPTH_FEED_CODE_BID: u8 = 41;
@@ -946,3 +984,126 @@ const _: () = assert!(
     DEDUP_RING_BUFFER_POWER >= 8 && DEDUP_RING_BUFFER_POWER <= 24,
     "DEDUP_RING_BUFFER_POWER must be in [8, 24]"
 );
+
+// ---------------------------------------------------------------------------
+// Compile-Time Assertions — Binary Protocol Offset Chain Verification
+// Source: Dhan Python SDK struct.unpack format strings.
+// Ensures every offset = previous_offset + previous_field_size.
+// ---------------------------------------------------------------------------
+
+// Header offset chain: <BHBi> = response_code(1) + msg_length(2) + segment(1) + security_id(4) = 8
+const _: () = assert!(
+    HEADER_OFFSET_RESPONSE_CODE == 0,
+    "header: response_code at 0"
+);
+const _: () = assert!(HEADER_OFFSET_MESSAGE_LENGTH == 1, "header: msg_length at 1");
+const _: () = assert!(HEADER_OFFSET_EXCHANGE_SEGMENT == 3, "header: segment at 3");
+const _: () = assert!(HEADER_OFFSET_SECURITY_ID == 4, "header: security_id at 4");
+const _: () = assert!(BINARY_HEADER_SIZE == 8, "header total = 8");
+
+// Ticker offset chain: header(8) + LTP(f32=4) + LTT(u32=4) = 16
+const _: () = assert!(TICKER_OFFSET_LTP == 8, "ticker: LTP at 8");
+const _: () = assert!(TICKER_OFFSET_LTT == 12, "ticker: LTT at 12");
+const _: () = assert!(TICKER_PACKET_SIZE == 16, "ticker total = 16");
+
+// Quote offset chain: <BHBIfHIfIIIffff> = 50
+const _: () = assert!(QUOTE_OFFSET_LTP == 8, "quote: LTP at 8");
+const _: () = assert!(QUOTE_OFFSET_LTQ == 12, "quote: LTQ at 12");
+const _: () = assert!(QUOTE_OFFSET_LTT == 14, "quote: LTT at 14");
+const _: () = assert!(QUOTE_OFFSET_ATP == 18, "quote: ATP at 18");
+const _: () = assert!(QUOTE_OFFSET_VOLUME == 22, "quote: volume at 22");
+const _: () = assert!(QUOTE_OFFSET_TOTAL_SELL_QTY == 26, "quote: total_sell at 26");
+const _: () = assert!(QUOTE_OFFSET_TOTAL_BUY_QTY == 30, "quote: total_buy at 30");
+const _: () = assert!(QUOTE_OFFSET_OPEN == 34, "quote: open at 34");
+const _: () = assert!(QUOTE_OFFSET_CLOSE == 38, "quote: close at 38");
+const _: () = assert!(QUOTE_OFFSET_HIGH == 42, "quote: high at 42");
+const _: () = assert!(QUOTE_OFFSET_LOW == 46, "quote: low at 46");
+const _: () = assert!(QUOTE_PACKET_SIZE == 50, "quote total = 50");
+
+// Full packet offset chain: diverges from Quote at 34
+// <BHBIfHIfIIIIIIffff100s> = 162
+const _: () = assert!(FULL_OFFSET_OI == 34, "full: OI at 34");
+const _: () = assert!(FULL_OFFSET_OI_DAY_HIGH == 38, "full: OI high at 38");
+const _: () = assert!(FULL_OFFSET_OI_DAY_LOW == 42, "full: OI low at 42");
+const _: () = assert!(FULL_OFFSET_OPEN == 46, "full: open at 46");
+const _: () = assert!(FULL_OFFSET_CLOSE == 50, "full: close at 50");
+const _: () = assert!(FULL_OFFSET_HIGH == 54, "full: high at 54");
+const _: () = assert!(FULL_OFFSET_LOW == 58, "full: low at 58");
+const _: () = assert!(FULL_OFFSET_DEPTH_START == 62, "full: depth at 62");
+const _: () = assert!(
+    FULL_QUOTE_PACKET_SIZE
+        == FULL_OFFSET_DEPTH_START + MARKET_DEPTH_LEVELS * MARKET_DEPTH_LEVEL_SIZE,
+    "full total = 62 + 5*20 = 162"
+);
+
+// Market Depth standalone offset chain: <BHBIf100s> = 112
+const _: () = assert!(MARKET_DEPTH_OFFSET_LTP == 8, "mkt_depth: LTP at 8");
+const _: () = assert!(
+    MARKET_DEPTH_OFFSET_DEPTH_START == 12,
+    "mkt_depth: depth at 12"
+);
+const _: () = assert!(
+    MARKET_DEPTH_PACKET_SIZE
+        == MARKET_DEPTH_OFFSET_DEPTH_START + MARKET_DEPTH_LEVELS * MARKET_DEPTH_LEVEL_SIZE,
+    "mkt_depth total = 12 + 5*20 = 112"
+);
+
+// Per-level offset chain: <IIHHff> = 20 bytes
+const _: () = assert!(DEPTH_LEVEL_OFFSET_BID_QTY == 0, "level: bid_qty at 0");
+const _: () = assert!(DEPTH_LEVEL_OFFSET_ASK_QTY == 4, "level: ask_qty at 4");
+const _: () = assert!(DEPTH_LEVEL_OFFSET_BID_ORDERS == 8, "level: bid_orders at 8");
+const _: () = assert!(
+    DEPTH_LEVEL_OFFSET_ASK_ORDERS == 10,
+    "level: ask_orders at 10"
+);
+const _: () = assert!(DEPTH_LEVEL_OFFSET_BID_PRICE == 12, "level: bid_price at 12");
+const _: () = assert!(DEPTH_LEVEL_OFFSET_ASK_PRICE == 16, "level: ask_price at 16");
+const _: () = assert!(MARKET_DEPTH_LEVEL_SIZE == 20, "level total = 20");
+
+// Deep depth per-level offset chain: <dII> = 16 bytes
+const _: () = assert!(DEEP_DEPTH_LEVEL_OFFSET_PRICE == 0, "deep_level: price at 0");
+const _: () = assert!(
+    DEEP_DEPTH_LEVEL_OFFSET_QUANTITY == 8,
+    "deep_level: qty at 8"
+);
+const _: () = assert!(
+    DEEP_DEPTH_LEVEL_OFFSET_ORDERS == 12,
+    "deep_level: orders at 12"
+);
+const _: () = assert!(DEEP_DEPTH_LEVEL_SIZE == 16, "deep_level total = 16");
+
+// Deep depth header offset chain: <hBBiI> = 12 bytes
+const _: () = assert!(
+    DEEP_DEPTH_HEADER_OFFSET_MSG_LENGTH == 0,
+    "deep_hdr: msg_len at 0"
+);
+const _: () = assert!(
+    DEEP_DEPTH_HEADER_OFFSET_FEED_CODE == 2,
+    "deep_hdr: feed_code at 2"
+);
+const _: () = assert!(
+    DEEP_DEPTH_HEADER_OFFSET_EXCHANGE_SEGMENT == 3,
+    "deep_hdr: segment at 3"
+);
+const _: () = assert!(
+    DEEP_DEPTH_HEADER_OFFSET_SECURITY_ID == 4,
+    "deep_hdr: security_id at 4"
+);
+const _: () = assert!(
+    DEEP_DEPTH_HEADER_OFFSET_MSG_SEQUENCE == 8,
+    "deep_hdr: sequence at 8"
+);
+const _: () = assert!(DEEP_DEPTH_HEADER_SIZE == 12, "deep_hdr total = 12");
+
+// OI packet: <BHBII> = 12 bytes
+const _: () = assert!(OI_OFFSET_VALUE == 8, "oi: value at 8");
+const _: () = assert!(OI_PACKET_SIZE == 12, "oi total = 12");
+
+// Previous Close packet: <BHBIfI> = 16 bytes
+const _: () = assert!(PREV_CLOSE_OFFSET_PRICE == 8, "prev_close: price at 8");
+const _: () = assert!(PREV_CLOSE_OFFSET_OI == 12, "prev_close: OI at 12");
+const _: () = assert!(PREVIOUS_CLOSE_PACKET_SIZE == 16, "prev_close total = 16");
+
+// Disconnect packet: <BHBIH> = 10 bytes
+const _: () = assert!(DISCONNECT_OFFSET_CODE == 8, "disconnect: code at 8");
+const _: () = assert!(DISCONNECT_PACKET_SIZE == 10, "disconnect total = 10");

--- a/crates/core/src/parser/deep_depth.rs
+++ b/crates/core/src/parser/deep_depth.rs
@@ -17,8 +17,9 @@ use dhan_live_trader_common::constants::{
     DEEP_DEPTH_FEED_CODE_ASK, DEEP_DEPTH_FEED_CODE_BID, DEEP_DEPTH_HEADER_OFFSET_EXCHANGE_SEGMENT,
     DEEP_DEPTH_HEADER_OFFSET_FEED_CODE, DEEP_DEPTH_HEADER_OFFSET_MSG_LENGTH,
     DEEP_DEPTH_HEADER_OFFSET_MSG_SEQUENCE, DEEP_DEPTH_HEADER_OFFSET_SECURITY_ID,
-    DEEP_DEPTH_HEADER_SIZE, DEEP_DEPTH_LEVEL_SIZE, TWENTY_DEPTH_LEVELS, TWENTY_DEPTH_PACKET_SIZE,
-    TWO_HUNDRED_DEPTH_LEVELS, TWO_HUNDRED_DEPTH_PACKET_SIZE,
+    DEEP_DEPTH_HEADER_SIZE, DEEP_DEPTH_LEVEL_OFFSET_ORDERS, DEEP_DEPTH_LEVEL_OFFSET_PRICE,
+    DEEP_DEPTH_LEVEL_OFFSET_QUANTITY, DEEP_DEPTH_LEVEL_SIZE, TWENTY_DEPTH_LEVELS,
+    TWENTY_DEPTH_PACKET_SIZE, TWO_HUNDRED_DEPTH_LEVELS, TWO_HUNDRED_DEPTH_PACKET_SIZE,
 };
 use dhan_live_trader_common::tick_types::DeepDepthLevel;
 
@@ -165,9 +166,9 @@ fn parse_deep_depth_levels(
     for i in 0..level_count {
         let base = DEEP_DEPTH_HEADER_SIZE + i * DEEP_DEPTH_LEVEL_SIZE;
         levels.push(DeepDepthLevel {
-            price: read_f64_le(raw, base),
-            quantity: read_u32_le(raw, base + 8),
-            orders: read_u32_le(raw, base + 12),
+            price: read_f64_le(raw, base + DEEP_DEPTH_LEVEL_OFFSET_PRICE),
+            quantity: read_u32_le(raw, base + DEEP_DEPTH_LEVEL_OFFSET_QUANTITY),
+            orders: read_u32_le(raw, base + DEEP_DEPTH_LEVEL_OFFSET_ORDERS),
         });
     }
 

--- a/crates/core/src/parser/full_packet.rs
+++ b/crates/core/src/parser/full_packet.rs
@@ -4,6 +4,8 @@
 //! CRITICAL: Diverges from Quote at offset 34. Full has OI fields where Quote has OHLC.
 
 use dhan_live_trader_common::constants::{
+    DEPTH_LEVEL_OFFSET_ASK_ORDERS, DEPTH_LEVEL_OFFSET_ASK_PRICE, DEPTH_LEVEL_OFFSET_ASK_QTY,
+    DEPTH_LEVEL_OFFSET_BID_ORDERS, DEPTH_LEVEL_OFFSET_BID_PRICE, DEPTH_LEVEL_OFFSET_BID_QTY,
     FULL_OFFSET_CLOSE, FULL_OFFSET_DEPTH_START, FULL_OFFSET_HIGH, FULL_OFFSET_LOW, FULL_OFFSET_OI,
     FULL_OFFSET_OI_DAY_HIGH, FULL_OFFSET_OI_DAY_LOW, FULL_OFFSET_OPEN, FULL_QUOTE_PACKET_SIZE,
     MARKET_DEPTH_LEVEL_SIZE, MARKET_DEPTH_LEVELS, QUOTE_OFFSET_ATP, QUOTE_OFFSET_LTP,
@@ -89,12 +91,12 @@ pub fn parse_full_packet(
     for (i, level) in depth.iter_mut().enumerate() {
         let base = FULL_OFFSET_DEPTH_START + i * MARKET_DEPTH_LEVEL_SIZE;
         *level = MarketDepthLevel {
-            bid_quantity: read_u32_le(raw, base),
-            ask_quantity: read_u32_le(raw, base + 4),
-            bid_orders: read_u16_le(raw, base + 8),
-            ask_orders: read_u16_le(raw, base + 10),
-            bid_price: read_f32_le(raw, base + 12),
-            ask_price: read_f32_le(raw, base + 16),
+            bid_quantity: read_u32_le(raw, base + DEPTH_LEVEL_OFFSET_BID_QTY),
+            ask_quantity: read_u32_le(raw, base + DEPTH_LEVEL_OFFSET_ASK_QTY),
+            bid_orders: read_u16_le(raw, base + DEPTH_LEVEL_OFFSET_BID_ORDERS),
+            ask_orders: read_u16_le(raw, base + DEPTH_LEVEL_OFFSET_ASK_ORDERS),
+            bid_price: read_f32_le(raw, base + DEPTH_LEVEL_OFFSET_BID_PRICE),
+            ask_price: read_f32_le(raw, base + DEPTH_LEVEL_OFFSET_ASK_PRICE),
         };
     }
 

--- a/crates/core/src/parser/market_depth.rs
+++ b/crates/core/src/parser/market_depth.rs
@@ -7,6 +7,8 @@
 //! Source: Dhan Python SDK `process_market_depth()` in `marketfeed.py`.
 
 use dhan_live_trader_common::constants::{
+    DEPTH_LEVEL_OFFSET_ASK_ORDERS, DEPTH_LEVEL_OFFSET_ASK_PRICE, DEPTH_LEVEL_OFFSET_ASK_QTY,
+    DEPTH_LEVEL_OFFSET_BID_ORDERS, DEPTH_LEVEL_OFFSET_BID_PRICE, DEPTH_LEVEL_OFFSET_BID_QTY,
     MARKET_DEPTH_LEVEL_SIZE, MARKET_DEPTH_LEVELS, MARKET_DEPTH_OFFSET_DEPTH_START,
     MARKET_DEPTH_OFFSET_LTP, MARKET_DEPTH_PACKET_SIZE,
 };
@@ -74,12 +76,12 @@ pub fn parse_market_depth_packet(
     for (i, level) in depth.iter_mut().enumerate() {
         let base = MARKET_DEPTH_OFFSET_DEPTH_START + i * MARKET_DEPTH_LEVEL_SIZE;
         *level = MarketDepthLevel {
-            bid_quantity: read_u32_le(raw, base),
-            ask_quantity: read_u32_le(raw, base + 4),
-            bid_orders: read_u16_le(raw, base + 8),
-            ask_orders: read_u16_le(raw, base + 10),
-            bid_price: read_f32_le(raw, base + 12),
-            ask_price: read_f32_le(raw, base + 16),
+            bid_quantity: read_u32_le(raw, base + DEPTH_LEVEL_OFFSET_BID_QTY),
+            ask_quantity: read_u32_le(raw, base + DEPTH_LEVEL_OFFSET_ASK_QTY),
+            bid_orders: read_u16_le(raw, base + DEPTH_LEVEL_OFFSET_BID_ORDERS),
+            ask_orders: read_u16_le(raw, base + DEPTH_LEVEL_OFFSET_ASK_ORDERS),
+            bid_price: read_f32_le(raw, base + DEPTH_LEVEL_OFFSET_BID_PRICE),
+            ask_price: read_f32_le(raw, base + DEPTH_LEVEL_OFFSET_ASK_PRICE),
         };
     }
 


### PR DESCRIPTION
## Summary
- **20/200-level depth parsers**: O(1) binary parsers for Dhan's separate depth WebSocket feed (`wss://depth-api-feed.dhan.co/twentydepth`). Handles bid (41) / ask (51) feed codes, f64 prices, 16-byte levels, and stacked packets.
- **Order update types & parser**: Complete type system for live order updates from the JSON WebSocket (`wss://api-order-update.dhan.co`). Enums for OrderStatus, TransactionType, ProductType, OrderType, OrderValidity + full OrderUpdate struct with PascalCase serde mapping.
- **Subscription builders**: 20-depth subscribe/unsubscribe message builders (RequestCode 23/24) with batching support.
- **Named constants for all byte offsets**: Replaced all hardcoded magic numbers with compile-time-verified named constants audited against the official Dhan Python SDK.

## Changes
- `crates/common/src/constants.rs` — 20+ deep-depth protocol constants + byte offset constants with compile-time assertions
- `crates/common/src/order_types.rs` — New: order update enums and structs
- `crates/common/src/tick_types.rs` — New: DeepDepthLevel type (f64 price, u32 qty/orders, Copy)
- `crates/core/src/parser/deep_depth.rs` — New: 20/200-depth binary parser
- `crates/core/src/parser/order_update.rs` — New: order update JSON parser + login builder
- `crates/core/src/websocket/subscription_builder.rs` — 20-depth subscribe/unsubscribe builders
- `crates/core/src/parser/full_packet.rs` — Use named constants
- `crates/core/src/parser/market_depth.rs` — Use named constants
- `docs/phases/PHASE_1_LIVE_TRADING.md` — Corrected Sections 6 & 10 with verified protocol specs

11 files changed, +1,865 / -80

## Test plan
- [x] All 1,114 tests pass (946 unit + 5 integration + 163 storage)
- [x] cargo fmt --check clean
- [x] cargo clippy clean (zero warnings)
- [x] Compile-time assertions verify byte offsets match Dhan Python SDK

https://claude.ai/code/session_01H5kR5UbJbZQFmUHZKNBLr1