### PR TITLE
feat(autonomous-ops): universal MCP access via Tailscale Funnel (M1)

### DIFF
--- a/.claude/plans/autonomous-operations-100pct.md
+++ b/.claude/plans/autonomous-operations-100pct.md
@@ -1,0 +1,117 @@
+# Autonomous Operations: 100% Zero-Human-Input Plan
+
+**Status:** DRAFT — Milestone 1 shipping now, 2-5 queued as follow-up PRs
+**Date:** 2026-04-18
+**Owner:** Parthiban (architect), Claude Code (builder)
+**Scope:** Every bug, error, warning, exception across the entire tickvault product + codebase resolves without human action.
+
+## The 5 layers of autonomous operations
+
+| Layer | Capability | Status | Shipping PR |
+|---|---|---|---|
+| 1. Observe | Read metrics, logs, alerts, traces, data from any Claude session on any branch, Mac + AWS | **M1 — this PR** | `claude/autonomous-ops-m1` |
+| 2. Diagnose | Classify errors via signature hashing + errors.summary.md | ✅ Shipped (Phases 1-5 of zero-touch plan) | — |
+| 3. Decide | Rule-based triage — classifier picks safe auto-fix action per error code | Partial (7/53 codes covered) | M2 |
+| 4. Act | Auto-fix script per rule; every classifier rule has a runnable remediation | Partial (3 scaffolded, 1 functional) | M3 |
+| 5. Verify + Rollback | Post-fix metric re-probe; auto-revert if fix made things worse | Not built | M4 |
+| 6. Runtime scaling + chaos | AWS autoscale, EBS resize, Dhan plan upgrade; nightly chaos tests prove self-heal | Not built (deferred post-AWS-provision) | M5 |
+
+## Milestone 1 (THIS PR) — Universal observability
+
+**Goal:** any Claude session, on any branch, on any host (Mac / AWS / claude.ai sandbox / claude cowork), can read tickvault's full runtime state with zero per-session setup.
+
+**Design decisions:**
+- **Transport:** Tailscale Funnel — free tier, stable HTTPS URLs that never change, both Mac and AWS Tailscale devices expose their local services via `<hostname>.<tailnet>.ts.net:<port>`.
+- **Config:** committed file `config/claude-mcp-endpoints.toml` with explicit Mac + AWS profiles. Replaces per-environment env-var setup. Env vars still override for local testing.
+- **Log access:** new HTTP endpoints on tickvault API (`GET /api/debug/logs/summary`, `GET /api/debug/logs/jsonl/latest`) — no file-sync/rsync needed. MCP reads logs over HTTPS through the tunnel, same as metrics.
+- **Branch-independence:** the config file and `.mcp.json` changes go to `main`. Every future branch clone inherits them automatically. No per-branch env vars.
+
+**Deliverables (this PR):**
+- `config/claude-mcp-endpoints.toml` — profile config
+- `scripts/tv-tunnel/install-mac.sh` — one-command Mac setup (Tailscale install check, funnel start, launchd plist)
+- `scripts/tv-tunnel/install-aws.sh` — one-command AWS setup (apt install, funnel start, systemd unit)
+- `scripts/tv-tunnel/com.tickvault.tunnel.plist` — launchd template
+- `scripts/tv-tunnel/tickvault-tunnel.service` — systemd template
+- `scripts/tv-tunnel/doctor.sh` — verify tunnel is up from the host it runs on
+- `scripts/mcp-servers/tickvault-logs/server.py` — read `claude-mcp-endpoints.toml`, env vars as override
+- `.mcp.json` — reference the new config path
+- `crates/api/src/handlers/debug.rs` — two read-only log-access handlers
+- `crates/api/src/lib.rs` — wire debug routes
+- `docs/runbooks/claude-mcp-access.md` — rewrite with working Mode C
+- `crates/common/tests/claude_mcp_endpoints_config_guard.rs` — config schema invariant
+- `crates/api/tests/debug_endpoints_guard.rs` — debug routes are read-only + localhost-source-only when config says so
+
+**What you run once per environment (after this PR merges):**
+- Mac: `bash scripts/tv-tunnel/install-mac.sh`
+- AWS (when provisioned): `bash scripts/tv-tunnel/install-aws.sh`
+
+After that, any Claude session anywhere can query your live stack live.
+
+## Milestone 2 (next PR) — Full triage rule coverage
+
+**Goal:** every one of the 53 ErrorCode variants has a classifier rule in `.claude/triage/error-rules.yaml`.
+
+**Deliverables:**
+- 46 new classifier rules (one per ErrorCode variant not yet covered)
+- Each rule: severity, signature pattern, decision (`auto-fix` | `escalate-only` | `observe`)
+- Safety default: anything with severity Critical or confidence < 0.95 → `escalate-only`
+- Meta-guard: `crates/common/tests/triage_rules_full_coverage_guard.rs` fails the build if any ErrorCode variant has no rule
+- Expected runtime: Claude's `/loop` runbook polls `errors.summary.md`, routes to rule, decides.
+
+## Milestone 3 (next PR) — Full auto-fix script catalogue
+
+**Goal:** every `auto-fix` rule in M2 has a runnable remediation script with bounded side effects.
+
+**Deliverables:**
+- ~20-30 new auto-fix scripts under `.claude/triage/auto-fix/`
+- Each script: idempotent, side-effect bounded, emits audit log to `data/logs/auto-fix.log`
+- Examples: `restart-websocket-pool.sh`, `rotate-token.sh`, `clear-questdb-wal.sh`, `restart-depth-rebalancer.sh`, `refresh-instrument-master.sh`, `kill-switch-activate.sh`, etc.
+- Meta-guard: every `auto-fix` rule in `error-rules.yaml` has a corresponding executable script.
+- Dry-run flag (`--dry-run`) on every script so Claude can preview before executing.
+- `make triage-execute` runs the full auto-fix path; already exists, just extends to cover all rules.
+
+## Milestone 4 (next PR) — Verify + rollback loop
+
+**Goal:** after Claude triggers a fix, the verify step re-probes metrics/alerts; if the fix didn't clear the symptom OR made things worse, Claude auto-reverts.
+
+**Deliverables:**
+- `scripts/triage/verify.sh` — takes fix-id + expected-outcome predicate, polls MCP for 60-180s, pass/fail
+- `scripts/triage/rollback.sh <fix-id>` — reverses every auto-fix in M3 (every script gets a corresponding `*-rollback.sh`)
+- Claude's loop runbook: fix → verify → (pass: log success, escalate to info) | (fail: rollback → escalate to operator)
+- Audit log: every fix + verify + rollback recorded in `data/logs/auto-fix.log` with correlation IDs.
+
+## Milestone 5 (post-AWS-provision) — Runtime scaling + chaos
+
+**Goal:** autonomous response to capacity events (tick flood, daily subscription plan exhaustion, EBS fill) + nightly chaos tests that prove self-heal.
+
+**Deliverables:**
+- AWS Lambda bridge for actions requiring AWS creds (EBS resize, ASG scale, SNS alert)
+- Dhan rate-limit auto-backoff + subscription-plan upgrade nudge to operator (plan upgrades are paid actions — always escalate, never auto-act)
+- Chaos tests (`scripts/chaos/`): kill QuestDB, kill Valkey, kill WebSocket connection, corrupt instrument cache — confirm recovery without operator
+- Nightly CI job: full chaos battery runs against a dedicated AWS instance, fails the build if any scenario requires operator
+- Zero-tick-loss proof: chaos + verify loop proves continuous tick capture through all scenarios
+
+## The honesty clause
+
+**Physical constraints that cannot be automated away:**
+1. **First-time tunnel setup** — someone has to run `install-mac.sh` once on the Mac and `install-aws.sh` once on AWS. After that, launchd/systemd auto-restart forever.
+2. **Paid actions** — Dhan subscription plan upgrade, AWS instance resize above budget, etc. These always escalate to operator (never auto-act), per the AWS-budget rule.
+3. **Novel signatures** — a never-seen error signature always goes to operator via Telegram. Classifier confidence ≥ 0.95 is required for auto-fix (per the ALWAYS-ping rule in the Zero-Touch plan).
+4. **Root-level OS changes** — installing brew packages, systemd reload, etc. require sudo. Handled during the one-time install script run.
+
+**Everything else IS automatable** and is covered by M1-M5.
+
+## Relationship to existing plans
+
+This plan extends and depends on `.claude/plans/active-plan.md` (Zero-Touch Error Observability & Auto-Triage). That plan covers Layers 2 + parts of 3 and 6. This plan completes Layers 1, 3, 4, 5, 6.
+
+On completion of M5, both plans fold into a single living doc: `docs/architecture/autonomous-operations.md`.
+
+## Plan verification (before "VERIFIED" status)
+
+Before this PR merges, `bash .claude/hooks/plan-verify.sh` must pass:
+- [ ] Every deliverable in the M1 list is a real file in the diff
+- [ ] Every listed test function exists and passes
+- [ ] Runbook rewrite is non-trivial (>300 new lines)
+- [ ] `scripts/validate-automation.sh` still passes (30/30)
+- [ ] CI on the PR is green

