### PR TITLE
fix(ci): add rust-src component to fuzz workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,6 +40,7 @@ jobs:
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
           toolchain: ${{ env.NIGHTLY_VERSION }}
+          components: rust-src
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2


### PR DESCRIPTION
## Summary
- Add `components: rust-src` to the nightly toolchain step in `fuzz.yml`
- `cargo fuzz` internally uses `-Z build-std` which requires `rust-src` to be installed
- This was the root cause of all fuzz build failures (#216, #217, #220, #221)

## Root Cause
`cargo fuzz build` compiles with `-Z build-std --target x86_64-unknown-linux-gnu`, which rebuilds the standard library from source. This requires the `rust-src` component. The safety workflow already has this (`components: rust-src`) for ASan/TSan/careful, but the fuzz workflow was missing it.

Locally, `rust-src` happened to be installed (from other toolchain usage), masking the issue.

## Fixes
Closes #220, closes #221

## Test plan
- [x] `cargo +nightly-2026-03-15 fuzz build tick_parser` succeeds locally
- [x] `cargo +nightly-2026-03-15 fuzz build config_parser` succeeds locally
- [ ] Fuzz workflow dispatch after merge should pass

https://claude.ai/code/session_01RveunKL57ngnyxXoiuqRSf