### PR TITLE
fix(ci): increase fuzz RSS limit and add diagnostic output

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -83,15 +83,27 @@ jobs:
         id: fuzz
         if: steps.check.outputs.exists == 'true' && steps.build.outcome == 'success'
         run: |
-          # Run for 5 minutes per target
-          timeout 300 cargo +${{ env.NIGHTLY_VERSION }} fuzz run ${{ matrix.target }} -- -max_total_time=300 || {
-            EXIT_CODE=$?
+          # Run for 5 minutes per target.
+          # -rss_limit_mb=4096: increase RSS limit for ASan-instrumented builds.
+          # -max_total_time=300: stop after 5 minutes if no crash found.
+          timeout 300 cargo +${{ env.NIGHTLY_VERSION }} fuzz run ${{ matrix.target }} \
+            -- -max_total_time=300 -rss_limit_mb=4096 2>&1 | tee /tmp/fuzz-run.log || {
+            EXIT_CODE=${PIPESTATUS[0]}
             if [ "$EXIT_CODE" -eq 124 ]; then
               echo "Fuzz run completed (timeout reached — no crashes found)"
             else
-              echo "Fuzz run found a crash!"
-              echo "fuzz_crashed=true" >> "$GITHUB_OUTPUT"
-              exit 1
+              echo "=== Fuzz run failed (exit code $EXIT_CODE) ==="
+              echo "=== Last 50 lines ==="
+              tail -50 /tmp/fuzz-run.log
+              # Check if there's an actual crash artifact
+              if ls fuzz/artifacts/${{ matrix.target }}/* 2>/dev/null; then
+                echo "fuzz_crashed=true" >> "$GITHUB_OUTPUT"
+                exit 1
+              else
+                echo "No crash artifact found — likely a runtime/memory issue, not a code bug."
+                echo "fuzz_crashed=true" >> "$GITHUB_OUTPUT"
+                exit 1
+              fi
             fi
           }
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -67,9 +67,15 @@ jobs:
         id: build
         if: steps.check.outputs.exists == 'true'
         run: |
-          cargo +${{ env.NIGHTLY_VERSION }} fuzz build ${{ matrix.target }} 2>&1 || {
+          echo "=== Environment ==="
+          rustc +${{ env.NIGHTLY_VERSION }} --version
+          cargo fuzz --version || true
+          echo "=== Building ==="
+          cargo +${{ env.NIGHTLY_VERSION }} fuzz build ${{ matrix.target }} 2>&1 | tee /tmp/fuzz-build.log || {
             echo "build_failed=true" >> "$GITHUB_OUTPUT"
             echo "::error::Fuzz target ${{ matrix.target }} failed to BUILD (not a crash). Check nightly compatibility."
+            echo "=== Last 50 lines of build log ==="
+            tail -50 /tmp/fuzz-build.log
             exit 1
           }
 


### PR DESCRIPTION
## Summary
- Increase libfuzzer RSS limit to 4096MB (`-rss_limit_mb=4096`) for ASan-instrumented fuzz builds
- Capture fuzz run output with `tee` for diagnostic visibility
- Use `PIPESTATUS[0]` to correctly capture exit code through pipe
- Report whether crash artifacts exist when the run fails

## Context
After fixing the fuzz build (`rust-src` in #222), the build succeeds but the
fuzz *run* crashes immediately on CI (~40s total). Locally, both targets run
13M+ iterations with zero crashes. The CI failure is likely ASan-instrumented
binary hitting the default RSS limit (2048MB) on the CI runner.

## Fixes
Closes #226, closes #227 (if this resolves the crashes)

## Test plan
- [x] `cargo +nightly-2026-03-15 fuzz run tick_parser -- -max_total_time=30` passes locally (13.5M runs)
- [x] `cargo +nightly-2026-03-15 fuzz run config_parser -- -max_total_time=30` passes locally (1M runs)
- [ ] Trigger fuzz workflow dispatch after merge — should pass or show diagnostic output

https://claude.ai/code/session_01RveunKL57ngnyxXoiuqRSf