### PR TITLE
feat(autonomous-ops): full ErrorCode triage rule coverage (M2)

### DIFF
--- a/.claude/triage/error-rules.yaml
+++ b/.claude/triage/error-rules.yaml
@@ -168,3 +168,585 @@ rules:
       Circuit breaker opened means 3 consecutive order failures. Never
       auto-reset — the operator must diagnose whether the underlying
       issue is authentication, rate limiting, or a bad order payload.
+
+  # =======================================================================
+  # MILESTONE 2 — full ErrorCode coverage (48 new rules, total 54 codes)
+  #
+  # See .claude/plans/autonomous-operations-100pct.md for scope + safety.
+  # Conservative defaults: unknown/Critical/<0.95-confidence -> escalate.
+  # Only 6 codes have auto_* actions today (tied to 3 existing scripts);
+  # everything else is silence (internal handler fixes it) or escalate
+  # (operator review). M3 adds auto_fix scripts and upgrades these rules.
+  # =======================================================================
+
+  # -----------------------------------------------------------------------
+  # Critical — auth / account / global connection cap. Never auto-action.
+  # -----------------------------------------------------------------------
+
+  - name: dh-902-no-api-access-escalate
+    match:
+      code: DH-902
+    action: escalate
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DH-902 = account has no API access. Requires operator to check
+      subscription status with Dhan support. Never auto-retry.
+
+  - name: dh-903-account-issue-escalate
+    match:
+      code: DH-903
+    action: escalate
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DH-903 = account-level issue (margin blocked, compliance hold, etc).
+      HALT + alert operator. Never auto-act.
+
+  - name: data-805-too-many-connections-escalate
+    match:
+      code: DATA-805
+    action: escalate
+    runbook_path: .claude/rules/dhan/live-market-feed.md
+    confidence: 1.0
+    cooldown_secs: 60
+    justification: >-
+      DATA-805 means >5 WebSocket connections. The in-app handler pauses
+      ALL connections for 60s and then audits before reconnecting one at a
+      time. If the signature still fires post-recovery, it is a real leak
+      requiring operator diagnosis.
+
+  - name: data-808-auth-failed-escalate
+    match:
+      code: DATA-808
+    action: escalate
+    runbook_path: .claude/rules/dhan/authentication.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-808 = Data API authentication failed. Token is present but
+      rejected. Operator must check client_id + token validity.
+
+  - name: data-809-token-invalid-escalate
+    match:
+      code: DATA-809
+    action: escalate
+    runbook_path: .claude/rules/dhan/authentication.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-809 = access token invalid. App already attempts single
+      rotation; further failure requires manual token regeneration.
+
+  - name: data-810-client-id-invalid-escalate
+    match:
+      code: DATA-810
+    action: escalate
+    runbook_path: .claude/rules/dhan/authentication.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-810 = client_id invalid. Never recoverable automatically —
+      requires operator to re-check SSM config and Dhan dashboard.
+
+  - name: auth-gap-01-token-expiry-escalate
+    match:
+      code: AUTH-GAP-01
+    action: escalate
+    runbook_path: .claude/rules/dhan/authentication.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      Token expiry pipeline failed to refresh in the 23h window. The
+      app halts at end-of-token-life — operator must rotate manually.
+
+  - name: auth-gap-02-disconnect-token-map-escalate
+    match:
+      code: AUTH-GAP-02
+    action: escalate
+    runbook_path: .claude/rules/dhan/authentication.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      AUTH-GAP-02 = wrong disconnect-code is triggering token refresh,
+      or a 807 disconnect is not triggering refresh. Logic regression —
+      operator must review ws_disconnect_codes test suite.
+
+  - name: oms-gap-06-dry-run-safety-escalate
+    match:
+      code: OMS-GAP-06
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      OMS-GAP-06 = dry_run safety gate breached: an order was submitted
+      to Dhan when dry_run=true. HALT trading immediately + operator
+      review. Never auto-action, never silence.
+
+  - name: i-p0-06-emergency-download-escalate
+    match:
+      code: I-P0-06
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      I-P0-06 = all instrument caches missing AND live download failed.
+      Trading cannot start without instruments — CRITICAL escalation.
+
+  # -----------------------------------------------------------------------
+  # High — order / risk / rate-limit / regulatory
+  # -----------------------------------------------------------------------
+
+  - name: dh-905-input-exception-escalate
+    match:
+      code: DH-905
+    action: escalate
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DH-905 = Dhan rejected the request as invalid. NEVER retry —
+      retrying a malformed request wastes rate-limit budget. Operator
+      must fix the request payload.
+
+  - name: dh-906-order-error-escalate
+    match:
+      code: DH-906
+    action: escalate
+    runbook_path: .claude/rules/dhan/orders.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DH-906 = order rejected by Dhan. Reasons include insufficient
+      margin, wrong product type, stale SecurityId, market-closed. Never
+      auto-retry — operator reviews.
+
+  - name: oms-gap-01-state-machine-escalate
+    match:
+      code: OMS-GAP-01
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      OMS-GAP-01 = invalid state transition attempted (e.g. Traded ->
+      Pending). State machine corruption — HALT + operator review.
+
+  - name: oms-gap-02-reconciliation-escalate
+    match:
+      code: OMS-GAP-02
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      OMS-GAP-02 = status mismatch between OMS state and Dhan order book.
+      Ghost order or wrong-status drift — operator diagnoses before any
+      further order placement.
+
+  - name: oms-gap-04-rate-limit-silence
+    match:
+      code: OMS-GAP-04
+    action: silence
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 600
+    justification: >-
+      OMS-GAP-04 rate-limit rejections are handled by the GCRA burst
+      algorithm — the next request naturally waits its slot. Silence
+      keeps Telegram clean; if burst exhaustion lasts > cooldown the
+      signature re-fires and escalates.
+
+  - name: oms-gap-05-idempotency-escalate
+    match:
+      code: OMS-GAP-05
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      OMS-GAP-05 = correlation-id collision or UUID non-uniqueness.
+      Duplicate order risk — operator stops trading, investigates.
+
+  - name: risk-gap-01-pretrade-escalate
+    match:
+      code: RISK-GAP-01
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      RISK-GAP-01 = pre-trade risk check rejected an order (halt /
+      daily-loss / position-limit). The rejection itself is safe; the
+      LOG escalation surfaces when auto-halt fires so operator knows.
+
+  - name: risk-gap-02-position-pnl-escalate
+    match:
+      code: RISK-GAP-02
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      RISK-GAP-02 = fill recording / P&L tracking invariant violated.
+      Never silence — operator must reconcile positions manually.
+
+  - name: i-p0-03-expiry-at-gate-4-escalate
+    match:
+      code: I-P0-03
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      I-P0-03 = attempted to submit order for an expired contract.
+      Universe is stale — operator forces instrument rebuild before
+      resuming trading.
+
+  - name: data-807-token-expired-escalate
+    match:
+      code: DATA-807
+    action: escalate
+    runbook_path: .claude/rules/dhan/authentication.md
+    confidence: 0.90
+    cooldown_secs: 0
+    justification: >-
+      DATA-807 triggers the token-refresh pipeline automatically via
+      AUTH-GAP-02. If we still see a 807 event surfaced to the triage
+      log, the refresh failed — escalate. M3 will add a rotate-token
+      auto-fix script; until then confidence stays below 0.95 and this
+      rule escalates.
+
+  # -----------------------------------------------------------------------
+  # Medium — data pipeline correctness
+  # -----------------------------------------------------------------------
+
+  - name: i-p0-01-duplicate-security-id-escalate
+    match:
+      code: I-P0-01
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      I-P0-01 = duplicate security_id in CSV universe. Data-quality
+      issue from Dhan — operator diagnoses whether to hotfix the
+      universe filter or file a support ticket.
+
+  - name: i-p0-02-count-consistency-escalate
+    match:
+      code: I-P0-02
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      I-P0-02 = post-build derivative count below minimum threshold.
+      CSV truncation or parser regression — operator checks before
+      allowing trading to proceed with sparse universe.
+
+  - name: i-p0-04-cache-persistence-escalate
+    match:
+      code: I-P0-04
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      I-P0-04 = instrument cache dir is on tmpfs or otherwise
+      non-persistent. Cold-boot risk — operator fixes mount before
+      trusting cached universe.
+
+  - name: i-p0-05-s3-backup-silence
+    match:
+      code: I-P0-05
+    action: silence
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 86400
+    justification: >-
+      I-P0-05 fires when S3 backup config is missing. Pre-AWS-provision
+      this is expected. Silence daily — re-enable via operator when the
+      S3 bucket is live.
+
+  - name: i-p1-03-security-id-reuse-escalate
+    match:
+      code: I-P1-03
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 3600
+    justification: >-
+      I-P1-03 = Dhan reassigned a security_id (expired contract id
+      reused for a new contract). Operator reviews delta_detector output
+      before accepting the rebuild.
+
+  - name: i-p1-05-compound-dedup-key-escalate
+    match:
+      code: I-P1-05
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      I-P1-05 = DEDUP_KEY_DERIVATIVE_CONTRACTS missing underlying_symbol.
+      Source-level regression — operator reverts or fixes the constant.
+
+  - name: i-p1-06-segment-in-tick-dedup-escalate
+    match:
+      code: I-P1-06
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      I-P1-06 = DEDUP_KEY_TICKS missing exchange_segment. Cross-segment
+      collision risk — operator fixes constant and re-verifies meta-guard.
+
+  - name: i-p1-08-single-row-lifecycle-silence
+    match:
+      code: I-P1-08
+    action: silence
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 86400
+    justification: >-
+      I-P1-08 lifecycle events (active -> expired flips) are expected
+      daily after CSV rebuild. Silence daily; escalate only on
+      count-anomalies surfaced by I-P0-02.
+
+  - name: gap-net-01-ip-monitor-escalate
+    match:
+      code: GAP-NET-01
+    action: escalate
+    runbook_path: .claude/rules/dhan/authentication.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      GAP-NET-01 = app's detected public IP drifted from registered
+      Dhan static IP. Orders will be rejected from April 1, 2026.
+      Operator must setIP via the Dhan portal (7-day cooldown).
+
+  - name: gap-sec-01-api-auth-escalate
+    match:
+      code: GAP-SEC-01
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 60
+    justification: >-
+      GAP-SEC-01 = tickvault API auth middleware rejected a request.
+      Expected at low volume (health probes); escalate if the same IP
+      hammers it, indicating token leak or scanner.
+
+  - name: ws-gap-01-disconnect-classification-silence
+    match:
+      code: WS-GAP-01
+    action: silence
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 300
+    justification: >-
+      WS-GAP-01 surfaces reconnectable disconnect codes (800, 807,
+      Unknown). The WebSocket auto-reconnects. Silence — if reconnect
+      stalls, RISK-GAP-03 (tick gap) fires as the consequence and
+      escalates via its own rule.
+
+  - name: ws-gap-02-subscription-batching-escalate
+    match:
+      code: WS-GAP-02
+    action: escalate
+    runbook_path: .claude/rules/dhan/live-market-feed.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      WS-GAP-02 = subscription batch size violated (>100 per message or
+      numeric SecurityId). Source-level regression — operator fixes
+      subscription_builder.rs.
+
+  - name: ws-gap-03-connection-state-escalate
+    match:
+      code: WS-GAP-03
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      WS-GAP-03 = connection state machine invariant violated. Operator
+      reviews ws_connection_state test suite.
+
+  - name: risk-gap-03-tick-gap-escalate
+    match:
+      code: RISK-GAP-03
+    action: escalate
+    runbook_path: .claude/rules/project/live-market-feed-subscription.md
+    confidence: 1.0
+    cooldown_secs: 900
+    justification: >-
+      RISK-GAP-03 = tick gap exceeded warn/error threshold. Outside
+      market hours this is expected (no ticks flowing). Inside market
+      hours it indicates a stall — escalate with 15min cooldown.
+
+  - name: storage-gap-02-f32-f64-precision-escalate
+    match:
+      code: STORAGE-GAP-02
+    action: escalate
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      STORAGE-GAP-02 = IEEE 754 widening artifact slipped through
+      f32_to_f64_clean(). Source-level regression — operator reviews.
+
+  - name: dh-907-data-error-escalate
+    match:
+      code: DH-907
+    action: escalate
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DH-907 = Dhan data API rejected request params. Do not retry
+      blindly. Operator reviews request and fixes root cause.
+
+  - name: dh-908-internal-server-error-silence
+    match:
+      code: DH-908
+    action: silence
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 600
+    justification: >-
+      DH-908 = Dhan-side 5xx. The in-app retry with backoff handles it.
+      Silence — if DH-908 fires more than cooldown window repeatedly the
+      signature re-surfaces and escalates automatically.
+
+  - name: dh-909-network-error-silence
+    match:
+      code: DH-909
+    action: silence
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 600
+    justification: >-
+      DH-909 = network error. Retry with backoff handles it. Silence
+      with cooldown; re-surfaces if persistent.
+
+  - name: data-800-internal-server-error-silence
+    match:
+      code: DATA-800
+    action: silence
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 600
+    justification: >-
+      DATA-800 = Dhan-side 500. Retry handles it; silence with cooldown.
+
+  - name: data-804-instruments-exceed-limit-escalate
+    match:
+      code: DATA-804
+    action: escalate
+    runbook_path: .claude/rules/dhan/live-market-feed.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-804 = subscription list exceeds Dhan's per-connection limit
+      (5000). Subscription planner regression — operator fixes the
+      distribution logic.
+
+  - name: data-806-not-subscribed-escalate
+    match:
+      code: DATA-806
+    action: escalate
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-806 = account not subscribed to Data API product. Operator
+      confirms subscription with Dhan support — cannot auto-fix.
+
+  - name: data-811-invalid-expiry-escalate
+    match:
+      code: DATA-811
+    action: escalate
+    runbook_path: .claude/rules/dhan/historical-data.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-811 = expiry date not in Dhan's list. Universe staleness —
+      operator rebuilds instruments and re-verifies request.
+
+  - name: data-812-invalid-date-format-escalate
+    match:
+      code: DATA-812
+    action: escalate
+    runbook_path: .claude/rules/dhan/historical-data.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-812 = date format mismatch (intraday requires YYYY-MM-DD
+      HH:MM:SS, daily requires YYYY-MM-DD). Source-level regression —
+      operator fixes request builder.
+
+  - name: data-814-invalid-request-escalate
+    match:
+      code: DATA-814
+    action: escalate
+    runbook_path: .claude/rules/dhan/api-introduction.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DATA-814 = request schema invalid. Source-level regression —
+      operator fixes request shape, never retry blindly.
+
+  # -----------------------------------------------------------------------
+  # Low — scheduler / trading-day / informational / unknown
+  # -----------------------------------------------------------------------
+
+  - name: i-p1-01-daily-scheduler-silence
+    match:
+      code: I-P1-01
+    action: silence
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 86400
+    justification: >-
+      I-P1-01 = daily scheduler drift event. Observational — scheduler
+      self-corrects on next cycle. Silence daily.
+
+  - name: i-p1-02-delta-field-coverage-silence
+    match:
+      code: I-P1-02
+    action: silence
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 86400
+    justification: >-
+      I-P1-02 = delta_detector logged a field change. Informational —
+      useful to diff CSVs but not actionable.
+
+  - name: i-p2-02-trading-day-guard-silence
+    match:
+      code: I-P2-02
+    action: silence
+    runbook_path: .claude/rules/project/gap-enforcement.md
+    confidence: 1.0
+    cooldown_secs: 86400
+    justification: >-
+      I-P2-02 weekend/holiday downloads are expected when the operator
+      runs tickvault outside market days for testing. Silence daily.
+
+  - name: dh-910-other-escalate
+    match:
+      code: DH-910
+    action: escalate
+    runbook_path: .claude/rules/dhan/annexure-enums.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DH-910 is the catch-all for unknown Dhan error codes. ALWAYS
+      escalate — an unknown code must be documented and mapped.

