### PR TITLE
fix(auth): macOS grep compatibility + TOTP retry on window boundary

### DIFF
--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -128,11 +128,11 @@ fi
 # GATE 6: Commit message format (conventional commits)
 # ─────────────────────────────────────────────
 echo "  [6/7] Commit message format..." >&2
-# Extract -m "message" from the git commit command
-COMMIT_MSG=$(echo "$COMMAND" | grep -oP '(?<=-m\s["\x27])[^"\x27]+' 2>/dev/null | head -1 || true)
+# Extract -m "message" from the git commit command (macOS-compatible, no grep -P)
+COMMIT_MSG=$(echo "$COMMAND" | sed -n "s/.*-m [\"'][^\"']*[\"'].*/&/p" 2>/dev/null | sed "s/.*-m [\"']//" | sed "s/[\"'].*//" | head -1 || true)
 if [ -z "$COMMIT_MSG" ]; then
   # Try extracting from heredoc pattern: -m "$(cat <<'EOF' ... EOF )"
-  COMMIT_MSG=$(echo "$COMMAND" | grep -oP '(?<=-m\s").*' 2>/dev/null | head -1 || true)
+  COMMIT_MSG=$(echo "$COMMAND" | sed -n 's/.*-m "\(.*\)/\1/p' 2>/dev/null | head -1 || true)
 fi
 if [ -n "$COMMIT_MSG" ]; then
   # Extract first line only

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -682,6 +682,11 @@ pub const TOTP_PERIOD_SECS: u64 = 30;
 /// TOTP skew tolerance (number of periods to accept before/after current).
 pub const TOTP_SKEW: u8 = 1;
 
+/// Maximum TOTP retry attempts before treating as permanent failure.
+/// TOTP can fail due to window boundary timing — retrying with a fresh
+/// 30-second window resolves transient issues without masking bad secrets.
+pub const TOTP_MAX_RETRIES: u32 = 2;
+
 // ---------------------------------------------------------------------------
 // Authentication — Dhan REST API Endpoint Paths
 // ---------------------------------------------------------------------------

--- a/crates/core/src/auth/token_manager.rs
+++ b/crates/core/src/auth/token_manager.rs
@@ -22,7 +22,7 @@ use tracing::{error, info, instrument, warn};
 use dhan_live_trader_common::config::{DhanConfig, NetworkConfig, TokenConfig};
 use dhan_live_trader_common::constants::{
     AUTH_RETRY_MAX_BACKOFF_SECS, DHAN_GENERATE_TOKEN_PATH, DHAN_RENEW_TOKEN_PATH,
-    DHAN_TOKEN_GENERATION_COOLDOWN_SECS,
+    DHAN_TOKEN_GENERATION_COOLDOWN_SECS, TOTP_MAX_RETRIES, TOTP_PERIOD_SECS,
 };
 use dhan_live_trader_common::error::ApplicationError;
 use dhan_live_trader_common::sanitize::redact_url_params;
@@ -159,7 +159,10 @@ impl TokenManager {
         });
 
         // Infinite retry for transient errors, fail fast for permanent errors.
+        // TOTP errors get limited retries (window boundary timing can cause
+        // valid secrets to produce rejected codes).
         let mut attempt = 0u32;
+        let mut totp_retries = 0u32;
         let mut delay = Duration::from_millis(network_config.retry_initial_delay_ms);
         let max_delay = Duration::from_secs(AUTH_RETRY_MAX_BACKOFF_SECS);
 
@@ -185,6 +188,43 @@ impl TokenManager {
                             reason: format!("PERMANENT: {reason} — check SSM credentials"),
                         });
                         return Err(err);
