### PR TITLE
feat(infra): auto-start Docker services and fix order update WS off-hours noise

### DIFF
--- a/crates/app/src/infra.rs
+++ b/crates/app/src/infra.rs
@@ -1,0 +1,250 @@
+//! Infrastructure orchestrator — auto-starts Docker services if not running.
+//!
+//! On startup, probes QuestDB and Jaeger. If unreachable, fetches infra
+//! credentials from AWS SSM and runs `docker compose up -d`. Waits for
+//! services to be healthy before returning.
+//!
+//! This eliminates the manual `docker compose up -d` step — just run the
+//! binary (from IntelliJ or CLI) and everything starts automatically.
+
+use std::net::TcpStream;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use secrecy::ExposeSecret;
+use tracing::{debug, info, warn};
+
+use dhan_live_trader_common::config::QuestDbConfig;
+use dhan_live_trader_core::auth::secret_manager;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// TCP probe timeout for infrastructure services.
+const INFRA_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Maximum wait time for Docker services to become healthy.
+const INFRA_HEALTH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Polling interval when waiting for services to become healthy.
+const INFRA_HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Path to docker-compose file relative to project root.
+const DOCKER_COMPOSE_PATH: &str = "deploy/docker/docker-compose.yml";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Ensures Docker infrastructure services are running.
+///
+/// 1. Probes QuestDB HTTP port — if reachable, returns immediately.
+/// 2. If unreachable, fetches infra credentials from SSM.
+/// 3. Runs `docker compose up -d` with SSM-sourced env vars.
+/// 4. Waits for QuestDB to become healthy (up to 60s).
+///
+/// Best-effort: if Docker or SSM is unavailable, logs a warning
+/// and returns — the app already handles missing services gracefully.
+pub async fn ensure_infra_running(questdb_config: &QuestDbConfig) {
+    if is_service_reachable(&questdb_config.host, questdb_config.http_port) {
+        debug!(
+            host = %questdb_config.host,
+            port = questdb_config.http_port,
+            "infrastructure already running (QuestDB reachable)"
+        );
+        return;
+    }
+
+    info!("infrastructure not running — auto-starting Docker services");
+
+    // Fetch infra credentials from SSM concurrently.
+    let (questdb_creds, grafana_creds, telegram_creds) = match tokio::join!(
+        secret_manager::fetch_questdb_credentials(),
+        secret_manager::fetch_grafana_credentials(),
+        secret_manager::fetch_telegram_credentials(),
+    ) {
+        (Ok(q), Ok(g), Ok(t)) => (q, g, t),
+        (q_result, g_result, t_result) => {
+            if let Err(ref err) = q_result {
+                warn!(
+                    ?err,
+                    "failed to fetch QuestDB credentials from SSM — cannot auto-start Docker"
+                );
+            }
+            if let Err(ref err) = g_result {
+                warn!(
+                    ?err,
+                    "failed to fetch Grafana credentials from SSM — cannot auto-start Docker"
+                );
+            }
+            if let Err(ref err) = t_result {
+                warn!(
+                    ?err,
+                    "failed to fetch Telegram credentials from SSM — cannot auto-start Docker"
+                );
+            }
+            return;
+        }
+    };
+
+    // Build env vars for docker-compose.
+    let env_vars = [
+        (
+            "DLT_QUESTDB_PG_USER",
+            questdb_creds.pg_user.expose_secret().to_string(),
+        ),
+        (
+            "DLT_QUESTDB_PG_PASSWORD",
+            questdb_creds.pg_password.expose_secret().to_string(),
+        ),
+        (
+            "DLT_GRAFANA_ADMIN_USER",
+            grafana_creds.admin_user.expose_secret().to_string(),
+        ),
+        (
+            "DLT_GRAFANA_ADMIN_PASSWORD",
+            grafana_creds.admin_password.expose_secret().to_string(),
+        ),
+        (
+            "DLT_TELEGRAM_BOT_TOKEN",
+            telegram_creds.bot_token.expose_secret().to_string(),
+        ),
+        (
+            "DLT_TELEGRAM_CHAT_ID",
+            telegram_creds.chat_id.expose_secret().to_string(),
+        ),
+    ];
+
+    // Run docker compose up -d.
+    match run_docker_compose_up(&env_vars).await {
+        Ok(()) => {
+            info!("docker compose started — waiting for services to be healthy");
+        }
+        Err(err) => {
+            warn!(
+                ?err,
+                "docker compose up failed — services may not be available"
+            );
+            return;
+        }
+    }
+
+    // Wait for QuestDB to become healthy.
+    wait_for_service_healthy("QuestDB", &questdb_config.host, questdb_config.http_port).await;
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+/// TCP probe — returns true if a TCP connection can be established.
+fn is_service_reachable(host: &str, port: u16) -> bool {
+    let addr = format!("{host}:{port}");
+    TcpStream::connect_timeout(
+        &addr.parse().unwrap_or_else(|_| {
+            // Fallback for hostname resolution — try localhost.
+            format!("127.0.0.1:{port}")
+                .parse()
+                .expect("127.0.0.1:<port> must parse") // APPROVED: infallible for valid port
+        }),
+        INFRA_PROBE_TIMEOUT,
+    )
+    .is_ok()
+}
+
+/// Runs `docker compose up -d` with the given environment variables.
+async fn run_docker_compose_up(env_vars: &[(&str, String)]) -> Result<()> {
+    use tokio::process::Command;
+
+    let mut cmd = Command::new("docker");
+    cmd.args(["compose", "-f", DOCKER_COMPOSE_PATH, "up", "-d"]);
+
+    for (key, value) in env_vars {
+        cmd.env(key, value);
+    }
+
+    let output = cmd
+        .output()
+        .await
+        .context("failed to execute docker compose — is Docker installed?")?;
+
+    if output.status.success() {
+        info!("docker compose up -d completed successfully");
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!(
+            "docker compose up -d failed (exit {}): {}",
+            output.status,
+            stderr.trim()
+        ))
+    }
+}
+
+/// Polls a service until it becomes reachable or timeout expires.
+async fn wait_for_service_healthy(name: &str, host: &str, port: u16) {
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < INFRA_HEALTH_TIMEOUT {
+        if is_service_reachable(host, port) {
+            info!(service = name, "service is healthy");
+            return;
+        }
+        debug!(
+            service = name,
+            elapsed_secs = start.elapsed().as_secs(),
+            "waiting for service to be healthy"
+        );
+        tokio::time::sleep(INFRA_HEALTH_POLL_INTERVAL).await;
+    }
+
+    warn!(
+        service = name,
+        timeout_secs = INFRA_HEALTH_TIMEOUT.as_secs(),
+        "service did not become healthy within timeout — continuing anyway"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unreachable_service_returns_false() {
+        // Port 1 is almost never open on any machine.
+        assert!(
+            !is_service_reachable("127.0.0.1", 1),
+            "port 1 should not be reachable"
+        );
+    }
+
+    #[test]
+    fn test_docker_compose_path_exists() {
+        assert!(
+            DOCKER_COMPOSE_PATH.ends_with(".yml"),
+            "docker compose path must be a YAML file"
+        );
+    }
+
+    #[test]
+    fn test_probe_timeout_is_reasonable() {
+        assert!(INFRA_PROBE_TIMEOUT.as_secs() >= 1);
+        assert!(INFRA_PROBE_TIMEOUT.as_secs() <= 10);
+    }
+
+    #[test]
+    fn test_health_timeout_is_reasonable() {
+        assert!(INFRA_HEALTH_TIMEOUT.as_secs() >= 30);
+        assert!(INFRA_HEALTH_TIMEOUT.as_secs() <= 120);
+    }
+
+    #[test]
+    fn test_health_poll_interval_less_than_timeout() {
+        assert!(INFRA_HEALTH_POLL_INTERVAL < INFRA_HEALTH_TIMEOUT);
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -8,8 +8,9 @@
 //! 2. Initialize observability (Prometheus metrics + OpenTelemetry tracing)
 //! 3. Initialize structured logging with OpenTelemetry layer
 //! 4. Initialize Telegram notification service (best-effort)
-//! 5. Authenticate with Dhan API (SSM → TOTP → JWT)
-//! 6. Set up QuestDB tick persistence (best-effort)
+//! 5. Ensure Docker infrastructure is running (auto-start if needed)
+//! 6. Authenticate with Dhan API (SSM → TOTP → JWT)
+//! 7. Set up QuestDB tick persistence (best-effort)
 //! 7. Build F&O universe + subscription plan from instrument CSV
 //! 8. Build WebSocket connection pool with planned instruments
 //! 9. Spawn tick processing pipeline (pure capture — parse → filter → persist)
@@ -18,6 +19,7 @@
 //! 12. Spawn token renewal background task
 //! 13. Await shutdown signal (Ctrl+C)
 
+mod infra;
 mod observability;
 
 use std::net::SocketAddr;
@@ -192,7 +194,12 @@ async fn main() -> Result<()> {
     let notifier = NotificationService::initialize(&config.notification).await;
 
     // -----------------------------------------------------------------------
-    // Step 5: Authenticate with Dhan API (infinite retry for transient errors)
+    // Step 5: Ensure Docker infrastructure is running (auto-start if needed)
+    // -----------------------------------------------------------------------
+    infra::ensure_infra_running(&config.questdb).await;
+
+    // -----------------------------------------------------------------------
+    // Step 6: Authenticate with Dhan API (infinite retry for transient errors)
     // -----------------------------------------------------------------------
     info!("authenticating with Dhan API via SSM → TOTP → JWT");
 

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -355,6 +355,11 @@ pub const ORDER_UPDATE_LOGIN_MSG_CODE: u16 = 42;
 /// Order updates are infrequent — use longer timeout than market feed.
 pub const ORDER_UPDATE_READ_TIMEOUT_SECS: u64 = 120;
 
+/// Read timeout for order update WebSocket outside market hours (seconds).
+/// Off-hours: no orders expected, Dhan sends no data. Use 10 minutes to
+/// avoid noisy reconnect loops while still detecting dead connections.
+pub const ORDER_UPDATE_OFF_HOURS_READ_TIMEOUT_SECS: u64 = 600;
+
 /// Maximum reconnection attempts for order update WebSocket.
 pub const ORDER_UPDATE_MAX_RECONNECT_ATTEMPTS: u32 = 10;
 

--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -37,4 +37,6 @@ pub mod totp_generator;
 pub mod types;
 
 pub use token_manager::{TokenHandle, TokenManager};
-pub use types::{DhanCredentials, GrafanaCredentials, QuestDbCredentials, TokenState};
+pub use types::{
+    DhanCredentials, GrafanaCredentials, QuestDbCredentials, TelegramCredentials, TokenState,
+};

--- a/crates/core/src/auth/secret_manager.rs
+++ b/crates/core/src/auth/secret_manager.rs
@@ -17,7 +17,7 @@ use dhan_live_trader_common::constants::{
 };
 use dhan_live_trader_common::error::ApplicationError;
 
-use super::types::{DhanCredentials, GrafanaCredentials, QuestDbCredentials};
+use super::types::{DhanCredentials, GrafanaCredentials, QuestDbCredentials, TelegramCredentials};
 
 // ---------------------------------------------------------------------------
 // SSM Path Construction
@@ -241,6 +241,49 @@ pub async fn fetch_grafana_credentials() -> Result<GrafanaCredentials, Applicati
         admin_user,
         admin_password,
     })
+}
+
+/// Fetches Telegram bot credentials from AWS SSM Parameter Store.
+///
+/// Retrieves bot-token and chat-id, both wrapped in `SecretString`.
+/// Used by the infra orchestrator to inject into docker-compose
+/// environment variables for Grafana alerting.
+///
+/// # Errors
+///
+/// Returns `ApplicationError::SecretRetrieval` if any secret cannot be fetched.
+#[instrument(skip_all, fields(environment))]
+pub async fn fetch_telegram_credentials() -> Result<TelegramCredentials, ApplicationError> {
+    use dhan_live_trader_common::constants::{
+        SSM_TELEGRAM_SERVICE, TELEGRAM_BOT_TOKEN_SECRET, TELEGRAM_CHAT_ID_SECRET,
+    };
+
+    let environment = resolve_environment()?;
+    tracing::Span::current().record("environment", environment.as_str());
+
+    let ssm_client = create_ssm_client().await;
+
+    let bot_token_path = build_ssm_path(
+        &environment,
+        SSM_TELEGRAM_SERVICE,
+        TELEGRAM_BOT_TOKEN_SECRET,
+    );
+    let chat_id_path = build_ssm_path(&environment, SSM_TELEGRAM_SERVICE, TELEGRAM_CHAT_ID_SECRET);
+
+    info!(
+        bot_token_path = %bot_token_path,
+        chat_id_path = %chat_id_path,
+        "fetching Telegram credentials from SSM"
+    );
+
+    let (bot_token, chat_id) = tokio::try_join!(
+        fetch_secret(&ssm_client, &bot_token_path),
+        fetch_secret(&ssm_client, &chat_id_path),
+    )?;
+
+    info!("all Telegram credentials fetched successfully from SSM");
+
+    Ok(TelegramCredentials { bot_token, chat_id })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/auth/types.rs
+++ b/crates/core/src/auth/types.rs
@@ -144,6 +144,30 @@ impl fmt::Debug for GrafanaCredentials {
 }
 
 // ---------------------------------------------------------------------------
+// Telegram Credentials (from SSM)
+// ---------------------------------------------------------------------------
+
+/// Telegram bot credentials fetched from AWS SSM Parameter Store.
+///
+/// Used by the infra orchestrator to inject into docker-compose
+/// environment variables for Grafana alerting.
+pub struct TelegramCredentials {
+    /// Telegram bot token.
+    pub bot_token: SecretString,
+    /// Telegram chat ID.
+    pub chat_id: SecretString,
+}
+
+impl fmt::Debug for TelegramCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TelegramCredentials")
+            .field("bot_token", &"[REDACTED]")
+            .field("chat_id", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Token State (stored in ArcSwap)
 // ---------------------------------------------------------------------------
 

--- a/crates/core/src/websocket/order_update_connection.rs
+++ b/crates/core/src/websocket/order_update_connection.rs
@@ -22,8 +22,11 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tracing::{debug, error, info, warn};
 
+use chrono::{Datelike, FixedOffset, NaiveTime, Utc};
+
 use dhan_live_trader_common::constants::{
-    ORDER_UPDATE_MAX_RECONNECT_ATTEMPTS, ORDER_UPDATE_READ_TIMEOUT_SECS,
+    IST_UTC_OFFSET_SECONDS, ORDER_UPDATE_MAX_RECONNECT_ATTEMPTS,
+    ORDER_UPDATE_OFF_HOURS_READ_TIMEOUT_SECS, ORDER_UPDATE_READ_TIMEOUT_SECS,
     ORDER_UPDATE_RECONNECT_INITIAL_DELAY_MS, ORDER_UPDATE_RECONNECT_MAX_DELAY_MS,
 };
 use dhan_live_trader_common::order_types::OrderUpdate;
@@ -67,19 +70,30 @@ pub async fn run_order_update_connection(
                 info!("order update WebSocket disconnected cleanly — reconnecting");
             }
             Err(err) => {
-                consecutive_failures = consecutive_failures.saturating_add(1);
-                if consecutive_failures > ORDER_UPDATE_MAX_RECONNECT_ATTEMPTS {
-                    error!(
-                        attempts = consecutive_failures,
-                        "order update WebSocket exhausted reconnection attempts"
+                // Off-hours ReadTimeout is expected (no orders outside market hours).
+                // Log at debug level and reset backoff to avoid noise.
+                if matches!(err, OrderUpdateConnectionError::ReadTimeout)
+                    && !is_within_market_hours()
+                {
+                    debug!(
+                        "order update WebSocket idle timeout outside market hours — reconnecting"
                     );
-                    return;
+                    consecutive_failures = 0;
+                } else {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
+                    if consecutive_failures > ORDER_UPDATE_MAX_RECONNECT_ATTEMPTS {
+                        error!(
+                            attempts = consecutive_failures,
+                            "order update WebSocket exhausted reconnection attempts"
+                        );
+                        return;
+                    }
+                    warn!(
+                        ?err,
+                        attempt = consecutive_failures,
+                        "order update WebSocket error — will reconnect"
+                    );
                 }
-                warn!(
-                    ?err,
-                    attempt = consecutive_failures,
-                    "order update WebSocket error — will reconnect"
-                );
             }
         }
 
@@ -144,7 +158,13 @@ async fn connect_and_listen(
 
     debug!("order update WebSocket login sent");
 
-    let read_timeout = Duration::from_secs(ORDER_UPDATE_READ_TIMEOUT_SECS);
+    // Use longer timeout outside market hours to avoid reconnect noise.
+    let timeout_secs = if is_within_market_hours() {
+        ORDER_UPDATE_READ_TIMEOUT_SECS
+    } else {
+        ORDER_UPDATE_OFF_HOURS_READ_TIMEOUT_SECS
+    };
+    let read_timeout = Duration::from_secs(timeout_secs);
 
     // Read loop — receive order updates until disconnect.
     loop {
@@ -200,6 +220,40 @@ async fn connect_and_listen(
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Market hours check
+// ---------------------------------------------------------------------------
+
+/// Data collection window boundaries (IST).
+/// Orders can only arrive during market hours (09:00 – 16:00 IST).
+const DATA_COLLECTION_START: (u32, u32) = (9, 0);
+const DATA_COLLECTION_END: (u32, u32) = (16, 0);
+
+/// Returns `true` if the current IST time is within data collection hours.
+///
+/// Cold path — called once per connection lifecycle. Allocation-free.
+fn is_within_market_hours() -> bool {
+    #[allow(clippy::expect_used)] // APPROVED: compile-time provable — 19800 always valid
+    let ist =
+        FixedOffset::east_opt(IST_UTC_OFFSET_SECONDS).expect("IST offset 19800s is always valid"); // APPROVED: compile-time provable constant
+    let now_ist = Utc::now().with_timezone(&ist).time();
+
+    // Also check weekday — no orders on Saturday/Sunday.
+    let today = Utc::now().with_timezone(&ist).weekday();
+    if matches!(today, chrono::Weekday::Sat | chrono::Weekday::Sun) {
+        return false;
+    }
+
+    #[allow(clippy::expect_used)] // APPROVED: compile-time provable constants
+    let start = NaiveTime::from_hms_opt(DATA_COLLECTION_START.0, DATA_COLLECTION_START.1, 0)
+        .expect("09:00:00 is always valid"); // APPROVED: compile-time provable constant
+    #[allow(clippy::expect_used)] // APPROVED: compile-time provable constants
+    let end = NaiveTime::from_hms_opt(DATA_COLLECTION_END.0, DATA_COLLECTION_END.1, 0)
+        .expect("16:00:00 is always valid"); // APPROVED: compile-time provable constant
+
+    now_ist >= start && now_ist < end
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Infra auto-start**: Docker services auto-launch on `cargo run` if QuestDB isn't reachable — zero-touch workflow
- **TelegramCredentials**: New SSM fetch function for Telegram bot token + chat ID (needed by docker-compose env vars)
- **Off-hours noise fix**: Order update WS uses 600s timeout outside market hours (vs 120s during), logs at debug level, resets backoff counter
- **Market hours detection**: `is_within_market_hours()` with IST weekday + time range check

## Changes (7 files, +403/-18)

| File | Change |
|------|--------|
| `crates/app/src/infra.rs` | New — infra orchestrator (probe, SSM fetch, docker compose up, health wait) |
| `crates/app/src/main.rs` | Add `mod infra` + Step 5 call before auth |
| `crates/common/src/constants.rs` | Add `ORDER_UPDATE_OFF_HOURS_READ_TIMEOUT_SECS` |
| `crates/core/src/auth/mod.rs` | Export `TelegramCredentials` |
| `crates/core/src/auth/secret_manager.rs` | Add `fetch_telegram_credentials()` |
| `crates/core/src/auth/types.rs` | Add `TelegramCredentials` struct with redacted Debug |
| `crates/core/src/websocket/order_update_connection.rs` | Market-hours-aware timeout + off-hours debug logging |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::perf` passes
- [x] `cargo test --workspace` — all tests pass
- [x] Single clean commit on top of main — no merge conflicts

https://claude.ai/code/session_01EHDy82vBD8BrjPvYXCpSXB