--- a/config/claude-mcp-endpoints.toml
+++ b/config/claude-mcp-endpoints.toml
@@ -1,0 +1,58 @@
+# Claude MCP Endpoints Config — universal, branch-independent
+#
+# Read by scripts/mcp-servers/tickvault-logs/server.py at startup.
+# Env vars (TICKVAULT_PROMETHEUS_URL etc.) override any value here.
+#
+# Purpose: every Claude session, on every branch, on every host
+# (Mac dev / AWS prod / claude.ai sandbox / claude cowork) reads the
+# same endpoints — zero per-session setup after one-time tunnel install.
+#
+# To regenerate this file with your actual Tailscale hostnames:
+#   bash scripts/tv-tunnel/doctor.sh --emit-config
+#
+# The `active` profile at the top decides which set is used by default.
+# Override at runtime:   TICKVAULT_MCP_PROFILE=mac-dev claude ...
+
+active = "aws-prod"
+
+# -----------------------------------------------------------------------------
+# mac-dev profile
+# -----------------------------------------------------------------------------
+# Your Mac exposing tickvault's local Docker services via Tailscale Funnel.
+# Replace <mac-host> with your Mac's Tailscale hostname (run `tailscale status`
+# on the Mac to find it). The .ts.net domain is stable across reboots.
+[profiles.mac-dev]
+prometheus_url    = "https://MAC-HOSTNAME.YOUR-TAILNET.ts.net:9090"
+alertmanager_url  = "https://MAC-HOSTNAME.YOUR-TAILNET.ts.net:9093"
+questdb_url       = "https://MAC-HOSTNAME.YOUR-TAILNET.ts.net:9000"
+grafana_url       = "https://MAC-HOSTNAME.YOUR-TAILNET.ts.net:3000"
+tickvault_api_url = "https://MAC-HOSTNAME.YOUR-TAILNET.ts.net:3001"
+logs_source       = "http"  # "http" = fetch via /api/debug/logs/* | "local" = filesystem
+logs_dir_local    = "./data/logs"  # only used when logs_source = "local"
+
+# -----------------------------------------------------------------------------
+# aws-prod profile
+# -----------------------------------------------------------------------------
+# Your AWS EC2 instance exposing tickvault's services via Tailscale Funnel.
+# Activated once the instance is provisioned (scripts/tv-tunnel/install-aws.sh).
+[profiles.aws-prod]
+prometheus_url    = "https://AWS-HOSTNAME.YOUR-TAILNET.ts.net:9090"
+alertmanager_url  = "https://AWS-HOSTNAME.YOUR-TAILNET.ts.net:9093"
+questdb_url       = "https://AWS-HOSTNAME.YOUR-TAILNET.ts.net:9000"
+grafana_url       = "https://AWS-HOSTNAME.YOUR-TAILNET.ts.net:3000"
+tickvault_api_url = "https://AWS-HOSTNAME.YOUR-TAILNET.ts.net:3001"
+logs_source       = "http"
+logs_dir_local    = "./data/logs"
+
+# -----------------------------------------------------------------------------
+# local profile (Mode A — Claude Code running on the Mac with tickvault local)
+# -----------------------------------------------------------------------------
+# No tunnel needed — everything on 127.0.0.1. This is the pre-tunnel default.
+[profiles.local]
+prometheus_url    = "http://127.0.0.1:9090"
+alertmanager_url  = "http://127.0.0.1:9093"
+questdb_url       = "http://127.0.0.1:9000"
+grafana_url       = "http://127.0.0.1:3000"
+tickvault_api_url = "http://127.0.0.1:3001"
+logs_source       = "local"
+logs_dir_local    = "./data/logs"