+                    }
+
+                    // TOTP errors — retry with a fresh 30-second window, but cap retries
+                    // to avoid infinite loops when the secret is genuinely wrong.
+                    if is_totp_error(&reason) {
+                        totp_retries = totp_retries.saturating_add(1);
+                        if totp_retries > TOTP_MAX_RETRIES {
+                            error!(
+                                attempt,
+                                totp_retries,
+                                error = %reason,
+                                "TOTP failed after {TOTP_MAX_RETRIES} retries — verify TOTP secret in SSM"
+                            );
+                            notifier.notify(NotificationEvent::AuthenticationFailed {
+                                reason: format!(
+                                    "TOTP invalid after {TOTP_MAX_RETRIES} retries — check /dlt/<env>/dhan/totp-secret in SSM"
+                                ),
+                            });
+                            return Err(err);
+                        }
+                        warn!(
+                            attempt,
+                            totp_retries,
+                            max = TOTP_MAX_RETRIES,
+                            "TOTP rejected — waiting for next 30s window before retry"
+                        );
+                        // Wait for the next TOTP window (30s) to get a fresh code.
+                        tokio::select! {
+                            () = tokio::time::sleep(Duration::from_secs(TOTP_PERIOD_SECS)) => {}
+                            _ = tokio::signal::ctrl_c() => {
+                                info!("shutdown signal received during TOTP retry wait");
+                                return Err(ApplicationError::AuthenticationFailed {
+                                    reason: "shutdown during TOTP retry wait".to_string(),
+                                });
+                            }
+                        }
+                        continue;
                     }
 
                     // Dhan rate limit — use the 125-second cooldown.
