### PR TITLE
feat(notification): typed CandleCrossMatchSkipped event

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4085,6 +4085,9 @@ fn spawn_historical_candle_fetch(
             );
         } else {
             // Non-trading day: skip cross-match (no live data to compare).
+            // Emit the typed SKIPPED notification so the operator gets
+            // explicit closure on Telegram instead of silently missing
+            // the post-fetch cross-match step on weekends / holidays.
             info!(
                 instruments_fetched = summary.instruments_fetched,
                 instruments_failed = summary.instruments_failed,
@@ -4092,6 +4095,10 @@ fn spawn_historical_candle_fetch(
                 verification_passed = verify_report.passed,
                 "non-trading day historical fetch complete (cross-match skipped — no live data)"
             );
+            bg_notifier.notify(NotificationEvent::CandleCrossMatchSkipped {
+                reason: "weekend or holiday — not a trading day".to_string(),
+                candles_compared: 0,
+            });
         }
     });
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4045,8 +4045,9 @@ fn spawn_historical_candle_fetch(
                     candles_compared = cross_match.candles_compared,
                     "cross-match SKIPPED — no live data in materialized views (first run, fresh DB, or post-market boot)"
                 );
-                bg_notifier.notify(NotificationEvent::Custom {
-                    message: "Historical vs Live cross-match SKIPPED\nNo live data in materialized views (first run, fresh DB, or post-market boot). Will compare on next run after live ticks are collected during market hours.".to_string(),
+                bg_notifier.notify(NotificationEvent::CandleCrossMatchSkipped {
+                    reason: "no live data in materialized views".to_string(),
+                    candles_compared: cross_match.candles_compared,
                 });
             } else if cross_match.passed {
                 bg_notifier.notify(NotificationEvent::CandleCrossMatchPassed {

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -321,6 +321,18 @@ pub enum NotificationEvent {
         mismatch_details: Vec<String>,
     },
 
+    /// Historical vs Live candle cross-match skipped — no live data in
+    /// materialized views yet (first run, fresh DB, or post-market boot
+    /// before any live ticks have been collected during market hours).
+    CandleCrossMatchSkipped {
+        /// Human-readable reason for skipping (e.g. "no live data in materialized views").
+        reason: String,
+        /// LEFT JOIN row count from the cross-match query. Meaningless on its
+        /// own when no live data exists, but surfaced for diagnostic parity
+        /// with `CandleCrossMatchPassed`/`Failed`.
+        candles_compared: usize,
+    },
+
     /// Public IP verification failed — static IP mismatch or detection failure.
     IpVerificationFailed {
         /// Human-readable reason for the failure.
@@ -783,6 +795,14 @@ impl NotificationEvent {
                 }
                 msg
             }
+            Self::CandleCrossMatchSkipped {
+                reason,
+                candles_compared,
+            } => {
+                format!(
+                    "<b>Historical vs Live cross-match SKIPPED</b>\nReason: {reason}\n(first run, fresh DB, or post-market boot — no live ticks yet)\nLEFT JOIN rows: {candles_compared} (diagnostic only)\nWill compare on next run after live ticks during market hours."
+                )
+            }
             Self::IpVerificationFailed { reason } => {
                 format!(
                     "<b>IP VERIFICATION FAILED</b>\n{reason}\n\nBoot blocked — no Dhan API calls will be made."
@@ -896,6 +916,7 @@ impl NotificationEvent {
             Self::HistoricalFetchComplete { .. } => Severity::Low,
             Self::CandleVerificationPassed { .. } => Severity::Low,
             Self::CandleCrossMatchPassed { .. } => Severity::Low,
+            Self::CandleCrossMatchSkipped { .. } => Severity::Low,
             Self::Custom { .. } => Severity::High,
             Self::RiskHalt { .. } => Severity::Critical,
             Self::WebSocketReconnectionExhausted { .. } => Severity::Critical,
@@ -1439,6 +1460,39 @@ mod tests {
         let event = NotificationEvent::CandleCrossMatchPassed {
             timeframes_checked: 5,
             candles_compared: 187500,
+        };
+        assert_eq!(event.severity(), Severity::Low);
+    }
+
+    #[test]
+    fn test_cross_match_skipped_message() {
+        let event = NotificationEvent::CandleCrossMatchSkipped {
+            reason: "no live data in materialized views".to_string(),
+            candles_compared: 0,
+        };
+        let msg = event.to_message();
+        assert!(msg.contains("cross-match SKIPPED"));
+        assert!(msg.contains("no live data"));
+        assert!(msg.contains("first run"));
+        assert!(msg.contains("Will compare on next run"));
+    }
+
+    #[test]
+    fn test_cross_match_skipped_shows_reason() {
+        let event = NotificationEvent::CandleCrossMatchSkipped {
+            reason: "fresh DB after migration".to_string(),
+            candles_compared: 348_968,
+        };
+        let msg = event.to_message();
+        assert!(msg.contains("fresh DB after migration"));
+        assert!(msg.contains("348968"));
+    }
+
+    #[test]
+    fn test_cross_match_skipped_is_low() {
+        let event = NotificationEvent::CandleCrossMatchSkipped {
+            reason: "no live data".to_string(),
+            candles_compared: 0,
         };
         assert_eq!(event.severity(), Severity::Low);
     }

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -1497,6 +1497,22 @@ mod tests {
         assert_eq!(event.severity(), Severity::Low);
     }
 
+    #[test]
+    fn test_cross_match_skipped_weekend_reason_renders() {
+        // Regression: weekend / non-trading-day boot must emit the typed
+        // SKIPPED event so Telegram always shows closure for the
+        // post-fetch cross-match step.
+        let event = NotificationEvent::CandleCrossMatchSkipped {
+            reason: "weekend or holiday — not a trading day".to_string(),
+            candles_compared: 0,
+        };
+        let msg = event.to_message();
+        assert!(msg.contains("SKIPPED"));
+        assert!(msg.contains("weekend or holiday"));
+        assert!(msg.contains("not a trading day"));
+        assert_eq!(event.severity(), Severity::Low);
+    }
+
     // -- Severity tests --
 
     #[test]


### PR DESCRIPTION
## Summary

When the post-market cross-match finds no live data in the materialized
views (first run, fresh DB, or post-market boot before any live ticks
have been collected), the caller in `main.rs` was sending the
"SKIPPED" Telegram message via the generic
`NotificationEvent::Custom { message }` variant.

`Custom` is forced to `Severity::High` and has no typed contract — no
structured tests, no stable fields, no consistent alongside
`CandleCrossMatchPassed` / `CandleCrossMatchFailed`.

This PR adds a first-class typed variant:

```rust
CandleCrossMatchSkipped {
    reason: String,
    candles_compared: usize,
}
```

- Severity: `Low` (informational)
- Telegram message: `"Historical vs Live cross-match SKIPPED\nReason: {reason}\n..."`
- Diagnostic field: `candles_compared` (LEFT-JOIN row count, shown for parity)
- Caller site: `crates/app/src/main.rs` post-market cross-match branch

## Why

Operator confusion: the existing Telegram chat shows
`Candle verification OK` (a **different** check,
`CandleVerificationPassed`, that only validates historical-candle
internal OHLC consistency and does not touch live ticks) immediately
after historical fetch. The SKIPPED message was buried inside a generic
`Custom{}` notification, which made it look like the
Passed/Failed/Skipped path was only half-implemented. With a typed
variant the skip is now first-class, testable, and structurally
identical to its Passed/Failed siblings.

## Test plan

- [x] `test_cross_match_skipped_message` — asserts message contains
      "SKIPPED", "no live data", "first run", "Will compare on next run"
- [x] `test_cross_match_skipped_shows_reason` — asserts reason string
      and `candles_compared` render into the message
- [x] `test_cross_match_skipped_is_low` — asserts severity is `Low`
- [x] `cargo check -p tickvault-core -p tickvault-app` — green
- [x] `cargo fmt --check` — green
- [x] Pre-commit 9-gate hook — green
