### PR TITLE
fix(historical): float timestamp deserializer + drop legacy candles_1m table

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -243,7 +243,7 @@ async fn main() -> Result<()> {
     // Step 6: Set up QuestDB tick persistence (best-effort)
     // -----------------------------------------------------------------------
     info!(
-        "setting up QuestDB tables (ticks + instruments + depth + previous_close + candles_1m + materialized views)"
+        "setting up QuestDB tables (ticks + instruments + depth + previous_close + historical_candles_1m + materialized views)"
     );
 
     ensure_tick_table_dedup_keys(&config.questdb).await;

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -909,7 +909,9 @@ pub const QUESTDB_TABLE_MARKET_DEPTH: &str = "market_depth";
 pub const QUESTDB_TABLE_PREVIOUS_CLOSE: &str = "previous_close";
 
 /// QuestDB table: 1-minute OHLCV candles from Dhan historical API.
-pub const QUESTDB_TABLE_CANDLES_1M: &str = "candles_1m";
+/// Named `historical_candles_1m` to avoid collision with the `candles_1m`
+/// materialized view (which aggregates live 1s candles).
+pub const QUESTDB_TABLE_CANDLES_1M: &str = "historical_candles_1m";
 
 /// QuestDB table: 1-second OHLCV candles aggregated from live ticks.
 pub const QUESTDB_TABLE_CANDLES_1S: &str = "candles_1s";

--- a/crates/common/src/tick_types.rs
+++ b/crates/common/src/tick_types.rs
@@ -154,6 +154,10 @@ pub struct HistoricalCandle {
 ///
 /// Each field is a parallel array — index N across all arrays forms one candle.
 /// Dhan returns timestamps as IST-naive epoch seconds (same as WebSocket feed).
+///
+/// Note: Dhan sometimes returns integer fields (volume, open_interest) as floats
+/// (e.g., `105600.0` instead of `105600`). The `deserialize_f64_as_i64_vec`
+/// deserializer handles both forms by truncating floats to i64.
 #[derive(Debug, serde::Deserialize)]
 pub struct DhanIntradayResponse {
     /// Opening prices per candle.
@@ -164,13 +168,35 @@ pub struct DhanIntradayResponse {
     pub low: Vec<f64>,
     /// Closing prices per candle.
     pub close: Vec<f64>,
-    /// Volume per candle.
+    /// Volume per candle (Dhan may return as int or float).
+    #[serde(deserialize_with = "deserialize_f64_as_i64_vec")]
     pub volume: Vec<i64>,
     /// Timestamps as epoch seconds (IST-naive from Dhan).
     pub timestamp: Vec<i64>,
     /// Open interest per candle (present when `oi: true` in request).
-    #[serde(default)]
+    /// Dhan may return as int or float.
+    #[serde(default, deserialize_with = "deserialize_f64_as_i64_vec_or_default")]
     pub open_interest: Vec<i64>,
+}
+
+/// Deserializes a JSON array of numbers (int or float) into `Vec<i64>`.
+///
+/// Dhan API inconsistently returns some integer fields as floats
+/// (e.g., volume `105600.0` instead of `105600`). This handles both.
+fn deserialize_f64_as_i64_vec<'de, D>(deserializer: D) -> Result<Vec<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let values: Vec<f64> = serde::Deserialize::deserialize(deserializer)?;
+    Ok(values.into_iter().map(|v| v as i64).collect())
+}
+
+/// Same as `deserialize_f64_as_i64_vec` but defaults to empty vec if absent.
+fn deserialize_f64_as_i64_vec_or_default<'de, D>(deserializer: D) -> Result<Vec<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_as_i64_vec(deserializer)
 }
 
 impl DhanIntradayResponse {

--- a/crates/common/src/tick_types.rs
+++ b/crates/common/src/tick_types.rs
@@ -172,6 +172,8 @@ pub struct DhanIntradayResponse {
     #[serde(deserialize_with = "deserialize_f64_as_i64_vec")]
     pub volume: Vec<i64>,
     /// Timestamps as epoch seconds (IST-naive from Dhan).
+    /// Dhan may return as int or float.
+    #[serde(deserialize_with = "deserialize_f64_as_i64_vec")]
     pub timestamp: Vec<i64>,
     /// Open interest per candle (present when `oi: true` in request).
     /// Dhan may return as int or float.

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -1,7 +1,7 @@
 //! Cross-verification of live tick data against historical candles.
 //!
 //! Queries QuestDB to compare live ticks stored in the `ticks` table against
-//! 1-minute candles in `candles_1m`. Reports discrepancies to detect data
+//! 1-minute candles in `historical_candles_1m`. Reports discrepancies to detect data
 //! quality issues, missed ticks, or stale feeds.
 //!
 //! # Verification Checks

--- a/crates/storage/src/candle_persistence.rs
+++ b/crates/storage/src/candle_persistence.rs
@@ -1,6 +1,6 @@
 //! QuestDB persistence for 1-minute OHLCV candles from Dhan historical API.
 //!
-//! Stores candles in a dedicated `candles_1m` table with DEDUP UPSERT KEYS
+//! Stores candles in a dedicated `historical_candles_1m` table with DEDUP UPSERT KEYS
 //! on `(ts, security_id)` to ensure idempotent re-ingestion.
 //!
 //! # Table Schema
@@ -148,11 +148,11 @@ impl CandlePersistenceWriter {
 // Table DDL + DEDUP Setup
 // ---------------------------------------------------------------------------
 
-/// SQL to create the `candles_1m` table with explicit schema.
+/// SQL to create the `historical_candles_1m` table with explicit schema.
 ///
 /// Idempotent — safe to call every startup.
 const CANDLES_1M_CREATE_DDL: &str = "\
-    CREATE TABLE IF NOT EXISTS candles_1m (\
+    CREATE TABLE IF NOT EXISTS historical_candles_1m (\
         segment SYMBOL,\
         security_id LONG,\
         open DOUBLE,\
@@ -197,21 +197,21 @@ pub async fn ensure_candle_table_dedup_keys(questdb_config: &QuestDbConfig) {
     {
         Ok(response) => {
             if response.status().is_success() {
-                info!("candles_1m table ensured (CREATE TABLE IF NOT EXISTS)");
+                info!("historical_candles_1m table ensured (CREATE TABLE IF NOT EXISTS)");
             } else {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
                 warn!(
                     %status,
                     body = body.chars().take(200).collect::<String>(),
-                    "candles_1m table CREATE DDL returned non-success"
+                    "historical_candles_1m table CREATE DDL returned non-success"
                 );
             }
         }
         Err(err) => {
             warn!(
                 ?err,
-                "candles_1m table CREATE DDL request failed — table not pre-created"
+                "historical_candles_1m table CREATE DDL request failed — table not pre-created"
             );
             return;
         }
@@ -230,23 +230,23 @@ pub async fn ensure_candle_table_dedup_keys(questdb_config: &QuestDbConfig) {
     {
         Ok(response) => {
             if response.status().is_success() {
-                debug!("DEDUP UPSERT KEYS enabled for candles_1m table");
+                debug!("DEDUP UPSERT KEYS enabled for historical_candles_1m table");
             } else {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
                 warn!(
                     %status,
                     body = body.chars().take(200).collect::<String>(),
-                    "candles_1m table DEDUP DDL returned non-success"
+                    "historical_candles_1m table DEDUP DDL returned non-success"
                 );
             }
         }
         Err(err) => {
-            warn!(?err, "candles_1m table DEDUP DDL request failed");
+            warn!(?err, "historical_candles_1m table DEDUP DDL request failed");
         }
     }
 
-    info!("candles_1m table setup complete (DDL + DEDUP UPSERT KEYS)");
+    info!("historical_candles_1m table setup complete (DDL + DEDUP UPSERT KEYS)");
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_candles_1m_ddl_contains_table_name() {
-        assert!(CANDLES_1M_CREATE_DDL.contains("candles_1m"));
+        assert!(CANDLES_1M_CREATE_DDL.contains("historical_candles_1m"));
         assert!(CANDLES_1M_CREATE_DDL.contains("TIMESTAMP(ts)"));
         assert!(CANDLES_1M_CREATE_DDL.contains("PARTITION BY DAY"));
     }

--- a/crates/storage/src/materialized_views.rs
+++ b/crates/storage/src/materialized_views.rs
@@ -268,7 +268,20 @@ pub async fn ensure_candle_views(questdb_config: &QuestDbConfig) {
     );
     execute_ddl(&client, &base_url, &dedup_sql, "candles_1s DEDUP").await;
 
-    // Step 3: Create materialized views in dependency order.
+    // Step 3: Drop legacy `candles_1m` TABLE if it exists.
+    // Previously, historical candles used the name `candles_1m` which conflicts
+    // with the `candles_1m` materialized view. Historical data now goes to
+    // `historical_candles_1m`. This DROP is idempotent — once the old table is
+    // gone, the IF EXISTS makes it a no-op on subsequent startups.
+    execute_ddl(
+        &client,
+        &base_url,
+        "DROP TABLE IF EXISTS candles_1m",
+        "drop legacy candles_1m table",
+    )
+    .await;
+
+    // Step 4: Create materialized views in dependency order.
     let mut created_count: u32 = 0;
     for def in VIEW_DEFS {
         let sql = build_view_sql(def);


### PR DESCRIPTION
## Summary

- **Timestamp float fix**: Dhan API also returns timestamps as float (`1772595900.0`) — applied the same `deserialize_f64_as_i64_vec` deserializer
- **Legacy table migration**: Added idempotent `DROP TABLE IF EXISTS candles_1m` before materialized view creation to remove the old table that was blocking the `candles_1m` view

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::perf` passes
- [x] `cargo test -p dhan-live-trader-common -p dhan-live-trader-storage` passes
- [x] Single clean commit on top of main

https://claude.ai/code/session_01EHDy82vBD8BrjPvYXCpSXB