@@ -555,14 +595,26 @@ impl TokenManager {
 ///
 /// Permanent errors indicate wrong credentials in SSM or a blocked account.
 /// The system should notify the user and exit, not retry indefinitely.
+///
+/// Note: TOTP errors are excluded — they may be transient due to window
+/// boundary timing. Use [`is_totp_error`] to handle TOTP retries separately.
 fn is_permanent_auth_error(reason: &str) -> bool {
     let lower = reason.to_lowercase();
     lower.contains("invalid pin")
         || lower.contains("invalid client")
-        || lower.contains("totp") && (lower.contains("invalid") || lower.contains("failed"))
         || lower.contains("blocked")
         || lower.contains("suspended")
         || lower.contains("disabled")
+}
+
+/// Returns `true` if the error is a TOTP-related auth failure.
+///
+/// TOTP errors are retryable up to [`TOTP_MAX_RETRIES`] times because they
+/// can fail when the code is generated near a 30-second window boundary
+/// and expires during HTTP transit to Dhan's servers.
+fn is_totp_error(reason: &str) -> bool {
+    let lower = reason.to_lowercase();
+    lower.contains("totp") && (lower.contains("invalid") || lower.contains("failed"))
 }
 
 /// Returns `true` if the error is Dhan's token generation rate limit.
@@ -1946,9 +1998,18 @@ mod tests {
     }
 
     #[test]
-    fn test_totp_invalid_is_permanent() {
-        assert!(is_permanent_auth_error("TOTP verification failed"));
-        assert!(is_permanent_auth_error("Dhan auth error: Invalid TOTP"));
+    fn test_totp_invalid_is_not_permanent() {
+        // TOTP errors are retryable (window boundary timing), not permanent.
+        assert!(!is_permanent_auth_error("TOTP verification failed"));
+        assert!(!is_permanent_auth_error("Dhan auth error: Invalid TOTP"));
+    }
+
+    #[test]
+    fn test_totp_error_detected() {
+        assert!(is_totp_error("TOTP verification failed"));
+        assert!(is_totp_error("Dhan auth error: Invalid TOTP"));
+        assert!(!is_totp_error("Invalid Pin"));
+        assert!(!is_totp_error("network error"));
     }
 
     #[test]

--- a/crates/core/src/auth/token_manager.rs
+++ b/crates/core/src/auth/token_manager.rs
@@ -214,6 +214,11 @@ impl TokenManager {
                             max = TOTP_MAX_RETRIES,
                             "TOTP rejected — waiting for next 30s window before retry"
                         );
+                        notifier.notify(NotificationEvent::AuthenticationFailed {
+                            reason: format!(
+                                "TOTP rejected (retry {totp_retries}/{TOTP_MAX_RETRIES}) — waiting 30s for fresh window"
+                            ),
+                        });
                         // Wait for the next TOTP window (30s) to get a fresh code.
                         tokio::select! {
                             () = tokio::time::sleep(Duration::from_secs(TOTP_PERIOD_SECS)) => {}

--- a/scripts/setup-observability.sh
+++ b/scripts/setup-observability.sh
@@ -310,7 +310,7 @@ fi
 # ---- Step 9: Wait for all services ----
 step "Waiting for services to be healthy"
 HEALTH_FAIL=0
-wait_for_http "QuestDB"         "http://localhost:9000"             60 || HEALTH_FAIL=$((HEALTH_FAIL + 1))
+wait_for_http "QuestDB"         "http://localhost:9000"            120 || HEALTH_FAIL=$((HEALTH_FAIL + 1))
 wait_for_http "Prometheus"      "http://localhost:9090/-/healthy"    30 || HEALTH_FAIL=$((HEALTH_FAIL + 1))
 wait_for_http "Grafana"         "http://localhost:3000/api/health"  45 || HEALTH_FAIL=$((HEALTH_FAIL + 1))
 wait_for_http "Jaeger UI"       "http://localhost:16686"            30 || HEALTH_FAIL=$((HEALTH_FAIL + 1))
@@ -335,7 +335,7 @@ if [ -n "$PROM_TARGETS" ]; then
     info "Targets: ${UP_COUNT}/${TOTAL_TARGETS} UP"
     if [ "$DOWN_COUNT" -gt 0 ]; then
         # Extract down job names
-        echo "$PROM_TARGETS" | grep -oP '"job":"[^"]*"[^}]*"health":"down"' | grep -oP '"job":"[^"]*"' | sort -u | while read -r line; do
+        echo "$PROM_TARGETS" | grep -o '"job":"[^"]*"[^}]*"health":"down"' | grep -o '"job":"[^"]*"' | sort -u | while read -r line; do
             warn "Target DOWN: $line"
         done
     fi
@@ -376,7 +376,7 @@ if [ -n "$DASH_JSON" ] && [ "$DASH_JSON" != "[]" ]; then
     DASH_COUNT=$(echo "$DASH_JSON" | grep -o '"uid"' | wc -l | tr -d ' ')
     # Check for expected dashboards by UID
     for uid in dlt-system-overview dlt-traefik dlt-logs; do
-        DASH_TITLE=$(echo "$DASH_JSON" | grep -oP "\"uid\":\"${uid}\"[^}]*\"title\":\"[^\"]*\"" | grep -oP '"title":"[^"]*"' | head -1 || echo "")
+        DASH_TITLE=$(echo "$DASH_JSON" | grep -o "\"uid\":\"${uid}\"[^}]*\"title\":\"[^\"]*\"" | grep -o '"title":"[^"]*"' | head -1 || echo "")
         if [ -n "$DASH_TITLE" ]; then
             info "  ${uid}: loaded"
         else


### PR DESCRIPTION
## Summary

- **Fix `grep -oP` (Perl regex) on macOS** — replaced with POSIX-compatible `grep -o` and `sed` in `setup-observability.sh` and `pre-commit-gate.sh`. This was the root cause of first-run setup failures on macOS (BSD grep doesn't support `-P`). Second run worked because containers were already up from step 8, so the fast path kicked in.
- **Increase QuestDB health check timeout** from 60s → 120s for first-time storage initialization on slower machines.
- **Reclassify TOTP errors from permanent to retryable** — TOTP codes can be rejected when generated near a 30-second window boundary. Now retries up to 2 times with 30s delay (ensuring a fresh TOTP window). Telegram notification sent on each retry attempt.

## Files Changed

| File | Change |
|------|--------|
| `scripts/setup-observability.sh` | `grep -oP` → `grep -o` (2 locations), QuestDB timeout 60s → 120s |
| `.claude/hooks/pre-commit-gate.sh` | `grep -oP` → `sed` for commit message extraction |
| `crates/common/src/constants.rs` | Add `TOTP_MAX_RETRIES = 2` constant |
| `crates/core/src/auth/token_manager.rs` | TOTP retry logic with 30s window wait, Telegram alerts on each retry, updated error classification + tests |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — 1,353 tests pass, 0 failures
- [ ] Manual test: clone fresh repo on macOS, run `ensure-ready.sh` — setup should complete without `grep -P` errors
- [ ] Manual test: run app when TOTP is near 30s window boundary — should retry and succeed

https://claude.ai/code/session_0181q2htj2eo4SbJZ7Z5zmfZ