### PR TITLE
fix(main): wire dormant check_clock_drift + spawn_heartbeat_watchdog

### DIFF
--- a/.claude/hooks/pub-fn-wiring-guard.sh
+++ b/.claude/hooks/pub-fn-wiring-guard.sh
@@ -50,8 +50,8 @@ for FILE in $SCOPE_FILES; do
 
   # Find pub fn declarations (excluding `pub(crate)` and `pub(super)` for now —
   # those are intentionally module-scoped).
-  while IFS=':' read -r LINENO REST; do
-    [ -n "$LINENO" ] || continue
+  while IFS=':' read -r FN_LINE REST; do
+    [ -n "$FN_LINE" ] || continue
 
     # Extract fn name. Handles `pub fn foo`, `pub async fn foo`,
     # `pub fn foo<T>`, `pub fn foo(`.
@@ -66,7 +66,7 @@ for FILE in $SCOPE_FILES; do
     esac
 
     # Check for // WIRING-EXEMPT: on the line directly above.
-    PREV_LINE=$((LINENO - 1))
+    PREV_LINE=$((FN_LINE - 1))
     if sed -n "${PREV_LINE}p" "$FILE" 2>/dev/null | grep -q 'WIRING-EXEMPT:'; then
       continue
     fi
@@ -85,7 +85,7 @@ for FILE in $SCOPE_FILES; do
 
     # The declaration itself shows up in the count (1 reference). Anything > 1 means a caller exists.
     if [ "$CALL_COUNT" -le 1 ]; then
-      VIOLATIONS+=("${FILE}:${LINENO}: pub fn ${FN_NAME}() has no call sites")
+      VIOLATIONS+=("${FILE}:${FN_LINE}: pub fn ${FN_NAME}() has no call sites")
     fi
   done < <(grep -nE '^\s*pub\s+(async\s+|const\s+|unsafe\s+)?fn\s+[a-zA-Z_]' "$FILE" 2>/dev/null || true)
 done

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -27,8 +27,9 @@
 // Modules are declared in lib.rs for coverage instrumentation.
 use dhan_live_trader_app::boot_helpers::{
     CONFIG_BASE_PATH, CONFIG_LOCAL_PATH, FAST_BOOT_WINDOW_END, FAST_BOOT_WINDOW_START, IstTimer,
-    compute_market_close_sleep, create_log_file_writer, effective_ws_stagger, format_bind_addr,
-    format_cross_match_details, format_timeframe_details, format_violation_details,
+    check_clock_drift, compute_market_close_sleep, create_log_file_writer, effective_ws_stagger,
+    format_bind_addr, format_cross_match_details, format_timeframe_details,
+    format_violation_details, spawn_heartbeat_watchdog,
 };
 use dhan_live_trader_app::{infra, observability, trading_pipeline};
 
@@ -143,6 +144,22 @@ async fn main() -> Result<()> {
         mode = ?config.strategy.mode,
         "S6-Step4: sandbox-only window check passed"
     );
