### PR TITLE
feat(autonomous-ops): GET /api/debug/spill/status read-only diagnostic (M6)

### DIFF
--- a/crates/api/src/handlers/debug.rs
+++ b/crates/api/src/handlers/debug.rs
@@ -28,6 +28,12 @@ const ERRORS_JSONL_PREFIX: &str = "errors.jsonl";
 /// Env-var override for the logs directory location.
 const LOGS_DIR_ENV: &str = "TV_LOGS_DIR";
 
+/// Default spill directory. Matches `TICK_SPILL_DIR` in
+/// `crates/storage/src/tick_persistence.rs`. Read-only diagnostics
+/// only — never deletes or replays from this dir.
+const DEFAULT_SPILL_DIR: &str = "data/spill";
+const SPILL_DIR_ENV: &str = "TV_SPILL_DIR";
+
 fn resolve_logs_dir() -> PathBuf {
     if let Ok(custom) = std::env::var(LOGS_DIR_ENV) {
         if !custom.trim().is_empty() {
@@ -59,6 +65,144 @@ pub async fn logs_jsonl_latest() -> impl IntoResponse {
             "{\"error\":\"no errors.jsonl file present\"}".to_string(),
         ),
     }
+}
+
+fn resolve_spill_dir() -> PathBuf {
+    if let Ok(custom) = std::env::var(SPILL_DIR_ENV) {
+        if !custom.trim().is_empty() {
+            return PathBuf::from(custom);
+        }
+    }
+    PathBuf::from(DEFAULT_SPILL_DIR)
+}
+
+/// GET /api/debug/spill/status — read-only spill-directory diagnostics.
+///
+/// Returns JSON of the form:
+/// ```json
+/// {
+///   "spill_dir": "data/spill",
+///   "exists": true,
+///   "categories": {
+///     "ticks": {"file_count": 0, "total_bytes": 0, "newest_file": null},
+///     "candles": {"file_count": 0, "total_bytes": 0, "newest_file": null},
+///     "depth":   {"file_count": 0, "total_bytes": 0, "newest_file": null}
+///   }
+/// }
+/// ```
+///
+/// Lets Claude / operator query "is anything spilled right now?" via MCP
+/// without filesystem access. Strictly read-only — never deletes or
+/// drains. The `auto-fix-drain-spill.sh` script (M3) consumes this
+/// endpoint as its pre-flight check.
+pub async fn spill_status() -> impl IntoResponse {
+    let dir = resolve_spill_dir();
+    let exists = dir.is_dir();
+
+    let mut categories = String::from("{");
+    let mut first = true;
+    for kind in ["ticks", "candles", "depth"] {
+        let cat_dir = dir.join(kind);
+        let (count, bytes, newest) = scan_spill_category(&cat_dir);
+        if !first {
+            categories.push(',');
+        }
+        first = false;
+        let newest_field = match newest {
+            Some(name) => format!("\"{}\"", json_escape(&name)),
+            None => "null".to_string(),
+        };
+        categories.push_str(&format!(
+            "\"{kind}\":{{\"file_count\":{count},\"total_bytes\":{bytes},\"newest_file\":{newest_field}}}"
+        ));
+    }
+    categories.push('}');
+
+    // Also scan the top-level spill dir for legacy ticks-YYYYMMDD.bin
+    // files that pre-date the per-category subdirs.
+    let (legacy_count, legacy_bytes, legacy_newest) = scan_legacy_spill(&dir);
+    let legacy_newest_field = match legacy_newest {
+        Some(name) => format!("\"{}\"", json_escape(&name)),
+        None => "null".to_string(),
+    };
+
+    let body = format!(
+        "{{\"spill_dir\":\"{}\",\"exists\":{},\"categories\":{},\"legacy_top_level\":{{\"file_count\":{legacy_count},\"total_bytes\":{legacy_bytes},\"newest_file\":{legacy_newest_field}}}}}",
+        json_escape(&dir.display().to_string()),
+        exists,
+        categories
+    );
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        body,
+    )
+}
+
+fn scan_spill_category(dir: &Path) -> (u64, u64, Option<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (0, 0, None);
+    };
+    let mut count: u64 = 0;
+    let mut bytes: u64 = 0;
+    let mut newest: Option<(std::time::SystemTime, String)> = None;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if !name.ends_with(".bin") {
+            continue;
+        }
+        count += 1;
+        bytes += meta.len();
+        if let Ok(mtime) = meta.modified() {
+            match newest {
+                Some((existing, _)) if mtime <= existing => {}
+                _ => newest = Some((mtime, name)),
+            }
+        }
+    }
+    (count, bytes, newest.map(|(_, n)| n))
+}
+
+fn scan_legacy_spill(dir: &Path) -> (u64, u64, Option<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (0, 0, None);
+    };
+    let mut count: u64 = 0;
+    let mut bytes: u64 = 0;
+    let mut newest: Option<(std::time::SystemTime, String)> = None;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        // Legacy pattern: ticks-YYYYMMDD.bin or candles-*.bin at top level.
+        if !name.ends_with(".bin") {
+            continue;
+        }
+        count += 1;
+        bytes += meta.len();
+        if let Ok(mtime) = meta.modified() {
+            match newest {
+                Some((existing, _)) if mtime <= existing => {}
+                _ => newest = Some((mtime, name)),
+            }
+        }
+    }
+    (count, bytes, newest.map(|(_, n)| n))
+}
+
+fn json_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 fn newest_jsonl(dir: &Path) -> Option<PathBuf> {
@@ -241,6 +385,102 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         unsafe {
             std::env::remove_var(LOGS_DIR_ENV);
+        }
+    }
+
+    #[test]
+    fn resolve_spill_dir_default_when_env_unset() {
+        unsafe {
+            std::env::remove_var(SPILL_DIR_ENV);
+        }
+        assert_eq!(resolve_spill_dir(), PathBuf::from(DEFAULT_SPILL_DIR));
+    }
+
+    #[test]
+    fn resolve_spill_dir_respects_env_override() {
+        unsafe {
+            std::env::set_var(SPILL_DIR_ENV, "/tmp/tv-spill-test");
+        }
+        assert_eq!(resolve_spill_dir(), PathBuf::from("/tmp/tv-spill-test"));
+        unsafe {
+            std::env::remove_var(SPILL_DIR_ENV);
+        }
+    }
+
+    #[test]
+    fn scan_spill_category_returns_zero_when_dir_missing() {
+        let path = PathBuf::from("/nonexistent/spill-test-dir");
+        let (count, bytes, newest) = scan_spill_category(&path);
+        assert_eq!(count, 0);
+        assert_eq!(bytes, 0);
+        assert!(newest.is_none());
+    }
+
+    #[test]
+    fn scan_spill_category_counts_bin_files_and_picks_newest() {
+        let tmp = mktemp("scan_spill");
+        let dir = tmp.path();
+        fs::write(dir.join("ticks-1.bin"), b"abc").unwrap();
+        fs::write(dir.join("ticks-2.bin"), b"defgh").unwrap();
+        fs::write(dir.join("not-spill.txt"), b"ignored").unwrap();
+        let (count, bytes, newest) = scan_spill_category(dir);
+        assert_eq!(count, 2);
+        assert_eq!(bytes, 8);
+        assert!(newest.is_some());
+    }
+
+    #[test]
+    fn json_escape_handles_quotes_and_backslashes() {
+        assert_eq!(json_escape("simple"), "simple");
+        assert_eq!(json_escape(r#"path"with"quotes"#), r#"path\"with\"quotes"#);
+        assert_eq!(json_escape(r"back\slash"), r"back\\slash");
+    }
+
+    #[tokio::test]
+    async fn spill_status_returns_200_with_categories_even_when_dir_missing() {
+        unsafe {
+            std::env::set_var(SPILL_DIR_ENV, "/nonexistent/spill-test-dir-xyz");
+        }
+        let response = spill_status().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+        assert!(body_str.contains("\"exists\":false"));
+        assert!(body_str.contains("\"ticks\""));
+        assert!(body_str.contains("\"candles\""));
+        assert!(body_str.contains("\"depth\""));
+        assert!(body_str.contains("\"file_count\":0"));
+        unsafe {
+            std::env::remove_var(SPILL_DIR_ENV);
+        }
+    }
+
+    #[tokio::test]
+    async fn spill_status_reports_real_counts_when_dir_populated() {
+        let tmp = mktemp("spill_status");
+        // Create category subdirs with one bin each
+        for kind in ["ticks", "candles", "depth"] {
+            let cat_dir = tmp.path().join(kind);
+            fs::create_dir_all(&cat_dir).unwrap();
+            fs::write(cat_dir.join(format!("{kind}-2026-04-19.bin")), b"hello").unwrap();
+        }
+        unsafe {
+            std::env::set_var(SPILL_DIR_ENV, tmp.path().to_str().unwrap());
+        }
+        let response = spill_status().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = std::str::from_utf8(&body).unwrap();
+        assert!(body_str.contains("\"exists\":true"));
+        assert!(body_str.contains("\"file_count\":1"));
+        assert!(body_str.contains("\"total_bytes\":5"));
+        assert!(body_str.contains("ticks-2026-04-19.bin"));
+        unsafe {
+            std::env::remove_var(SPILL_DIR_ENV);
         }
     }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -156,6 +156,10 @@ pub fn build_router(state: SharedAppState, allowed_origins: &[String], dry_run: 
         .route(
             "/api/debug/logs/jsonl/latest",
             axum::routing::get(handlers::debug::logs_jsonl_latest),
+        )
+        .route(
+            "/api/debug/spill/status",
+            axum::routing::get(handlers::debug::spill_status),
         );
 
     public_routes


### PR DESCRIPTION
## Summary — Milestone 6: GET /api/debug/spill/status

Stacked on #286 (M5). Read-only spill-directory diagnostics endpoint.

Lets Claude/operator query "is anything spilled right now?" via MCP without filesystem access. The `auto-fix-drain-spill.sh` script (M3) consumes this endpoint as its pre-flight check.

## Endpoint

`GET /api/debug/spill/status` returns:

```json
{
  "spill_dir": "data/spill",
  "exists": true,
  "categories": {
    "ticks":   { "file_count": 0, "total_bytes": 0, "newest_file": null },
    "candles": { "file_count": 0, "total_bytes": 0, "newest_file": null },
    "depth":   { "file_count": 0, "total_bytes": 0, "newest_file": null }
  },
  "legacy_top_level": { "file_count": 0, "total_bytes": 0, "newest_file": null }
}
```

## Safety

- Strictly read-only — never deletes, never replays, never opens for write
- No locks acquired — concurrent with live ILP writers
- Returns 200 OK even when spill_dir is missing (sets `exists=false`)
- Env var `TV_SPILL_DIR` override mirrors `TV_LOGS_DIR` from M1

## Why M6 (read-only) instead of original M3.5 (mutating)

M3.5 was the 4 mutating endpoints (auth/rotate, ws/reset-pool, kill-switch/activate, spill/drain). Those need **live verification I can't do in the sandbox** — token rotation can lock the Dhan account, kill-switch is one-way for the day, ws-reset drops ticks for 60s. Shipping them blind is irresponsible.

M6 endpoint is read-only — same observability value, zero risk, ships immediately. M3.5 stays queued for when you can co-test from your Mac.

## Tests

`cargo test -p tickvault-api --lib handlers::debug` → **18/18 PASS** (7 new + 11 pre-existing).

## Verification

```
cargo test -p tickvault-api --lib handlers::debug   → 18/18 PASS
bash scripts/100pct-audit.sh                         → 41 PASS / 0 GAP
bash scripts/validate-automation.sh                  → 30/30 PASS
```

## Stack (now 6 PRs)

| PR | Milestone |
|---|---|
| #283 | M1: Universal MCP access |
| #284 | M2: Full ErrorCode triage coverage |
| #285 | M3+M4: Auto-fix catalogue + verify/rollback harness |
| #286 | M5: 100% Audit Tracker |
| **#THIS** | M6: Spill diagnostic endpoint |

https://claude.ai/code/session_01T3z6eYqeNjsaHgDdTe252o