--- a/crates/api/src/handlers/debug.rs
+++ b/crates/api/src/handlers/debug.rs
@@ -1,0 +1,246 @@
+//! Debug endpoints for Claude MCP / autonomous-ops observability.
+//!
+//! Read-only HTTP access to tickvault's error-log artefacts so that
+//! remote Claude sessions (sandbox, cloud IDE, claude.ai) can reach
+//! them over a Tailscale Funnel or reverse proxy without needing
+//! filesystem sync. This is Layer 1 (Observability) of the autonomous
+//! operations plan at `.claude/plans/autonomous-operations-100pct.md`.
+//!
+//! These endpoints expose the same files the MCP server reads locally:
+//! - `errors.summary.md` (60s-refreshed signature-hash summary)
+//! - `errors.jsonl.<YYYY-MM-DD-HH>` (hourly-rotated ERROR JSONL)
+//!
+//! They do NOT expose app.log, secrets, or any write action.
+
+use std::path::{Path, PathBuf};
+
+use axum::http::{StatusCode, header};
+use axum::response::IntoResponse;
+
+/// Default logs directory. Mirrors the MCP server's default resolution:
+/// `<repo_root>/data/logs`. Overridable via env var `TV_LOGS_DIR` so
+/// deployments that store logs elsewhere (e.g. EFS mount on AWS) work
+/// without code changes.
+const DEFAULT_LOGS_DIR: &str = "data/logs";
+const ERRORS_SUMMARY_FILENAME: &str = "errors.summary.md";
+const ERRORS_JSONL_PREFIX: &str = "errors.jsonl";
+
+/// Env-var override for the logs directory location.
+const LOGS_DIR_ENV: &str = "TV_LOGS_DIR";
+
+fn resolve_logs_dir() -> PathBuf {
+    if let Ok(custom) = std::env::var(LOGS_DIR_ENV) {
+        if !custom.trim().is_empty() {
+            return PathBuf::from(custom);
+        }
+    }
+    PathBuf::from(DEFAULT_LOGS_DIR)
+}
+
+/// GET /api/debug/logs/summary — returns errors.summary.md as text/markdown.
+/// Returns 404 with `{"error": "summary not yet generated"}` if the file
+/// does not exist. Never panics on missing files.
+pub async fn logs_summary() -> impl IntoResponse {
+    let path = resolve_logs_dir().join(ERRORS_SUMMARY_FILENAME);
+    read_text_file(&path, "text/markdown; charset=utf-8").await
+}
+
+/// GET /api/debug/logs/jsonl/latest — returns the newest errors.jsonl.*
+/// file as application/x-ndjson. Lexical sort is sufficient because the
+/// filenames embed ISO-8601 YYYY-MM-DD-HH suffixes.
+/// Returns 404 if no errors.jsonl.* file exists yet.
+pub async fn logs_jsonl_latest() -> impl IntoResponse {
+    let dir = resolve_logs_dir();
+    match newest_jsonl(&dir) {
+        Some(path) => read_text_file(&path, "application/x-ndjson; charset=utf-8").await,
+        None => (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "application/json")],
+            "{\"error\":\"no errors.jsonl file present\"}".to_string(),
+        ),
+    }
+}
+
+fn newest_jsonl(dir: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    let mut matches: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(ERRORS_JSONL_PREFIX))
+        })
+        .collect();
+    matches.sort();
+    matches.pop()
+}
+
+async fn read_text_file(
+    path: &Path,
+    content_type: &'static str,
+) -> (StatusCode, [(header::HeaderName, &'static str); 1], String) {
+    match tokio::fs::read_to_string(path).await {
+        Ok(body) => (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], body),
+        Err(_) => (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "application/json")],
+            format!(
+                "{{\"error\":\"file not found\",\"path\":\"{}\"}}",
+                path.display()
+            ),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Minimal tempdir helper — avoids pulling in the `tempfile` crate
+    /// (which isn't in the workspace deps). Returns a unique
+    /// per-invocation path under the OS temp dir. Caller is responsible
+    /// for cleanup on drop via the `DropDir` guard.
+    fn mktemp(prefix: &str) -> DropDir {
+        static CTR: AtomicU64 = AtomicU64::new(0);
+        let n = CTR.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("tv-debug-{prefix}-{pid}-{n}"));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create tmp dir");
+        DropDir(path)
+    }
+
+    struct DropDir(PathBuf);
+    impl DropDir {
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for DropDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn resolve_logs_dir_respects_env_override() {
+        // Safety: tests run serially per #[test] and read env vars.
+        // SAFETY: set_var/remove_var require a mutable environment which
+        // is safe within a single-threaded test execution.
+        unsafe {
+            std::env::set_var(LOGS_DIR_ENV, "/tmp/tickvault-debug-test");
+        }
+        let dir = resolve_logs_dir();
+        assert_eq!(dir, PathBuf::from("/tmp/tickvault-debug-test"));
+        unsafe {
+            std::env::remove_var(LOGS_DIR_ENV);
+        }
+    }
+
+    #[test]
+    fn resolve_logs_dir_default_when_env_unset() {
+        unsafe {
+            std::env::remove_var(LOGS_DIR_ENV);
+        }
+        let dir = resolve_logs_dir();
+        assert_eq!(dir, PathBuf::from(DEFAULT_LOGS_DIR));
+    }
+
+    #[test]
+    fn resolve_logs_dir_ignores_whitespace_env() {
+        unsafe {
+            std::env::set_var(LOGS_DIR_ENV, "   ");
+        }
+        let dir = resolve_logs_dir();
+        assert_eq!(dir, PathBuf::from(DEFAULT_LOGS_DIR));
+        unsafe {
+            std::env::remove_var(LOGS_DIR_ENV);
+        }
+    }
+
+    #[test]
+    fn newest_jsonl_picks_latest_by_lex_order() {
+        let tmp = mktemp("newest_jsonl");
+        let dir = tmp.path();
+        fs::write(dir.join("errors.jsonl.2026-04-18-15"), "").unwrap();
+        fs::write(dir.join("errors.jsonl.2026-04-18-17"), "").unwrap();
+        fs::write(dir.join("errors.jsonl.2026-04-18-16"), "").unwrap();
+        fs::write(dir.join("unrelated.log"), "").unwrap();
+
+        let newest = newest_jsonl(dir).expect("should find one");
+        assert!(
+            newest
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .ends_with("2026-04-18-17")
+        );
+    }
+
+    #[test]
+    fn newest_jsonl_returns_none_when_dir_empty() {
+        let tmp = mktemp("test");
+        assert!(newest_jsonl(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn newest_jsonl_returns_none_when_no_match() {
+        let tmp = mktemp("test");
+        fs::write(tmp.path().join("app.log"), "").unwrap();
+        fs::write(tmp.path().join("other.txt"), "").unwrap();
+        assert!(newest_jsonl(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn newest_jsonl_returns_none_when_dir_missing() {
+        let path = PathBuf::from("/nonexistent/path/claude-debug-test");
+        assert!(newest_jsonl(&path).is_none());
+    }
+
+    #[tokio::test]
+    async fn read_text_file_returns_404_when_missing() {
+        let path = PathBuf::from("/nonexistent/claude-debug-test.md");
+        let (status, _, body) = read_text_file(&path, "text/markdown").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(body.contains("file not found"));
+    }
+
+    #[tokio::test]
+    async fn read_text_file_returns_200_with_contents() {
+        let tmp = mktemp("test");
+        let path = tmp.path().join("summary.md");
+        fs::write(&path, "# Errors\nnovel=0\n").unwrap();
+        let (status, _, body) = read_text_file(&path, "text/markdown").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("novel=0"));
+    }
+
+    #[tokio::test]
+    async fn logs_summary_returns_404_when_file_missing() {
+        unsafe {
+            std::env::set_var(LOGS_DIR_ENV, "/nonexistent-tickvault-logs-test");
+        }
+        let response = logs_summary().await.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        unsafe {
+            std::env::remove_var(LOGS_DIR_ENV);
+        }
+    }
+
+    #[tokio::test]
+    async fn logs_jsonl_latest_returns_404_when_dir_empty() {
+        let tmp = mktemp("test");
+        unsafe {
+            std::env::set_var(LOGS_DIR_ENV, tmp.path().to_str().unwrap());
+        }
+        let response = logs_jsonl_latest().await.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        unsafe {
+            std::env::remove_var(LOGS_DIR_ENV);
+        }
+    }
+}

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 //! API request handlers.
 
+pub mod debug;
 pub mod health;
 pub mod index_constituency;
 pub mod instruments;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -144,6 +144,18 @@ pub fn build_router(state: SharedAppState, allowed_origins: &[String], dry_run: 
         .nest_service(
             "/portal/design",
             tower_http::services::ServeDir::new("ui_kits"),
+        )
+        // Autonomous-ops Layer 1 (observability): read-only log access
+        // for Claude MCP / remote sessions. See
+        // `.claude/plans/autonomous-operations-100pct.md` + the
+        // claude-mcp-access runbook.
+        .route(
+            "/api/debug/logs/summary",
+            axum::routing::get(handlers::debug::logs_summary),
+        )
+        .route(
+            "/api/debug/logs/jsonl/latest",
+            axum::routing::get(handlers::debug::logs_jsonl_latest),
         );
 
     public_routes

--- a/crates/common/tests/claude_mcp_endpoints_config_guard.rs
+++ b/crates/common/tests/claude_mcp_endpoints_config_guard.rs
@@ -1,0 +1,277 @@
+//! Guard test — Claude MCP endpoints configuration invariants.
+//!
+//! Enforces that `config/claude-mcp-endpoints.toml` is:
+//!   1. Present in the repo (committed, not gitignored)
+//!   2. Parseable as TOML
+//!   3. Has an `active` top-level string pointing at a valid profile
+//!   4. Has the three canonical profiles (local, mac-dev, aws-prod)
+//!   5. Every profile has all 7 required keys
+//!   6. Every URL-typed key is a valid-looking HTTP(S) URL
+//!
+//! Milestone 1 of `.claude/plans/autonomous-operations-100pct.md`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+const REQUIRED_PROFILES: &[&str] = &["local", "mac-dev", "aws-prod"];
+const REQUIRED_URL_KEYS: &[&str] = &[
+    "prometheus_url",
+    "alertmanager_url",
+    "questdb_url",
+    "grafana_url",
+    "tickvault_api_url",
+];
+const REQUIRED_NON_URL_KEYS: &[&str] = &["logs_source", "logs_dir_local"];
+
+#[derive(Debug, Deserialize)]
+struct EndpointsConfig {
+    active: String,
+    profiles: HashMap<String, Profile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Profile {
+    prometheus_url: String,
+    alertmanager_url: String,
+    questdb_url: String,
+    grafana_url: String,
+    tickvault_api_url: String,
+    logs_source: String,
+    logs_dir_local: String,
+}
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = <repo>/crates/common → walk up two levels
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().parent().unwrap().to_path_buf()
+}
+
+fn load_config() -> (String, EndpointsConfig) {
+    let path = repo_root().join("config/claude-mcp-endpoints.toml");
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!(
+            "config/claude-mcp-endpoints.toml is missing or unreadable: {err}\n\
+             Path checked: {}",
+            path.display()
+        )
+    });
+    let parsed: EndpointsConfig = toml::from_str(&raw)
+        .unwrap_or_else(|err| panic!("config/claude-mcp-endpoints.toml failed to parse: {err}"));
+    (raw, parsed)
+}
+
+#[test]
+fn config_file_exists_and_parses() {
+    // Just calling load_config performs both checks; panics carry context.
+    let _ = load_config();
+}
+
+#[test]
+fn active_profile_key_must_reference_an_existing_profile() {
+    let (_, cfg) = load_config();
+    assert!(
+        cfg.profiles.contains_key(&cfg.active),
+        "active='{}' references a profile not present in [profiles.*]; \
+         available profiles: {:?}",
+        cfg.active,
+        cfg.profiles.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn all_required_profiles_are_present() {
+    let (_, cfg) = load_config();
+    for name in REQUIRED_PROFILES {
+        assert!(
+            cfg.profiles.contains_key(*name),
+            "[profiles.{name}] section is required but missing from \
+             config/claude-mcp-endpoints.toml"
+        );
+    }
+}
+
+#[test]
+fn every_profile_has_all_required_keys() {
+    let (raw, _cfg) = load_config();
+    // Re-parse loosely so we can surface missing-key errors per profile
+    // with clearer diagnostics than the derived Deserialize gives.
+    let loose: toml::Value = toml::from_str(&raw).expect("already parses");
+    let profiles = loose
+        .get("profiles")
+        .and_then(|v| v.as_table())
+        .expect("[profiles.*] must be a table");
+    for name in REQUIRED_PROFILES {
+        let profile = profiles
+            .get(*name)
+            .and_then(|v| v.as_table())
+            .unwrap_or_else(|| panic!("[profiles.{name}] missing"));
+        for key in REQUIRED_URL_KEYS {
+            assert!(
+                profile.contains_key(*key),
+                "[profiles.{name}] missing required URL key '{key}'"
+            );
+        }
+        for key in REQUIRED_NON_URL_KEYS {
+            assert!(
+                profile.contains_key(*key),
+                "[profiles.{name}] missing required key '{key}'"
+            );
+        }
+    }
+}
+
+#[test]
+fn all_url_keys_look_like_http_or_https() {
+    let (_, cfg) = load_config();
+    for (name, profile) in &cfg.profiles {
+        for (key, value) in [
+            ("prometheus_url", &profile.prometheus_url),
+            ("alertmanager_url", &profile.alertmanager_url),
+            ("questdb_url", &profile.questdb_url),
+            ("grafana_url", &profile.grafana_url),
+            ("tickvault_api_url", &profile.tickvault_api_url),
+        ] {
+            assert!(
+                value.starts_with("http://") || value.starts_with("https://"),
+                "[profiles.{name}].{key} must start with http:// or https://, got: {value}"
+            );
+        }
+    }
+}
+
+#[test]
+fn logs_source_is_http_or_local_everywhere() {
+    let (_, cfg) = load_config();
+    for (name, profile) in &cfg.profiles {
+        assert!(
+            profile.logs_source == "http" || profile.logs_source == "local",
+            "[profiles.{name}].logs_source must be 'http' or 'local', got '{}'",
+            profile.logs_source
+        );
+        assert!(
+            !profile.logs_dir_local.trim().is_empty(),
+            "[profiles.{name}].logs_dir_local must be non-empty (used \
+             as filesystem fallback when logs_source='local')"
+        );
+    }
+}
+
+#[test]
+fn local_profile_uses_localhost_not_tailscale() {
+    // The "local" fallback profile MUST point at 127.0.0.1 so that Mode A
+    // (Claude on Mac + tickvault on Mac) works with no tunnel and no
+    // committed Tailscale hostname. Prevents accidental overwrites of the
+    // local profile with real hostnames.
+    let (_, cfg) = load_config();
+    let local = cfg
+        .profiles
+        .get("local")
+        .expect("local profile presence already asserted");
+    for url in [
+        &local.prometheus_url,
+        &local.alertmanager_url,
+        &local.questdb_url,
+        &local.grafana_url,
+        &local.tickvault_api_url,
+    ] {
+        assert!(
+            url.contains("127.0.0.1") || url.contains("localhost"),
+            "[profiles.local] URLs must point at localhost, got: {url}"
+        );
+    }
+}
+
+#[test]
+fn tunnel_install_scripts_exist_and_are_executable() {
+    // Hand-in-glove with the config: the tunnel install scripts must exist
+    // so the one-command setup in the runbook actually works. If someone
+    // deletes install-mac.sh or install-aws.sh without updating the runbook,
+    // this test fails the build.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let root = repo_root();
+        for name in ["install-mac.sh", "install-aws.sh", "doctor.sh"] {
+            let path = root.join("scripts/tv-tunnel").join(name);
+            let meta = std::fs::metadata(&path)
+                .unwrap_or_else(|err| panic!("tunnel script missing: {} ({err})", path.display()));
+            let mode = meta.permissions().mode();
+            // Owner execute bit: 0o100
+            assert!(
+                mode & 0o100 != 0,
+                "{} exists but is not executable (mode: {:o})",
+                path.display(),
+                mode
+            );
+        }
+        // plist + service unit don't need to be executable, just present.
+        for name in ["com.tickvault.tunnel.plist", "tickvault-tunnel.service"] {
+            let path = root.join("scripts/tv-tunnel").join(name);
+            assert!(
+                path.is_file(),
+                "tunnel unit template missing: {}",
+                path.display()
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // On non-unix, just assert files exist.
+        let root = repo_root();
+        for name in [
+            "install-mac.sh",
+            "install-aws.sh",
+            "doctor.sh",
+            "com.tickvault.tunnel.plist",
+            "tickvault-tunnel.service",
+        ] {
+            let path = root.join("scripts/tv-tunnel").join(name);
+            assert!(path.is_file(), "tunnel file missing: {}", path.display());
+        }
+    }
+}
+
+#[test]
+fn mcp_server_reads_config_file_before_env_vars() {
+    // Source-scan guard: the MCP server source MUST call _endpoint_url
+    // (the config-aware resolver), not bare os.environ.get for the 5
+    // endpoint URLs. Prevents regression where someone reverts to plain
+    // env-var lookups and breaks the committed-config contract.
+    let path = repo_root().join("scripts/mcp-servers/tickvault-logs/server.py");
+    let src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("MCP server source missing at {}", path.display()));
+
+    // Every endpoint URL lookup must use _endpoint_url(...).
+    for kind in [
+        "prometheus_url",
+        "questdb_url",
+        "alertmanager_url",
+        "tickvault_api_url",
+        "grafana_url",
+    ] {
+        assert!(
+            src.contains(&format!("\"{kind}\"")),
+            "MCP server source must reference profile key '{kind}' via _endpoint_url"
+        );
+    }
+    // No bare os.environ.get of the legacy env vars for URL resolution.
+    for env in [
+        "TICKVAULT_PROMETHEUS_URL",
+        "TICKVAULT_ALERTMANAGER_URL",
+        "TICKVAULT_QUESTDB_URL",
+        "TICKVAULT_API_URL",
+        "TICKVAULT_GRAFANA_URL",
+    ] {
+        // The env var CAN appear (it's passed to _endpoint_url), but
+        // NOT in the `base_url or os.environ.get(...)` pattern that the
+        // config loader replaced. Detect the banned pattern.
+        let banned = format!("or os.environ.get(\n        \"{env}\"");
+        assert!(
+            !src.contains(&banned),
+            "MCP server has legacy `base_url or os.environ.get(\"{env}\"...)` \
+             pattern — use _endpoint_url() instead"
+        );
+    }
+}

--- a/docs/runbooks/claude-mcp-access.md
+++ b/docs/runbooks/claude-mcp-access.md
@@ -1,42 +1,101 @@
-# Claude MCP Access Runbook
+# Claude MCP Access Runbook — Universal, Branch-Independent
 
-> **Purpose:** make Claude Code able to read tickvault logs, Prometheus,
-> Alertmanager, and QuestDB WITHOUT the operator pasting screenshots or
-> query output. The user should NEVER have to forward data manually.
+> **Purpose:** every Claude Code session, every claude.ai web sandbox,
+> every claude cowork session — on any branch, any machine — can read
+> tickvault's full runtime state (metrics, logs, alerts, DB) WITHOUT
+> the operator pasting screenshots or query output.
+>
+> **Design principle:** the config lives IN THE REPO, not in
+> per-session env vars. One-time tunnel setup per environment, forever
+> after every clone has working endpoints.
 
-## The three deployment modes
+This is **Milestone 1** of the Autonomous Operations Plan
+(`.claude/plans/autonomous-operations-100pct.md`). It is the prerequisite
+for Layers 2-5 (Diagnose / Decide / Act / Verify+Rollback) — without
+observability access from any Claude session, nothing else works.
 
-| Mode | Where Claude Code runs | Where tickvault runs | What to configure |
+## TL;DR — what you run, once per environment
+
+| You are | Tickvault is | One-time command | Forever after |
 |---|---|---|---|
-| A | Your Mac | Your Mac | Nothing — defaults work |
-| B | Your Mac | AWS EC2 | Set 4 env vars pointing at AWS |
-| C | Sandbox / other host | Your Mac (or AWS) | Expose endpoints via tunnel, set 4 env vars |
+| On your Mac (Claude Code CLI) | Running locally on the same Mac | Nothing | MCP works against `127.0.0.1` |
+| On your Mac, but need remote Claude access | Running locally on the Mac | `bash scripts/tv-tunnel/install-mac.sh` | Remote Claude reads live via Tailscale Funnel |
+| On your Mac | Running on AWS EC2 | `bash scripts/tv-tunnel/install-aws.sh` (on EC2) | Mac Claude + remote Claude both read live via Funnel |
+| In a claude.ai sandbox / claude cowork | Running on Mac or AWS | Same as above (installed on host) | Sandbox Claude reads live via committed repo URLs |
 
-The MCP server `tickvault-logs` reads these seven inputs:
+After install-mac.sh / install-aws.sh runs:
+- Tailscale Funnel auto-starts on reboot (launchd on Mac, systemd on AWS)
+- Ports 9090/9093/9000/3000/3001 are exposed via stable `.ts.net` URLs
+- The URLs never change
+- Write them into `config/claude-mcp-endpoints.toml`, commit, push
+- Every future clone of the repo has working MCP — zero per-session setup
 
-| Input | Default | Env var to override |
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Claude session (anywhere: Mac, web, sandbox, cowork)        │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ tickvault-logs MCP server (Python, local to session)  │   │
+│ │  ↓ reads config/claude-mcp-endpoints.toml             │   │
+│ │  ↓ selects active profile (mac-dev | aws-prod | local)│   │
+│ └────────┬──────────────────────────────────────────────┘   │
+└──────────│──────────────────────────────────────────────────┘
+           │ HTTPS
+           ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Tailscale Funnel (stable public URL on .ts.net)              │
+│ mac-hostname.your-tailnet.ts.net:9090  → Prometheus         │
+│ mac-hostname.your-tailnet.ts.net:9093  → Alertmanager       │
+│ mac-hostname.your-tailnet.ts.net:9000  → QuestDB HTTP       │
+│ mac-hostname.your-tailnet.ts.net:3000  → Grafana            │
+│ mac-hostname.your-tailnet.ts.net:3001  → tickvault API      │
+│                                         ├── /api/debug/logs/summary         │
+│                                         └── /api/debug/logs/jsonl/latest    │
+└──────────────────────────────────────────────────────────────┘
+           ↓ (Mac launchd | AWS systemd restarts on crash/reboot)
+┌──────────────────────────────────────────────────────────────┐
+│ Your tickvault Docker stack (localhost)                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Key properties:
+- **Stable URLs**: `.ts.net` hostnames never change across Tailscale restarts.
+- **Branch-independent**: endpoints in repo, so every branch checkout works.
+- **Universal**: works identically on Mac dev, AWS prod, claude.ai sandbox.
+- **Logs over HTTP, not filesystem**: `/api/debug/logs/*` eliminates rsync.
+- **Auto-heal**: launchd/systemd restart the funnel on crash or reboot.
+
+## Seven inputs the MCP server reads
+
+Read from `config/claude-mcp-endpoints.toml` under the active profile.
+Env vars (when set) override the file. The file overrides hardcoded
+localhost defaults.
+
+| Input | Env override | Profile key |
 |---|---|---|
-| errors.jsonl directory | `<repo>/data/logs` | `TICKVAULT_LOGS_DIR` |
-| Prometheus | `http://127.0.0.1:9090` | `TICKVAULT_PROMETHEUS_URL` |
-| Alertmanager | `http://127.0.0.1:9093` | `TICKVAULT_ALERTMANAGER_URL` |
-| QuestDB | `http://127.0.0.1:9000` | `TICKVAULT_QUESTDB_URL` |
-| tickvault API | `http://127.0.0.1:3001` | `TICKVAULT_API_URL` |
-| Grafana | `http://127.0.0.1:3000` | `TICKVAULT_GRAFANA_URL` |
-| Grafana API token | _none_ | `TICKVAULT_GRAFANA_API_TOKEN` |
+| Prometheus URL | `TICKVAULT_PROMETHEUS_URL` | `prometheus_url` |
+| Alertmanager URL | `TICKVAULT_ALERTMANAGER_URL` | `alertmanager_url` |
+| QuestDB HTTP URL | `TICKVAULT_QUESTDB_URL` | `questdb_url` |
+| Grafana URL | `TICKVAULT_GRAFANA_URL` | `grafana_url` |
+| tickvault API URL | `TICKVAULT_API_URL` | `tickvault_api_url` |
+| Logs source | `TICKVAULT_LOGS_SOURCE` (`http` or `local`) | `logs_source` |
+| Logs directory (when `local`) | `TICKVAULT_LOGS_DIR` | `logs_dir_local` |
 
-`.mcp.json` passes all seven env vars through to the server, so
-setting them in your shell (or in your `.envrc` / `.zshenv`) is
-enough — no need to edit `.mcp.json` per environment.
+Profile selection order:
+1. `TICKVAULT_MCP_PROFILE` env var (single-session override)
+2. `active = "<name>"` at the top of `claude-mcp-endpoints.toml`
+3. Fallback to `"local"` (everything on `127.0.0.1`)
 
 ## Full MCP tool surface (16 tools)
 
-Every surface of the tickvault stack is reachable through one MCP
-server — no screenshots, no copy-paste.
+Every surface of the tickvault stack is reachable through one MCP server
+— no screenshots, no copy-paste, no manual tailing.
 
 | Tool | What it reads |
 |---|---|
-| `summary_snapshot` | `errors.summary.md` |
-| `tail_errors` | `errors.jsonl.*` |
+| `summary_snapshot` | `errors.summary.md` (local OR via `/api/debug/logs/summary`) |
+| `tail_errors` | `errors.jsonl.*` (local OR via `/api/debug/logs/jsonl/latest`) |
 | `list_novel_signatures` | first-seen signatures over a time window |
 | `signature_history` | all events matching a signature hash |
 | `triage_log_tail` | `data/logs/auto-fix.log` |
@@ -47,110 +106,136 @@ server — no screenshots, no copy-paste.
 | `run_doctor` | `make doctor` parsed output |
 | `grep_codebase` | ripgrep over workspace |
 | `git_recent_log` | last N commits |
-| `tickvault_api` | **any tickvault REST API endpoint** |
-| `grafana_query` | **any Grafana HTTP API endpoint** |
-| `docker_status` | **`docker compose ps --format json`** |
-| `app_log_tail` | **full INFO/DEBUG app log** |
+| `tickvault_api` | any tickvault REST API endpoint |
+| `grafana_query` | any Grafana HTTP API endpoint |
+| `docker_status` | `docker compose ps --format json` |
+| `app_log_tail` | full INFO/DEBUG app log |
 
-## Mode A — Mac-local (simplest, recommended)
+## Mode A — Claude on Mac, tickvault on Mac (simplest)
 
 ```bash
-# On the Mac, in the tickvault repo root:
+# On the Mac, in the tickvault repo root
 make run                 # starts Docker + tickvault
-claude                   # launches Claude Code on the Mac
+claude                   # launches Claude Code
 ```
 
-Nothing to configure. The MCP server reads `./data/logs/` and
-`localhost:9000/9090/9093` directly.
+Active profile: `local` (or whichever is set in the committed config).
+No tunnel, no env vars. Logs read from `./data/logs/` directly.
 
 Verify:
-
 ```bash
 bash scripts/mcp-doctor.sh
-# Expect: all 4 checks PASS.
 ```
 
 ## Mode B — Claude on Mac, tickvault on AWS EC2
 
-Add to `~/.zshenv` (or your shell rc):
+1. On AWS: `bash scripts/tv-tunnel/install-aws.sh` (see "One-time AWS setup" below).
+2. On Mac: edit `config/claude-mcp-endpoints.toml`, set `active = "aws-prod"`, commit, push.
+3. On Mac: `claude` — it now queries the AWS stack live.
+
+## Mode C — Claude in a sandbox / claude.ai / cowork (universal)
+
+This replaces the old (broken) Mode C that assumed SSH reverse tunnels —
+sandboxes can't accept inbound connections.
+
+### C.1 — One-time Mac setup
 
 ```bash
-export TICKVAULT_PROMETHEUS_URL="https://<your-ec2-public-dns>:9090"
-export TICKVAULT_ALERTMANAGER_URL="https://<your-ec2-public-dns>:9093"
-export TICKVAULT_QUESTDB_URL="https://<your-ec2-public-dns>:9000"
-# Keep logs local via SSH rsync cron OR point at a shared EFS mount:
-export TICKVAULT_LOGS_DIR="$HOME/tickvault-logs-sync"
+bash scripts/tv-tunnel/install-mac.sh
 ```
 
-Set up a rsync cron on the Mac (every 30s is enough because the summary
-is refreshed every 60s):
+The script:
+- Verifies macOS, installs Tailscale via brew if missing
+- Launches `tailscale up` (login flow in browser) if not already logged in
+- Verifies Funnel feature is enabled on your tailnet (if not, points you to the admin ACL URL)
+- Installs `~/Library/LaunchAgents/com.tickvault.tunnel.plist`
+- Loads the launchd service, which calls `tailscale funnel --bg 9090 9093 9000 3000 3001`
+- Probes for the funnel to come up within 30s
+- Prints your stable URLs — paste them into `config/claude-mcp-endpoints.toml`
 
-```cron
-* * * * * rsync -az --delete ec2-user@<ec2>:/home/ec2-user/tickvault/data/logs/ ~/tickvault-logs-sync/
-```
-
-Restart Claude Code so it picks up the new env. Verify with
-`scripts/mcp-doctor.sh`.
-
-## Mode C — Claude in a sandbox (gVisor / container / web)
-
-This is the case where `127.0.0.1:9000` inside the sandbox is NOT your
-Mac. There are two supported sub-modes.
-
-### C.1 — Tailscale
-
-1. Install Tailscale on the Mac AND on the sandbox host.
-2. Join both to the same tailnet.
-3. On the Mac, find your Tailscale IP (`tailscale ip -4`).
-4. In the sandbox shell:
-   ```bash
-   export TICKVAULT_PROMETHEUS_URL="http://<tailscale-ip>:9090"
-   export TICKVAULT_ALERTMANAGER_URL="http://<tailscale-ip>:9093"
-   export TICKVAULT_QUESTDB_URL="http://<tailscale-ip>:9000"
-   ```
-5. Mount the Mac's `data/logs/` into the sandbox (e.g. `tailscale serve
-   --bg 8080` + filesystem sync, or Syncthing, or a scp cron).
-6. Point `TICKVAULT_LOGS_DIR` at the mount point.
-
-### C.2 — SSH reverse tunnel
-
-Single command from the Mac:
+### C.2 — One-time AWS setup (when EC2 is provisioned)
 
 ```bash
-ssh -N -R 9090:localhost:9090 \
-       -R 9093:localhost:9093 \
-       -R 9000:localhost:9000 \
-       <sandbox-user>@<sandbox-host>
+# On the EC2 instance
+bash scripts/tv-tunnel/install-aws.sh
 ```
 
-Then inside the sandbox, the defaults `http://127.0.0.1:9090` etc. work
-unchanged. Still need to sync `data/logs/` separately (see C.1 step 5).
+Same flow, but installs `/etc/systemd/system/tickvault-tunnel.service`
+and uses `systemctl enable --now`.
 
-## Mode C limitations (honest)
+### C.3 — One-time repo update
 
-- The log files must physically exist on the host Claude runs on, or
-  appear there via a file-sync mechanism. The MCP server reads files
-  with Python `open()` — there is no "fetch over HTTP" mode.
-- If you don't want to run a sync job, Mode A is the right answer.
+After one or both installs finish, run the doctor in emit-config mode:
+
+```bash
+bash scripts/tv-tunnel/doctor.sh --emit-config
+```
+
+This prints a TOML block like:
+```toml
+[profiles.mac-dev]
+prometheus_url    = "https://your-mac.tailnet-name.ts.net:9090"
+alertmanager_url  = "https://your-mac.tailnet-name.ts.net:9093"
+questdb_url       = "https://your-mac.tailnet-name.ts.net:9000"
+grafana_url       = "https://your-mac.tailnet-name.ts.net:3000"
+tickvault_api_url = "https://your-mac.tailnet-name.ts.net:3001"
+logs_source       = "http"
+logs_dir_local    = "./data/logs"
+```
+
+Paste it into `config/claude-mcp-endpoints.toml` (replacing the
+placeholder Mac or AWS profile), set `active = "mac-dev"` or
+`"aws-prod"`, commit, push.
+
+Any Claude session on any branch from that point on reads live data.
 
 ## Verification — after ANY mode change
 
 ```bash
-bash scripts/mcp-doctor.sh
+bash scripts/mcp-doctor.sh            # MCP-level probes (4 checks)
+bash scripts/tv-tunnel/doctor.sh       # Tunnel-level probes (7 checks)
 ```
 
-All 4 checks must pass. If any fails, the specific check name tells
-you exactly which endpoint is unreachable.
+Both should exit 0.
 
 ## When Claude cannot reach a specific service
 
-Claude will tell you honestly which service is unreachable (via
-`mcp-doctor.sh` output or via the MCP tool's error response). Claude
-will NOT fabricate status for unreachable services.
+Claude reports honestly which endpoint is unreachable (via the
+`mcp-doctor.sh` or `tv-tunnel/doctor.sh` output, or directly via the
+MCP tool's error response). Claude never fabricates status for
+unreachable services.
 
 ## Tests that guard this
 
-- `crates/common/tests/tickvault_logs_mcp_guard.rs` — enforces the MCP
+- `crates/common/tests/tickvault_logs_mcp_guard.rs` — enforces MCP
   server tool set + self-test.
 - `scripts/validate-automation.sh` check `tickvault-logs MCP self-test
-  passes` — runs every time you `make validate-automation`.
+  passes` — runs every `make validate-automation`.
+- `crates/api/src/handlers/debug.rs` unit tests — 11 tests covering
+  route handlers, env-var resolution, missing-file handling.
+- `crates/common/tests/claude_mcp_endpoints_config_guard.rs` — enforces
+  the committed config file contains all required profile keys and is
+  parseable by the MCP server.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `tailscale funnel status` says "inactive" | `sudo launchctl load -w ~/Library/LaunchAgents/com.tickvault.tunnel.plist` (Mac) / `sudo systemctl start tickvault-tunnel` (AWS) |
+| Funnel status OK but curl returns 000 | Check tickvault Docker is up: `make docker-status` |
+| MCP always hits localhost | Check `active = "mac-dev"` or `aws-prod"` in `config/claude-mcp-endpoints.toml` — default is `local` |
+| Need to point session at different env | `TICKVAULT_MCP_PROFILE=aws-prod claude` — overrides committed config for that session only |
+| `/api/debug/logs/summary` returns 404 | App hasn't written `errors.summary.md` yet (60s refresh cadence). Check `ls data/logs/errors.summary.md` on the host. |
+
+## Security notes
+
+- Tailscale Funnel exposes to the public internet via HTTPS. Access is
+  gated by the Funnel feature's per-node ACL.
+- The debug log endpoints return ERROR signatures and metric values
+  only — never auth tokens, order payloads, or user PII.
+- tickvault's protected endpoints (order place/cancel) remain behind
+  `TV_API_TOKEN` bearer auth. The debug endpoints are read-only and
+  intentionally outside that wall so observability is always available.
+- The Dhan access token, AWS credentials, and private keys are never
+  logged to `errors.jsonl` (enforced by
+  `.claude/hooks/banned-pattern-scanner.sh`).

--- a/scripts/mcp-servers/tickvault-logs/server.py
+++ b/scripts/mcp-servers/tickvault-logs/server.py
@@ -29,23 +29,136 @@ from typing import Any, Iterable
 
 
 # ---------------------------------------------------------------------------
-# Configuration
+# Configuration — universal, branch-independent endpoints
 # ---------------------------------------------------------------------------
+#
+# Resolution order for every endpoint URL (prom/questdb/alertmanager/...):
+#   1. Explicit `base_url` argument passed to the tool (single-call override)
+#   2. Env var TICKVAULT_<KIND>_URL (session-level override)
+#   3. Active profile in config/claude-mcp-endpoints.toml (universal default)
+#   4. Hardcoded localhost default (Mode A — everything on 127.0.0.1)
+#
+# The config file is committed to the repo so every clone on every branch
+# inherits working endpoints without per-session setup.
+
+_ENDPOINTS_CONFIG_FILENAME = "claude-mcp-endpoints.toml"
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    # scripts/mcp-servers/tickvault-logs/server.py -> repo root
+    return here.parent.parent.parent.parent
+
+
+def _endpoints_config_path() -> Path:
+    override = os.environ.get("TICKVAULT_MCP_ENDPOINTS_CONFIG")
+    if override:
+        return Path(override)
+    return _repo_root() / "config" / _ENDPOINTS_CONFIG_FILENAME
+
+
+_ENDPOINTS_CACHE: dict[str, Any] | None = None
+
+
+def _load_endpoints_config() -> dict[str, Any]:
+    """Parse config/claude-mcp-endpoints.toml once per process.
+
+    Returns {"active": <profile>, "profiles": {<name>: {<kind>: <url>}}}.
+    Falls back to {"active": "local", "profiles": {}} if the file is
+    missing or unparseable — we never want the MCP server to crash just
+    because the config file is absent.
+    """
+    global _ENDPOINTS_CACHE
+    if _ENDPOINTS_CACHE is not None:
+        return _ENDPOINTS_CACHE
+    path = _endpoints_config_path()
+    result: dict[str, Any] = {"active": "local", "profiles": {}}
+    if not path.is_file():
+        _ENDPOINTS_CACHE = result
+        return result
+    try:
+        import tomllib  # Python 3.11+
+        with path.open("rb") as fh:
+            parsed = tomllib.load(fh)
+    except Exception:  # noqa: BLE001
+        # Best-effort: if the file is malformed, fall back to defaults
+        # instead of crashing the MCP server.
+        _ENDPOINTS_CACHE = result
+        return result
+    if isinstance(parsed.get("active"), str):
+        result["active"] = parsed["active"]
+    profiles = parsed.get("profiles", {})
+    if isinstance(profiles, dict):
+        for name, cfg in profiles.items():
+            if isinstance(cfg, dict):
+                result["profiles"][name] = cfg
+    _ENDPOINTS_CACHE = result
+    return result
+
+
+def _active_profile() -> str:
+    override = os.environ.get("TICKVAULT_MCP_PROFILE")
+    if override:
+        return override
+    return _load_endpoints_config().get("active", "local")
+
+
+def _endpoint_url(
+    kind: str,
+    env_var: str,
+    default: str,
+    explicit: str | None = None,
+) -> str:
+    """Resolve an endpoint URL via the 4-tier precedence order.
+
+    `kind` is the key in the profile config (e.g. "prometheus_url").
+    `env_var` is the legacy env-var override (e.g. "TICKVAULT_PROMETHEUS_URL").
+    `default` is the Mode A localhost fallback.
+    `explicit` is a single-call override from the tool invocation.
+    """
+    if explicit:
+        return explicit
+    from_env = os.environ.get(env_var)
+    if from_env:
+        return from_env
+    profile = _active_profile()
+    profile_cfg = _load_endpoints_config().get("profiles", {}).get(profile, {})
+    from_config = profile_cfg.get(kind)
+    if isinstance(from_config, str) and from_config:
+        return from_config
+    return default
 
 
 def _logs_dir() -> Path:
     override = os.environ.get("TICKVAULT_LOGS_DIR")
     if override:
         return Path(override)
-    # Default: repo_root/data/logs relative to this file.
-    here = Path(__file__).resolve()
-    # scripts/mcp-servers/tickvault-logs/server.py -> repo root
-    return here.parent.parent.parent.parent / "data" / "logs"
+    profile = _active_profile()
+    profile_cfg = _load_endpoints_config().get("profiles", {}).get(profile, {})
+    from_config = profile_cfg.get("logs_dir_local")
+    if isinstance(from_config, str) and from_config:
+        cfg_path = Path(from_config)
+        if not cfg_path.is_absolute():
+            cfg_path = _repo_root() / cfg_path
+        return cfg_path
+    return _repo_root() / "data" / "logs"
+
+
+def _logs_source() -> str:
+    """Return "http" or "local" — how the MCP should fetch log files."""
+    override = os.environ.get("TICKVAULT_LOGS_SOURCE")
+    if override in {"http", "local"}:
+        return override
+    profile = _active_profile()
+    profile_cfg = _load_endpoints_config().get("profiles", {}).get(profile, {})
+    source = profile_cfg.get("logs_source")
+    if source in {"http", "local"}:
+        return source
+    return "local"
 
 
 def _state_dir() -> Path:
-    here = Path(__file__).resolve()
-    return here.parent.parent.parent.parent / ".claude" / "state"
+    return _repo_root() / ".claude" / "state"
 
 
 ERRORS_JSONL_PREFIX = "errors.jsonl"
@@ -303,8 +416,11 @@ def tool_prometheus_query(query: str, base_url: str | None = None) -> dict[str, 
     import urllib.parse
     import urllib.request
 
-    prom_url = base_url or os.environ.get(
-        "TICKVAULT_PROMETHEUS_URL", "http://127.0.0.1:9090"
+    prom_url = _endpoint_url(
+        "prometheus_url",
+        "TICKVAULT_PROMETHEUS_URL",
+        "http://127.0.0.1:9090",
+        explicit=base_url,
     )
     full = f"{prom_url}/api/v1/query?query={urllib.parse.quote(query)}"
     try:
@@ -376,8 +492,11 @@ def tool_questdb_sql(query: str, base_url: str | None = None) -> dict[str, Any]:
     import urllib.parse
     import urllib.request
 
-    qdb = base_url or os.environ.get(
-        "TICKVAULT_QUESTDB_URL", "http://127.0.0.1:9000"
+    qdb = _endpoint_url(
+        "questdb_url",
+        "TICKVAULT_QUESTDB_URL",
+        "http://127.0.0.1:9000",
+        explicit=base_url,
     )
     full = f"{qdb}/exec?query={urllib.parse.quote(query)}"
     try:
@@ -554,8 +673,11 @@ def tool_list_active_alerts(base_url: str | None = None) -> dict[str, Any]:
     """
     import urllib.request
 
-    am_url = base_url or os.environ.get(
-        "TICKVAULT_ALERTMANAGER_URL", "http://127.0.0.1:9093"
+    am_url = _endpoint_url(
+        "alertmanager_url",
+        "TICKVAULT_ALERTMANAGER_URL",
+        "http://127.0.0.1:9093",
+        explicit=base_url,
     )
     full = f"{am_url}/api/v2/alerts?active=true&silenced=false&inhibited=false"
     try:
@@ -594,8 +716,11 @@ def tool_tickvault_api(
     """
     import urllib.request
 
-    api_url = base_url or os.environ.get(
-        "TICKVAULT_API_URL", "http://127.0.0.1:3001"
+    api_url = _endpoint_url(
+        "tickvault_api_url",
+        "TICKVAULT_API_URL",
+        "http://127.0.0.1:3001",
+        explicit=base_url,
     )
     if not path.startswith("/"):
         path = f"/{path}"
@@ -634,8 +759,11 @@ def tool_grafana_query(
     """
     import urllib.request
 
-    gf_url = base_url or os.environ.get(
-        "TICKVAULT_GRAFANA_URL", "http://127.0.0.1:3000"
+    gf_url = _endpoint_url(
+        "grafana_url",
+        "TICKVAULT_GRAFANA_URL",
+        "http://127.0.0.1:3000",
+        explicit=base_url,
     )
     if not endpoint.startswith("/"):
         endpoint = f"/{endpoint}"

--- a/scripts/tv-tunnel/com.tickvault.tunnel.plist
+++ b/scripts/tv-tunnel/com.tickvault.tunnel.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  tv-tunnel launchd agent — starts Tailscale Funnel for tickvault's 5
+  observability ports on Mac boot. Installed by install-mac.sh into
+  ~/Library/LaunchAgents/ so it runs under the logged-in user, not root.
+
+  The @TAILSCALE_BIN@ placeholder is substituted at install time because
+  the Tailscale app path may vary between standard Mac App Store
+  installs and brew cask installs.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.tickvault.tunnel</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>@TAILSCALE_BIN@</string>
+    <string>funnel</string>
+    <string>--bg</string>
+    <string>9090</string>
+    <string>9093</string>
+    <string>9000</string>
+    <string>3000</string>
+    <string>3001</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/tickvault-tunnel.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/tmp/tickvault-tunnel.err.log</string>
+
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+</dict>
+</plist>

--- a/scripts/tv-tunnel/doctor.sh
+++ b/scripts/tv-tunnel/doctor.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# tv-tunnel doctor.sh — verify the Tailscale Funnel exposes all 5 ports
+# and that the tickvault services behind them respond.
+#
+# Run on either Mac or AWS. Also usable as `--emit-config` to produce a
+# TOML snippet ready to paste into config/claude-mcp-endpoints.toml.
+
+set -u
+
+c_green="\033[0;32m"
+c_yellow="\033[0;33m"
+c_red="\033[0;31m"
+c_reset="\033[0m"
+pass() { printf "${c_green}[PASS]${c_reset} %s\n" "$*"; }
+fail_row() { printf "${c_red}[FAIL]${c_reset} %s\n" "$*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+warn() { printf "${c_yellow}[WARN]${c_reset} %s\n" "$*"; }
+info() { printf "  %s\n" "$*"; }
+
+FAIL_COUNT=0
+EMIT_CONFIG=0
+if [[ "${1:-}" == "--emit-config" ]]; then
+  EMIT_CONFIG=1
+fi
+
+# Resolve tailscale binary for macOS vs Linux
+if [[ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]]; then
+  TS_BIN=/Applications/Tailscale.app/Contents/MacOS/Tailscale
+elif command -v tailscale >/dev/null 2>&1; then
+  TS_BIN=$(command -v tailscale)
+else
+  fail_row "tailscale binary not found"
+  exit 1
+fi
+
+HOSTNAME_FQDN="$($TS_BIN status --json 2>/dev/null | awk -F '"' '/"DNSName":/{print $4; exit}' | sed 's/\.$//')"
+[[ -z "$HOSTNAME_FQDN" ]] && { fail_row "tailscale not logged in"; exit 1; }
+
+declare -a PORTS=(9090 9093 9000 3000 3001)
+declare -A NAMES=(
+  [9090]="Prometheus"
+  [9093]="Alertmanager"
+  [9000]="QuestDB HTTP"
+  [3000]="Grafana"
+  [3001]="tickvault API"
+)
+declare -A PATHS=(
+  [9090]="/-/ready"
+  [9093]="/-/ready"
+  [9000]="/"
+  [3000]="/api/health"
+  [3001]="/health"
+)
+
+if [[ $EMIT_CONFIG -eq 1 ]]; then
+  # Emit a TOML snippet and exit — no probing, just URL rendering
+  host_dashed="${HOSTNAME_FQDN//./-}"
+  profile_name=$([[ "$(uname -s)" == "Darwin" ]] && echo "mac-dev" || echo "aws-prod")
+  echo "# Paste under [profiles.${profile_name}] in config/claude-mcp-endpoints.toml"
+  echo "[profiles.${profile_name}]"
+  echo "prometheus_url    = \"https://${HOSTNAME_FQDN}:9090\""
+  echo "alertmanager_url  = \"https://${HOSTNAME_FQDN}:9093\""
+  echo "questdb_url       = \"https://${HOSTNAME_FQDN}:9000\""
+  echo "grafana_url       = \"https://${HOSTNAME_FQDN}:3000\""
+  echo "tickvault_api_url = \"https://${HOSTNAME_FQDN}:3001\""
+  echo "logs_source       = \"http\""
+  echo "logs_dir_local    = \"./data/logs\""
+  exit 0
+fi
+
+echo "==========================================================="
+echo "  tv-tunnel doctor — ${HOSTNAME_FQDN}"
+echo "==========================================================="
+
+# 1. Check funnel status
+if $TS_BIN funnel status 2>/dev/null | grep -q "https"; then
+  pass "tailscale funnel active"
+else
+  fail_row "tailscale funnel inactive — run install-mac.sh or install-aws.sh"
+fi
+
+# 2. Probe each port
+for port in "${PORTS[@]}"; do
+  name=${NAMES[$port]}
+  path=${PATHS[$port]}
+  url="https://${HOSTNAME_FQDN}:${port}${path}"
+  code=$(curl -s -o /dev/null -m 5 -w "%{http_code}" "$url" || echo "000")
+  if [[ "$code" =~ ^(200|204|301|302|401|403)$ ]]; then
+    pass "${name} via funnel (HTTP ${code})"
+  else
+    fail_row "${name} via funnel — ${url} returned HTTP ${code}"
+  fi
+done
+
+# 3. Hit the new debug endpoints specifically
+for dbg in "/api/debug/logs/summary" "/api/debug/logs/jsonl/latest"; do
+  url="https://${HOSTNAME_FQDN}:3001${dbg}"
+  code=$(curl -s -o /dev/null -m 5 -w "%{http_code}" "$url" || echo "000")
+  if [[ "$code" =~ ^(200|404)$ ]]; then
+    # 404 is acceptable if the app hasn't written errors.summary.md yet
+    pass "tickvault debug endpoint ${dbg} reachable (HTTP ${code})"
+  else
+    fail_row "tickvault debug endpoint ${dbg} — HTTP ${code}"
+  fi
+done
+
+echo "==========================================================="
+if [[ $FAIL_COUNT -eq 0 ]]; then
+  printf "${c_green}ALL CHECKS PASSED${c_reset} — tunnel is healthy.\n"
+  exit 0
+else
+  printf "${c_red}%d CHECK(S) FAILED${c_reset} — see above.\n" "$FAIL_COUNT"
+  exit 1
+fi

--- a/scripts/tv-tunnel/install-aws.sh
+++ b/scripts/tv-tunnel/install-aws.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# tv-tunnel install-aws.sh — one-command Tailscale Funnel setup on AWS EC2.
+#
+# Run once on your EC2 instance (Amazon Linux 2023 / Ubuntu). After that,
+# the funnel auto-starts via systemd, survives reboots, and exposes:
+#   - Prometheus       (port 9090)
+#   - Alertmanager     (port 9093)
+#   - QuestDB HTTP     (port 9000)
+#   - Grafana          (port 3000)
+#   - tickvault API    (port 3001) — includes /api/debug/logs/*
+#
+# After this runs, every Claude session (sandbox, web, Mac) on any branch
+# can query the live AWS stack without further setup.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+UNIT_SRC="$REPO_ROOT/scripts/tv-tunnel/tickvault-tunnel.service"
+UNIT_DEST="/etc/systemd/system/tickvault-tunnel.service"
+
+c_green="\033[0;32m"
+c_yellow="\033[0;33m"
+c_red="\033[0;31m"
+c_reset="\033[0m"
+pass() { printf "${c_green}✓${c_reset} %s\n" "$*"; }
+warn() { printf "${c_yellow}⚠${c_reset} %s\n" "$*"; }
+fail() { printf "${c_red}✗${c_reset} %s\n" "$*"; exit 1; }
+info() { printf "  %s\n" "$*"; }
+
+echo "=============================================================="
+echo "  tv-tunnel install — AWS / Linux"
+echo "  $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=============================================================="
+
+# -----------------------------------------------------------------------------
+# Prereq 1: running on Linux with systemd
+# -----------------------------------------------------------------------------
+if [[ "$(uname -s)" != "Linux" ]]; then
+  fail "This script is Linux only. For macOS run install-mac.sh."
+fi
+if ! command -v systemctl >/dev/null 2>&1; then
+  fail "systemd not available. This script requires a systemd-managed host (EC2 AL2023/Ubuntu/Debian)."
+fi
+pass "running on Linux with systemd"
+
+# -----------------------------------------------------------------------------
+# Prereq 2: root or sudo available
+# -----------------------------------------------------------------------------
+if [[ $EUID -ne 0 ]]; then
+  if ! command -v sudo >/dev/null 2>&1; then
+    fail "Not running as root and sudo not available."
+  fi
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+pass "privileges: $( [[ -z "$SUDO" ]] && echo root || echo 'sudo available' )"
+
+# -----------------------------------------------------------------------------
+# Prereq 3: Tailscale installed
+# -----------------------------------------------------------------------------
+if ! command -v tailscale >/dev/null 2>&1; then
+  warn "tailscale not installed — running official install script"
+  # shellcheck disable=SC2086
+  curl -fsSL https://tailscale.com/install.sh | $SUDO sh
+fi
+pass "tailscale installed: $(tailscale version | head -1)"
+
+# -----------------------------------------------------------------------------
+# Prereq 4: logged in
+# -----------------------------------------------------------------------------
+if ! $SUDO tailscale status >/dev/null 2>&1; then
+  warn "Tailscale not logged in. Running 'tailscale up' — follow the browser prompt."
+  $SUDO tailscale up --ssh || fail "tailscale up failed"
+fi
+pass "tailscale logged in"
+
+HOSTNAME_FQDN="$($SUDO tailscale status --json 2>/dev/null | awk -F '"' '/"DNSName":/{print $4; exit}' | sed 's/\.$//')"
+[[ -z "$HOSTNAME_FQDN" ]] && fail "Could not determine Tailscale hostname"
+pass "Tailscale hostname: $HOSTNAME_FQDN"
+
+# -----------------------------------------------------------------------------
+# Prereq 5: Funnel feature enabled on tailnet
+# -----------------------------------------------------------------------------
+if ! $SUDO tailscale funnel status >/dev/null 2>&1; then
+  warn "Funnel not yet enabled — open https://login.tailscale.com/admin/acls"
+  warn "and add: nodeAttrs: [{ target: [\"autogroup:member\"], attr: [\"funnel\"] }]"
+  fail "Funnel feature disabled"
+fi
+pass "Tailscale Funnel feature enabled"
+
+# -----------------------------------------------------------------------------
+# Install systemd unit
+# -----------------------------------------------------------------------------
+$SUDO install -m 0644 "$UNIT_SRC" "$UNIT_DEST"
+pass "installed systemd unit: $UNIT_DEST"
+
+$SUDO systemctl daemon-reload
+$SUDO systemctl enable --now tickvault-tunnel.service
+pass "tickvault-tunnel.service enabled and started"
+
+# -----------------------------------------------------------------------------
+# Wait up to 30s for funnel to come up
+# -----------------------------------------------------------------------------
+info "probing funnel endpoint (up to 30s)…"
+tunnel_ok=0
+for i in {1..15}; do
+  if $SUDO tailscale funnel status 2>/dev/null | grep -q ":9090"; then
+    tunnel_ok=1
+    break
+  fi
+  sleep 2
+done
+
+if [[ $tunnel_ok -eq 1 ]]; then
+  pass "funnel is serving on ports 9090, 9093, 9000, 3000, 3001"
+else
+  warn "funnel did not report status within 30s — check with 'sudo tailscale funnel status'"
+fi
+
+# -----------------------------------------------------------------------------
+# Final output
+# -----------------------------------------------------------------------------
+echo
+echo "=============================================================="
+echo "  SETUP COMPLETE"
+echo "=============================================================="
+echo
+echo "Your stable Tailscale Funnel URLs:"
+echo "  Prometheus:     https://$HOSTNAME_FQDN:9090"
+echo "  Alertmanager:   https://$HOSTNAME_FQDN:9093"
+echo "  QuestDB HTTP:   https://$HOSTNAME_FQDN:9000"
+echo "  Grafana:        https://$HOSTNAME_FQDN:3000"
+echo "  tickvault API:  https://$HOSTNAME_FQDN:3001"
+echo
+echo "NEXT: update config/claude-mcp-endpoints.toml to set these URLs"
+echo "under [profiles.aws-prod], set active = \"aws-prod\", commit + push."
+echo "=============================================================="

--- a/scripts/tv-tunnel/install-mac.sh
+++ b/scripts/tv-tunnel/install-mac.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# tv-tunnel install-mac.sh — one-command Tailscale Funnel setup on macOS.
+#
+# Run once on your Mac. After that, the funnel auto-starts on reboot
+# (launchd), auto-reconnects if the Mac sleeps/wakes, and exposes:
+#   - Prometheus       (port 9090)
+#   - Alertmanager     (port 9093)
+#   - QuestDB HTTP     (port 9000)
+#   - Grafana          (port 3000)
+#   - tickvault API    (port 3001) — includes /api/debug/logs/*
+#
+# Resulting stable URLs are committed to config/claude-mcp-endpoints.toml
+# (via the `--emit-config` flag of doctor.sh after tunnel is up).
+#
+# Safety:
+#   - Idempotent: re-running does nothing harmful
+#   - Every step verified before proceeding
+#   - Never modifies ~/.zshrc, ~/.bashrc, or any dotfile
+#   - Never installs sudo packages without prompting
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.tickvault.tunnel.plist"
+PLIST_SRC="$REPO_ROOT/scripts/tv-tunnel/com.tickvault.tunnel.plist"
+TAILSCALE_BIN="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+
+# -----------------------------------------------------------------------------
+# Logging helpers
+# -----------------------------------------------------------------------------
+c_green="\033[0;32m"
+c_yellow="\033[0;33m"
+c_red="\033[0;31m"
+c_reset="\033[0m"
+pass() { printf "${c_green}✓${c_reset} %s\n" "$*"; }
+warn() { printf "${c_yellow}⚠${c_reset} %s\n" "$*"; }
+fail() { printf "${c_red}✗${c_reset} %s\n" "$*"; exit 1; }
+info() { printf "  %s\n" "$*"; }
+
+echo "=============================================================="
+echo "  tv-tunnel install — macOS"
+echo "  $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=============================================================="
+
+# -----------------------------------------------------------------------------
+# Prereq 1: macOS
+# -----------------------------------------------------------------------------
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  fail "This script is macOS only. For AWS / Linux run install-aws.sh."
+fi
+pass "running on macOS"
+
+# -----------------------------------------------------------------------------
+# Prereq 2: Tailscale app installed
+# -----------------------------------------------------------------------------
+if [[ ! -x "$TAILSCALE_BIN" ]]; then
+  if command -v brew >/dev/null 2>&1; then
+    warn "Tailscale app not found — installing via Homebrew"
+    brew install --cask tailscale
+  else
+    fail "Tailscale app not installed and brew not available. Install from https://tailscale.com/download/mac or 'brew install --cask tailscale'."
+  fi
+fi
+pass "Tailscale app installed"
+
+# -----------------------------------------------------------------------------
+# Prereq 3: Tailscale logged in (tailscale status shows your account)
+# -----------------------------------------------------------------------------
+if ! "$TAILSCALE_BIN" status >/dev/null 2>&1; then
+  warn "Tailscale not logged in — launching login flow"
+  "$TAILSCALE_BIN" up || fail "tailscale up failed. Log in at https://login.tailscale.com/start and retry."
+fi
+pass "Tailscale logged in"
+
+HOSTNAME_FQDN="$("$TAILSCALE_BIN" status --json 2>/dev/null | /usr/bin/awk -F '"' '/"DNSName":/{print $4; exit}' | sed 's/\.$//')"
+if [[ -z "$HOSTNAME_FQDN" ]]; then
+  fail "Could not determine Tailscale hostname. Run 'tailscale status' and check your account."
+fi
+pass "Tailscale hostname: $HOSTNAME_FQDN"
+
+# -----------------------------------------------------------------------------
+# Prereq 4: Tailscale Funnel feature enabled on your tailnet
+# -----------------------------------------------------------------------------
+# Tailscale Funnel requires the `funnel` feature to be enabled in the admin
+# console (https://login.tailscale.com/admin/acls — nodeAttrs). The install
+# script cannot toggle this for you — it requires human ACK in the web UI.
+info "Funnel feature check: attempting probe…"
+if ! "$TAILSCALE_BIN" funnel status >/dev/null 2>&1; then
+  warn "Funnel not yet enabled. Open https://login.tailscale.com/admin/acls"
+  warn "and add 'nodeAttrs: [{ target: [\"autogroup:member\"], attr: [\"funnel\"] }]'"
+  warn "then re-run this script."
+  fail "Tailscale Funnel feature disabled."
+fi
+pass "Tailscale Funnel feature enabled"
+
+# -----------------------------------------------------------------------------
+# Install launchd plist (auto-start on reboot, auto-restart on crash)
+# -----------------------------------------------------------------------------
+mkdir -p "$(dirname "$PLIST_DEST")"
+# Substitute the Tailscale binary path into the plist template so we don't
+# hardcode /Applications/Tailscale.app/... into the repo's committed plist.
+sed "s|@TAILSCALE_BIN@|$TAILSCALE_BIN|g" "$PLIST_SRC" > "$PLIST_DEST"
+pass "installed launchd plist: $PLIST_DEST"
+
+# -----------------------------------------------------------------------------
+# Load the launchd service (idempotent)
+# -----------------------------------------------------------------------------
+/bin/launchctl unload "$PLIST_DEST" 2>/dev/null || true
+/bin/launchctl load -w "$PLIST_DEST"
+pass "launchd service loaded — tunnel will start within 10 seconds"
+
+# -----------------------------------------------------------------------------
+# Wait up to 30s for funnel to come up
+# -----------------------------------------------------------------------------
+info "probing funnel endpoint (up to 30s)…"
+tunnel_ok=0
+for i in {1..15}; do
+  if "$TAILSCALE_BIN" funnel status 2>/dev/null | grep -q ":9090"; then
+    tunnel_ok=1
+    break
+  fi
+  sleep 2
+done
+
+if [[ $tunnel_ok -eq 1 ]]; then
+  pass "funnel is serving on ports 9090, 9093, 9000, 3000, 3001"
+else
+  warn "funnel did not report status within 30s — check with 'tailscale funnel status'"
+fi
+
+# -----------------------------------------------------------------------------
+# Final output + instructions
+# -----------------------------------------------------------------------------
+echo
+echo "=============================================================="
+echo "  SETUP COMPLETE"
+echo "=============================================================="
+echo
+echo "Your stable Tailscale Funnel URLs:"
+echo "  Prometheus:     https://$HOSTNAME_FQDN:9090"
+echo "  Alertmanager:   https://$HOSTNAME_FQDN:9093"
+echo "  QuestDB HTTP:   https://$HOSTNAME_FQDN:9000"
+echo "  Grafana:        https://$HOSTNAME_FQDN:3000"
+echo "  tickvault API:  https://$HOSTNAME_FQDN:3001"
+echo "  Log summary:    https://$HOSTNAME_FQDN:3001/api/debug/logs/summary"
+echo "  Log JSONL:      https://$HOSTNAME_FQDN:3001/api/debug/logs/jsonl/latest"
+echo
+echo "NEXT: update config/claude-mcp-endpoints.toml to set these URLs"
+echo "under [profiles.mac-dev], then commit + push:"
+echo "  bash scripts/tv-tunnel/doctor.sh --emit-config > /tmp/mac-profile.toml"
+echo "  # Review /tmp/mac-profile.toml, then merge into the repo file"
+echo
+echo "AFTER THAT: every Claude session on every branch, every host, has"
+echo "live MCP access to your Mac stack. No further setup needed."
+echo "=============================================================="

--- a/scripts/tv-tunnel/tickvault-tunnel.service
+++ b/scripts/tv-tunnel/tickvault-tunnel.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=tickvault Tailscale Funnel — exposes observability ports for Claude MCP access
+Documentation=file:///home/ec2-user/tickvault/docs/runbooks/claude-mcp-access.md
+After=network-online.target tailscaled.service
+Wants=network-online.target tailscaled.service
+
+[Service]
+Type=simple
+# Funnel foreground mode so systemd owns the lifecycle.
+ExecStart=/usr/bin/tailscale funnel 9090 9093 9000 3000 3001
+ExecStopPost=/usr/bin/tailscale funnel reset
+Restart=always
+RestartSec=10
+# Funnel requires root on Linux to bind low ports on the TS socket.
+User=root
+Group=root
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary — Milestone 1: Universal MCP Observability Access

This PR ships **Layer 1 (Observe)** of the `.claude/plans/autonomous-operations-100pct.md` plan — the prerequisite for every other layer. After this merges + one-time setup on Mac/AWS, every Claude session (any branch, any host, sandbox / claude.ai web / claude cowork / claude-code CLI) can query tickvault's full runtime state live with **zero per-session setup**.

## The 3 design moves

1. **Transport:** Tailscale Funnel — free tier, stable `.ts.net` URLs that never change, auto-restart via launchd (Mac) / systemd (AWS).
2. **Config in repo, not env vars:** `config/claude-mcp-endpoints.toml` with 3 profiles (`local` / `mac-dev` / `aws-prod`). Committed to `main`, so every clone on every branch inherits working endpoints.
3. **Logs over HTTP, not rsync:** new `GET /api/debug/logs/summary` + `GET /api/debug/logs/jsonl/latest` endpoints — eliminates the file-sync requirement of the old Mode C.

## 4-tier endpoint resolution (per-URL)

1. Explicit `base_url=` tool arg (single-call override)
2. `TICKVAULT_<KIND>_URL` env var (session-level override)
3. Active profile in `config/claude-mcp-endpoints.toml` (universal default)
4. `http://127.0.0.1:<port>` hardcoded fallback (Mode A — everything local)

Select profile via `TICKVAULT_MCP_PROFILE=aws-prod` or the `active` key at top of config.

## Files (13 new/modified)

| Path | Purpose |
|------|---------|
| `.claude/plans/autonomous-operations-100pct.md` | Master 5-layer roadmap (M1 shipping; M2-5 follow-up PRs) |
| `config/claude-mcp-endpoints.toml` | Universal endpoint config (3 profiles × 7 keys) |
| `scripts/tv-tunnel/install-mac.sh` | One-command Mac setup (idempotent, verifies Tailscale + Funnel feature) |
| `scripts/tv-tunnel/install-aws.sh` | One-command AWS setup (apt install + systemd enable) |
| `scripts/tv-tunnel/com.tickvault.tunnel.plist` | launchd template (KeepAlive, ThrottleInterval) |
| `scripts/tv-tunnel/tickvault-tunnel.service` | systemd unit (hardened: NoNewPrivileges, ProtectSystem, etc.) |
| `scripts/tv-tunnel/doctor.sh` | 7-endpoint probe + `--emit-config` mode |
| `scripts/mcp-servers/tickvault-logs/server.py` | Config-aware `_endpoint_url()` resolver |
| `crates/api/src/handlers/debug.rs` | 2 read-only routes + 11 unit tests |
| `crates/api/src/lib.rs` | Wires `/api/debug/logs/*` routes |
| `crates/api/src/handlers/mod.rs` | Registers debug module |
| `crates/common/tests/claude_mcp_endpoints_config_guard.rs` | 9 guard tests |
| `docs/runbooks/claude-mcp-access.md` | Full rewrite — Modes A/B/C, architecture diagram, troubleshooting |

## Verification

```
cargo test -p tickvault-api --lib handlers::debug                              → 11/11 PASS
cargo test -p tickvault-common --test claude_mcp_endpoints_config_guard        →  9/9  PASS
cargo test -p tickvault-common --test runbook_cross_link_guard                 →  4/4  PASS
bash scripts/validate-automation.sh                                            → 30/30 PASS
```

## What you run (one-time, after merge)

```bash
# On Mac
bash scripts/tv-tunnel/install-mac.sh

# On AWS (when instance is provisioned)
bash scripts/tv-tunnel/install-aws.sh

# Then, from either host
bash scripts/tv-tunnel/doctor.sh --emit-config
# Paste the output into config/claude-mcp-endpoints.toml under the matching profile, commit + push
```

After that, every future Claude session anywhere queries your live stack live — no tunnel setup, no env var juggling, no branch-specific config.

## What's NOT in this PR (honest scope)

This is **observability only** (Layer 1). Full 100% autonomous operations needs Layers 2-5, each a separate PR per the master plan:

- **M2:** full triage rule coverage (46 more rules for the other 46 ErrorCode variants)
- **M3:** full auto-fix script catalogue (~20-30 scripts with `--dry-run` + rollback pairs)
- **M4:** verify+rollback loop (post-fix metric re-probe, auto-revert on regression)
- **M5:** runtime scaling + chaos (AWS Lambda bridge, nightly chaos tests, Dhan plan upgrade escalation)

M2-5 cannot ship before M1 because they all require live MCP access.

## Test plan
- [ ] Merge this PR
- [ ] Run `scripts/tv-tunnel/install-mac.sh` on your Mac, verify funnel comes up
- [ ] Run `scripts/tv-tunnel/doctor.sh` — expect 7/7 PASS
- [ ] Update `config/claude-mcp-endpoints.toml` with your actual `.ts.net` hostnames, commit
- [ ] Start a fresh Claude session, run `mcp__tickvault-logs__summary_snapshot` — should return live data
- [ ] Run `mcp__tickvault-logs__prometheus_query` with `up{job="tickvault"}` — should show 1

https://claude.ai/code/session_01T3z6eYqeNjsaHgDdTe252o