+
+    // S12 wiring: system clock drift check (cold path, boot only).
+    // SEBI + tick timestamp integrity requires the system clock to be
+    // within a few seconds of UTC. Drift > threshold logs WARN (fires
+    // Telegram via Loki hook). Best-effort — network errors return None
+    // and are non-fatal; the check exists to catch gross drifts (NTP
+    // failed, container clock skew, etc.) before market data starts
+    // flowing.
+    if let Some(drift_secs) = check_clock_drift().await {
+        info!(
+            drift_secs,
+            "S12: system clock drift check completed (0 = synced)"
+        );
+    } else {
+        warn!("S12: clock drift check failed (network or parse error) — proceeding");
+    }
 
     // Build trading calendar (validated inside config.validate() already).
     let trading_calendar = std::sync::Arc::new(
@@ -437,6 +454,18 @@ async fn main() -> Result<()> {
             tokio::sync::broadcast::channel::<dhan_live_trader_common::tick_types::ParsedTick>(
                 dhan_live_trader_common::constants::TICK_BROADCAST_CAPACITY,
             );
+
+        // S12 wiring: heartbeat watchdog (fast boot).
+        // Spawns a background task that every 30 seconds checks:
+        //   - Token handle has a non-None token
+        //   - Tick broadcast has > 0 active receivers
+        //   - Emits systemd WATCHDOG=1 ping
+        //   - Exports FD/thread system metrics
+        // Logs ERROR on any failure (fires Telegram via Loki hook).
+        let _fast_heartbeat_handle = spawn_heartbeat_watchdog(
+            std::sync::Arc::clone(&token_handle),
+            fast_tick_broadcast_sender.clone(),
+        );
 
         // S3-2: Gap-backfill channel + worker. The cold-path tick persistence
         // consumer publishes GapBackfillRequest here when a TickGapTracker
@@ -1388,6 +1417,15 @@ async fn main() -> Result<()> {
         tokio::sync::broadcast::channel::<dhan_live_trader_common::tick_types::ParsedTick>(
             dhan_live_trader_common::constants::TICK_BROADCAST_CAPACITY,
         );
+
+    // S12 wiring: heartbeat watchdog (slow boot).
+    // Same responsibilities as the fast-boot watchdog above. Spawned
+    // after token_handle + tick_broadcast_sender are both available.
+    // Runs until the process exits.
+    let _slow_heartbeat_handle = spawn_heartbeat_watchdog(
+        std::sync::Arc::clone(&token_handle),
+        tick_broadcast_sender.clone(),
+    );
 
     // S4-T1d: Slow-boot backfill infrastructure. Mirrors the fast-boot
     // wiring at line ~424 so the two boot modes have identical gap

--- a/crates/storage/src/deep_depth_persistence.rs
+++ b/crates/storage/src/deep_depth_persistence.rs
@@ -683,7 +683,8 @@ impl DeepDepthWriter {
     }
 
     /// Returns the number of records held in the resilience ring buffer.
-    // TEST-EXEMPT: trivial field getter, tested indirectly by ring buffer tests
+    // TEST-EXEMPT: trivial field getter, tested indirectly by ring buffer tests.
+    // WIRING-EXEMPT: observability getter exposed for future metric scraping + dlt-doctor diagnostic probes.
     pub fn buffered_count(&self) -> usize {
         self.depth_buffer.len()
     }


### PR DESCRIPTION
## Summary

Resolves the 3 dormant pub fns on `main` that the G1 wiring guard (from PR #260) correctly flagged after merging. These were legitimate safety infrastructure defined in `boot_helpers.rs` but never called from `main.rs` — dead code that landed from earlier PRs before the guard existed.

## Fixes

### 1. `check_clock_drift` — NOW WIRED
**Location:** `crates/app/src/boot_helpers.rs:242`
**Purpose:** SEBI + tick timestamp integrity. System clock drift > threshold corrupts every LTT-derived value.
**Fix:** Called once during boot sequence right after the sandbox window check. Logs drift at INFO level, warns on network error (non-fatal).

### 2. `spawn_heartbeat_watchdog` — NOW WIRED (both boot paths)
**Location:** `crates/app/src/boot_helpers.rs:279`
**Purpose:** 30-second background watchdog that checks token handle + tick broadcast health + emits systemd `WATCHDOG=1` ping + exports FD/thread metrics. ERROR log fires Telegram via Loki.
**Fix:** Spawned in BOTH boot paths after `token_handle` + `tick_broadcast_sender` are available.

### 3. `buffered_count` on `DepthPersistenceWriter` — WIRING-EXEMPT
**Location:** `crates/storage/src/deep_depth_persistence.rs:688`
**Purpose:** Trivial ring-buffer getter kept for future `dlt-doctor` diagnostic probes.
**Fix:** Added `// WIRING-EXEMPT:` comment on the line directly above `pub fn` (the G1 guard checks only the immediately-preceding line).

## Bonus: G1 hook bug fix

While fixing the 3 dormant fns I discovered a bug in `.claude/hooks/pub-fn-wiring-guard.sh`:

- Bash's `LINENO` is a reserved variable that **always expands to the current script line number**, NOT loop-local values.
- Every violation was reported at "line 88" regardless of the function's real location — because line 88 is where the `VIOLATIONS+=` statement lives inside the hook.
- The violation detection worked correctly; only the line-number display was wrong.

Fix: renamed `LINENO` → `FN_LINE` throughout the hook. Real line numbers now reported accurately.

## Verification

- `cargo check --workspace`: clean, 0 errors
- `.claude/hooks/pub-fn-wiring-guard.sh`: **PASS** (0 violations)
- `.claude/hooks/boot-symmetry-guard.sh`: **PASS**
- No behavior change to `check_clock_drift` or `spawn_heartbeat_watchdog` themselves — they were already well-tested inside `boot_helpers.rs`, just never invoked

## Files

- `crates/app/src/main.rs` — 2 new import symbols + 2 wire sites (fast-boot + slow-boot)
- `crates/storage/src/deep_depth_persistence.rs` — 1 WIRING-EXEMPT comment line
- `.claude/hooks/pub-fn-wiring-guard.sh` — LINENO → FN_LINE rename

## Test plan

- [ ] CI passes all gates
- [ ] Maintainer confirms clock drift logs appear at startup
- [ ] Maintainer confirms heartbeat watchdog spawns (look for "WATCHDOG" in journalctl after 35s)

https://claude.ai/code/session_012Rurz7cuq7LzE2u3g151EM