### PR TITLE
fix(ci): skip timing assertions under instrumented builds

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -67,10 +67,6 @@ jobs:
         id: build
         if: steps.check.outputs.exists == 'true'
         run: |
-          echo "=== Environment ==="
-          rustc +${{ env.NIGHTLY_VERSION }} --version
-          cargo fuzz --version || true
-          echo "=== Building ==="
           cargo +${{ env.NIGHTLY_VERSION }} fuzz build ${{ matrix.target }} 2>&1 | tee /tmp/fuzz-build.log || {
             echo "build_failed=true" >> "$GITHUB_OUTPUT"
             echo "::error::Fuzz target ${{ matrix.target }} failed to BUILD (not a crash). Check nightly compatibility."

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -69,9 +69,19 @@ jobs:
       - name: Run careful tests
         id: test
         if: steps.build.outcome == 'success'
+        env:
+          DLT_SKIP_PERF_ASSERTIONS: "1"
         run: |
-          cargo +${{ env.NIGHTLY_VERSION }} careful test --workspace 2>&1 || {
+          # --test-threads=1: reduces memory pressure on CI runners
+          # DLT_SKIP_PERF_ASSERTIONS: skip timing assertions (instrumentation = 10-100x slower)
+          cargo +${{ env.NIGHTLY_VERSION }} careful test --workspace \
+            -- --test-threads=1 2>&1 | tee /tmp/careful-test.log || {
             echo "test_failed=true" >> "$GITHUB_OUTPUT"
+            echo "=== cargo-careful test failed (exit code: ${PIPESTATUS[0]}) ==="
+            echo "=== Failed tests ==="
+            grep -E "^test .+ FAILED|^failures:" /tmp/careful-test.log || true
+            echo "=== Last 80 lines ==="
+            tail -80 /tmp/careful-test.log
             exit 1
           }
 
@@ -175,6 +185,7 @@ jobs:
         if: steps.build.outcome == 'success'
         env:
           RUSTFLAGS: "-Z sanitizer=address"
+          DLT_SKIP_PERF_ASSERTIONS: "1"
         run: |
           cargo +${{ env.NIGHTLY_VERSION }} test --workspace \
             --target x86_64-unknown-linux-gnu \
@@ -285,6 +296,7 @@ jobs:
         if: steps.build.outcome == 'success'
         env:
           RUSTFLAGS: "-Z sanitizer=thread"
+          DLT_SKIP_PERF_ASSERTIONS: "1"
         run: |
           cargo +${{ env.NIGHTLY_VERSION }} test --workspace \
             --target x86_64-unknown-linux-gnu \

--- a/crates/core/tests/load_stress.rs
+++ b/crates/core/tests/load_stress.rs
@@ -3,8 +3,18 @@
 //! Verifies that the system handles sustained throughput and burst traffic
 //! without degradation, memory leaks, or panics. These tests simulate
 //! real market conditions: ~25,000 instruments × 1-5 ticks/sec.
+//!
+//! NOTE: Timing assertions are skipped under instrumented builds
+//! (cargo-careful, sanitizers) where execution is 10-100x slower.
+//! Set `DLT_SKIP_PERF_ASSERTIONS=1` to skip timing checks.
 
 use std::time::{Duration, Instant};
+
+/// Returns true when running under instrumented builds (cargo-careful, sanitizers).
+/// Timing assertions are unreliable under instrumentation overhead.
+fn skip_perf_assertions() -> bool {
+    std::env::var("DLT_SKIP_PERF_ASSERTIONS").is_ok()
+}
 
 use dhan_live_trader_common::constants::{
     EXCHANGE_SEGMENT_NSE_FNO, QUOTE_PACKET_SIZE, TICKER_PACKET_SIZE,
@@ -61,10 +71,12 @@ fn stress_parse_100k_tickers() {
     assert_eq!(success_count, 100_000);
 
     // Sanity check: 100K parses should complete in under 1 second
-    assert!(
-        elapsed < Duration::from_secs(1),
-        "100K ticker parses took {elapsed:?} — too slow"
-    );
+    if !skip_perf_assertions() {
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "100K ticker parses took {elapsed:?} — too slow"
+        );
+    }
 }
 
 #[test]
@@ -81,10 +93,12 @@ fn stress_parse_100k_quotes() {
 
     let elapsed = start.elapsed();
     assert_eq!(success_count, 100_000);
-    assert!(
-        elapsed < Duration::from_secs(2),
-        "100K quote parses took {elapsed:?} — too slow"
-    );
+    if !skip_perf_assertions() {
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "100K quote parses took {elapsed:?} — too slow"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -110,10 +124,12 @@ fn stress_burst_10k_mixed_packets() {
     }
 
     let elapsed = start.elapsed();
-    assert!(
-        elapsed < Duration::from_millis(500),
-        "10K mixed burst took {elapsed:?} — too slow"
-    );
+    if !skip_perf_assertions() {
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "10K mixed burst took {elapsed:?} — too slow"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -141,10 +157,12 @@ fn stress_candle_aggregator_50k_ticks() {
     }
 
     let elapsed = start.elapsed();
-    assert!(
-        elapsed < Duration::from_secs(1),
-        "50K candle updates took {elapsed:?} — too slow"
-    );
+    if !skip_perf_assertions() {
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "50K candle updates took {elapsed:?} — too slow"
+        );
+    }
     // Should have produced some completed candles (new seconds)
     let total_completed = agg.completed_slice().len();
     assert!(total_completed > 0, "should produce completed candles");

--- a/crates/core/tests/timeout_enforcement.rs
+++ b/crates/core/tests/timeout_enforcement.rs
@@ -3,8 +3,16 @@
 //! Verifies that async operations respect deadlines and do not
 //! hang indefinitely. Critical for a trading system where stuck
 //! operations can block order execution.
+//!
+//! NOTE: Upper-bound timing assertions are skipped under instrumented
+//! builds where execution is 10-100x slower.
 
 use std::time::Duration;
+
+/// Returns true when running under instrumented builds.
+fn skip_perf_assertions() -> bool {
+    std::env::var("DLT_SKIP_PERF_ASSERTIONS").is_ok()
+}
 
 use tokio::time::timeout;
 
@@ -57,12 +65,14 @@ async fn timeout_tokio_sleep_completes_within_bounds() {
     tokio::time::sleep(target).await;
 
     let elapsed = start.elapsed();
-    // Should complete within 2x the target (generous for CI)
-    assert!(
-        elapsed < target * 3,
-        "sleep took {elapsed:?}, expected ~{target:?}"
-    );
-    // Should not complete too early
+    // Upper bound: skip under instrumentation (cargo-careful adds overhead)
+    if !skip_perf_assertions() {
+        assert!(
+            elapsed < target * 3,
+            "sleep took {elapsed:?}, expected ~{target:?}"
+        );
+    }
+    // Lower bound: should not complete too early (always valid)
     assert!(
         elapsed >= target - Duration::from_millis(5),
         "sleep completed too early: {elapsed:?}"

--- a/crates/trading/tests/load_stress.rs
+++ b/crates/trading/tests/load_stress.rs
@@ -2,8 +2,17 @@
 //!
 //! Verifies risk engine and indicator ring buffer handle
 //! sustained throughput without degradation.
+//!
+//! NOTE: Timing assertions are skipped under instrumented builds
+//! (cargo-careful, sanitizers) where execution is 10-100x slower.
+//! Set `DLT_SKIP_PERF_ASSERTIONS=1` to skip timing checks.
 
 use std::time::{Duration, Instant};
+
+/// Returns true when running under instrumented builds (cargo-careful, sanitizers).
+fn skip_perf_assertions() -> bool {
+    std::env::var("DLT_SKIP_PERF_ASSERTIONS").is_ok()
+}
 
 // ---------------------------------------------------------------------------
 // Sustained: Risk engine under load
@@ -29,10 +38,12 @@ fn stress_risk_engine_100k_checks() {
 
     let elapsed = start.elapsed();
     assert_eq!(engine.total_checks(), 100_000);
-    assert!(
-        elapsed < Duration::from_secs(1),
-        "100K risk checks took {elapsed:?} — too slow"
-    );
+    if !skip_perf_assertions() {
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "100K risk checks took {elapsed:?} — too slow"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -51,10 +62,12 @@ fn stress_ring_buffer_1m_pushes() {
     }
 
     let elapsed = start.elapsed();
-    assert!(
-        elapsed < Duration::from_millis(200),
-        "1M ring buffer pushes took {elapsed:?} — too slow"
-    );
+    if !skip_perf_assertions() {
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "1M ring buffer pushes took {elapsed:?} — too slow"
+        );
+    }
     // Capacity should be stable
     assert_eq!(
         ring.len() as usize,


### PR DESCRIPTION
## Summary
- Add `DLT_SKIP_PERF_ASSERTIONS` env var to skip timing-sensitive assertions
  under instrumented builds (cargo-careful, ASan, TSan)
- Guard all timing assertions in `load_stress.rs` and `timeout_enforcement.rs`
  with `skip_perf_assertions()` check
- Set the env var in safety.yml for all 3 instrumented test steps
- Add `--test-threads=1` to cargo-careful to reduce memory pressure
- Add diagnostic output capture (tee + tail) to cargo-careful test step
- Clean up fuzz.yml debug output (no longer needed)

## Root Cause
Instrumented builds (cargo-careful, sanitizers) add 10-100x execution overhead.
Stress tests asserting "100K ops in < 1 second" fail when the same ops take
5-10 seconds under instrumentation. These are false positives — the code is
correct, just slower under instrumentation.

## Design
- Timing assertions remain **active** in normal CI (`cargo test`)
- Only skipped in safety.yml where instrumentation overhead is expected
- Correctness assertions (result validation, no panics) still run everywhere
- Env var approach is explicit and grep-able

## Fixes
Closes #230

## Test plan
- [x] `cargo test --workspace` — all tests pass (timing assertions active)
- [x] `DLT_SKIP_PERF_ASSERTIONS=1 cargo test --test load_stress` — assertions skipped, tests pass
- [x] `DLT_SKIP_PERF_ASSERTIONS=1 cargo +nightly-2026-03-15 careful test --workspace -- --test-threads=1` — all 676 tests pass
- [ ] Safety workflow dispatch after merge — all 3 jobs should pass

https://claude.ai/code/session_01RveunKL57ngnyxXoiuqRSf