--- a/crates/common/tests/triage_rules_full_coverage_guard.rs
+++ b/crates/common/tests/triage_rules_full_coverage_guard.rs
@@ -1,0 +1,311 @@
+//! Meta-guard — every `ErrorCode` variant has a rule in
+//! `.claude/triage/error-rules.yaml`.
+//!
+//! Milestone 2 of `.claude/plans/autonomous-operations-100pct.md`.
+//!
+//! Without this guard a new ErrorCode variant added to the enum would
+//! silently bypass the autonomous-ops classifier — resulting in no
+//! triage decision, no auto-fix, no Telegram on that code. This test
+//! fails the build if ANY variant lacks a matching rule.
+
+use std::path::PathBuf;
+
+use tickvault_common::error_code::ErrorCode;
+
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().parent().unwrap().to_path_buf()
+}
+
+fn load_rules_yaml() -> String {
+    let path = repo_root().join(".claude/triage/error-rules.yaml");
+    std::fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!(
+            ".claude/triage/error-rules.yaml missing or unreadable: {err}\n\
+             Path: {}",
+            path.display()
+        )
+    })
+}
+
+#[test]
+fn every_error_code_variant_has_a_triage_rule() {
+    let yaml = load_rules_yaml();
+    let mut missing: Vec<&'static str> = Vec::new();
+    for code in ErrorCode::all() {
+        let needle = format!("code: {}", code.code_str());
+        // Require the exact pattern `code: <CODE>` to appear somewhere,
+        // either on its own line or followed by a whitespace + comment.
+        // The YAML structure is `      code: <CODE>` so the leading
+        // spaces and trailing context are validated by the schema test
+        // below, not here.
+        if !yaml_contains_code(&yaml, &needle) {
+            missing.push(code.code_str());
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "The following ErrorCode variants have no rule in \
+         .claude/triage/error-rules.yaml:\n  {}\n\n\
+         Every variant MUST have a triage decision (silence / \
+         auto_restart / auto_fix / escalate). See \
+         .claude/plans/autonomous-operations-100pct.md milestone 2.",
+        missing.join("\n  ")
+    );
+}
+
+/// Match `code: <NEEDLE>` at the start of a whitespace-only indented
+/// token stream. We accept the same-line comment form (`code: X  #
+/// placeholder...`) but reject partial matches like `code: DH-90` when
+/// looking for `code: DH-9` (unlikely here but worth guarding).
+fn yaml_contains_code(yaml: &str, needle: &str) -> bool {
+    for line in yaml.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix(needle) {
+            if rest.is_empty()
+                || rest.starts_with(' ')
+                || rest.starts_with('\t')
+                || rest.starts_with('#')
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[test]
+fn rule_count_matches_or_exceeds_variant_count() {
+    let yaml = load_rules_yaml();
+    let rule_count = yaml
+        .lines()
+        .filter(|l| l.trim_start().starts_with("- name:"))
+        .count();
+    let variant_count = ErrorCode::all().len();
+    assert!(
+        rule_count >= variant_count,
+        "Rule count {rule_count} < ErrorCode variant count {variant_count}. \
+         Every variant must have at least one rule; multiple rules for the \
+         same code are permitted (e.g. fan-out by message_contains)."
+    );
+}
+
+#[test]
+fn every_rule_has_a_required_action_field() {
+    let yaml = load_rules_yaml();
+    // Walk through rule blocks; each `- name:` must be followed within
+    // its block by one of the 4 allowed action values.
+    let allowed_actions = ["silence", "auto_restart", "auto_fix", "escalate"];
+    let mut rule_names: Vec<&str> = Vec::new();
+    let mut current_rule: Option<String> = None;
+    let mut current_has_action = false;
+    for line in yaml.lines() {
+        let trimmed = line.trim_start();
+        if let Some(name) = trimmed.strip_prefix("- name: ") {
+            // Finish previous rule
+            if let Some(rn) = current_rule.take() {
+                assert!(
+                    current_has_action,
+                    "Rule '{rn}' has no action field. Must be one of: {}",
+                    allowed_actions.join(" / ")
+                );
+            }
+            let name_owned = name.trim().to_string();
+            // Leak intentional — test-only, tiny, vector holds the &str
+            // for the duration of the test so diagnostics can print it.
+            let name_ref = Box::leak(name_owned.clone().into_boxed_str());
+            rule_names.push(name_ref);
+            current_rule = Some(name_owned);
+            current_has_action = false;
+        } else if let Some(action) = trimmed.strip_prefix("action: ") {
+            // Strip inline comments from action value (yaml allows "action: silence  # ...")
+            let action_clean = action.split('#').next().unwrap_or(action).trim();
+            assert!(
+                allowed_actions.contains(&action_clean),
+                "Rule '{}' has invalid action '{action_clean}'. \
+                 Allowed: {}",
+                current_rule.as_deref().unwrap_or("<unknown>"),
+                allowed_actions.join(" / ")
+            );
+            current_has_action = true;
+        }
+    }
+    // Final rule
+    if let Some(rn) = current_rule {
+        assert!(
+            current_has_action,
+            "Rule '{rn}' has no action field (last rule in file)."
+        );
+    }
+    assert!(!rule_names.is_empty(), "No rules parsed from yaml");
+}
+
+#[test]
+fn critical_severity_codes_must_all_escalate() {
+    // Safety invariant: ErrorCode::is_auto_triage_safe() returns false
+    // for Critical severity. This test walks the yaml and asserts that
+    // every rule whose code maps to a Critical variant uses
+    // `action: escalate` — NEVER silence / auto_restart / auto_fix.
+    let yaml = load_rules_yaml();
+    let critical_codes: Vec<&'static str> = ErrorCode::all()
+        .iter()
+        .filter(|c| !c.is_auto_triage_safe())
+        .map(|c| c.code_str())
+        .collect();
+
+    // For each critical code, find its rule block(s) and verify action.
+    for code in &critical_codes {
+        let mut in_block_for_code = false;
+        let mut block_action: Option<String> = None;
+        let mut saw_any = false;
+        for line in yaml.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("- name: ") {
+                // End of previous block — check if it was for our code
+                if in_block_for_code {
+                    saw_any = true;
+                    let action = block_action.as_deref().unwrap_or("<missing>");
+                    assert_eq!(
+                        action, "escalate",
+                        "Critical code {code} must have action: escalate, \
+                         got '{action}'. Critical severity codes MUST NEVER \
+                         auto-action per is_auto_triage_safe()."
+                    );
+                }
+                in_block_for_code = false;
+                block_action = None;
+            } else if let Some(found) = trimmed.strip_prefix("code: ") {
+                let value = found.split_whitespace().next().unwrap_or("");
+                if value == *code {
+                    in_block_for_code = true;
+                }
+            } else if let Some(action) = trimmed.strip_prefix("action: ") {
+                let clean = action.split('#').next().unwrap_or(action).trim();
+                block_action = Some(clean.to_string());
+            }
+        }
+        // Final block
+        if in_block_for_code {
+            saw_any = true;
+            let action = block_action.as_deref().unwrap_or("<missing>");
+            assert_eq!(
+                action, "escalate",
+                "Critical code {code} must have action: escalate, got '{action}'"
+            );
+        }
+        assert!(
+            saw_any,
+            "Critical code {code} has no rule block — other test catches this \
+             but surfacing here for clarity."
+        );
+    }
+
+    // Sanity: at least some critical codes exist
+    assert!(
+        !critical_codes.is_empty(),
+        "Expected at least one Critical-severity ErrorCode variant"
+    );
+}
+
+#[test]
+fn auto_fix_actions_must_reference_an_existing_script() {
+    // Every `auto_fix` or `auto_restart` rule must reference a real
+    // executable script in the repo. Prevents rules from pointing at
+    // non-existent scripts (which would fail silently at triage time).
+    let yaml = load_rules_yaml();
+    let root = repo_root();
+    let mut current_action: Option<String> = None;
+    let mut current_script: Option<String> = None;
+    let mut current_name: Option<String> = None;
+    let mut errors: Vec<String> = Vec::new();
+
+    fn check(
+        errors: &mut Vec<String>,
+        root: &std::path::Path,
+        name: Option<&str>,
+        action: Option<&str>,
+        script: Option<&str>,
+    ) {
+        let Some(action) = action else {
+            return;
+        };
+        if action != "auto_fix" && action != "auto_restart" {
+            return;
+        }
+        let Some(script) = script else {
+            errors.push(format!(
+                "Rule '{}' has action '{}' but no auto_fix_script field",
+                name.unwrap_or("<unknown>"),
+                action
+            ));
+            return;
+        };
+        let path = root.join(script);
+        if !path.is_file() {
+            errors.push(format!(
+                "Rule '{}' points at auto_fix_script '{}' which does not exist",
+                name.unwrap_or("<unknown>"),
+                script
+            ));
+        }
+    }
+
+    for line in yaml.lines() {
+        let trimmed = line.trim_start();
+        if let Some(name) = trimmed.strip_prefix("- name: ") {
+            check(
+                &mut errors,
+                &root,
+                current_name.as_deref(),
+                current_action.as_deref(),
+                current_script.as_deref(),
+            );
+            current_name = Some(name.trim().to_string());
+            current_action = None;
+            current_script = None;
+        } else if let Some(action) = trimmed.strip_prefix("action: ") {
+            let clean = action.split('#').next().unwrap_or(action).trim();
+            current_action = Some(clean.to_string());
+        } else if let Some(script) = trimmed.strip_prefix("auto_fix_script: ") {
+            current_script = Some(script.trim().to_string());
+        }
+    }
+    check(
+        &mut errors,
+        &root,
+        current_name.as_deref(),
+        current_action.as_deref(),
+        current_script.as_deref(),
+    );
+
+    assert!(
+        errors.is_empty(),
+        "auto_fix/auto_restart rule errors:\n  {}",
+        errors.join("\n  ")
+    );
+}
+
+#[test]
+fn coverage_summary_prints_breakdown() {
+    // Informational test — always passes. Prints a coverage table so
+    // developers can see at a glance which codes have which actions.
+    // Useful on local test runs; ignored in CI output by name filter.
+    let yaml = load_rules_yaml();
+    let total_variants = ErrorCode::all().len();
+    let rule_count = yaml
+        .lines()
+        .filter(|l| l.trim_start().starts_with("- name:"))
+        .count();
+    let critical_count = ErrorCode::all()
+        .iter()
+        .filter(|c| !c.is_auto_triage_safe())
+        .count();
+
+    eprintln!(
+        "\n  Triage rule coverage summary:\n    \
+         ErrorCode variants: {total_variants}\n    \
+         Triage rules:       {rule_count}\n    \
+         Critical codes:     {critical_count} (all must escalate)\n    \
+         All-variant guard:  every_error_code_variant_has_a_triage_rule"
+    );
+}


### PR DESCRIPTION
## Summary — Milestone 2: Full ErrorCode Triage Rule Coverage

Stacked on top of PR #283 (Milestone 1). Ships Layer 3 (Decide) of `.claude/plans/autonomous-operations-100pct.md`.

Every one of the **54 ErrorCode variants** now has an explicit triage decision in `.claude/triage/error-rules.yaml`. Before M2 only 6 codes had rules; the other 48 silently bypassed the classifier — no Telegram, no auto-fix, no operator visibility.

## What changed

- **48 new rules** appended to `.claude/triage/error-rules.yaml` (170 → 752 lines)
- **6-test meta-guard** at `crates/common/tests/triage_rules_full_coverage_guard.rs`

## Rule distribution by action

| Action | Count | Meaning |
|---|---|---|
| `escalate` | 38 | Operator review — default for any ambiguity |
| `silence` | 10 | Internal handler fixes it (rate-limit backoff, network retry, expected lifecycle churn, optional config) |
| `auto_restart` | 2 | Existing scripts: `clear-spill`, `restart-depth` |
| `auto_fix` | 1 | `refresh-instruments` (placeholder, M3 adds more) |

## Safety invariants (test-enforced)

1. **Every variant has a rule** — `every_error_code_variant_has_a_triage_rule`
2. **Critical codes MUST escalate** — `critical_severity_codes_must_all_escalate`
   (13 codes: DH-901/902/903, DATA-805/808/809/810, AUTH-GAP-01/02, OMS-GAP-03/06, I-P0-06)
3. **Auto-fix scripts must exist on disk** — `auto_fix_actions_must_reference_an_existing_script`
4. **Every rule has a valid action** — `every_rule_has_a_required_action_field`
5. **Rule count ≥ variant count** — `rule_count_matches_or_exceeds_variant_count`

## Verification

```
cargo test -p tickvault-common --test triage_rules_full_coverage_guard → 6/6 PASS
bash scripts/validate-automation.sh                                    → 30/30 PASS
```

## What this unlocks

- **M3** (full auto-fix script catalogue) — every code has a rule to upgrade as its fix script lands.
- **Claude `/loop`** runbook can now route every signature through an actual decision; no more "unknown code skipped" paths.
- **Operator never sees a silent error** — Critical always escalates, everything else is explicit silence-with-justification or explicit auto-action.

## Scope boundary

M2 is **YAML + test-only**. No Rust source or runtime behaviour modified. Safe to ship before M3.

## Test plan

- [ ] M1 (#283) merges first
- [ ] Rebase this branch onto main, verify tests still pass
- [ ] Merge — after merge, every future Claude session has a classifier rule for every possible error

https://claude.ai/code/session_01T3z6eYqeNjsaHgDdTe252o