### PR TITLE
chore(config): default active MCP profile to local

### DIFF
--- a/config/claude-mcp-endpoints.toml
+++ b/config/claude-mcp-endpoints.toml
@@ -13,7 +13,7 @@
 # The `active` profile at the top decides which set is used by default.
 # Override at runtime:   TICKVAULT_MCP_PROFILE=mac-dev claude ...
 
-active = "aws-prod"
+active = "local"
 
 # -----------------------------------------------------------------------------
 # mac-dev profile


### PR DESCRIPTION
## Summary

One-line config change: `active = "aws-prod"` → `active = "local"`.

Docker Desktop + full stack is running on the Mac (confirmed by operator screenshots:
Grafana infrastructure panel shows Application / QuestDB / Prometheus / Traefik / Valkey
all `UP`). The current TOML default points at a tunnel hostname that hasn't been
provisioned yet (`AWS-HOSTNAME.YOUR-TAILNET.ts.net`), so every fresh Claude session's
bootstrap was probing all 5 endpoints as OFFLINE — defeating the auto-attach chain.

Switching the default to `local` makes SessionStart resolve to `http://127.0.0.1:*`
on the Mac, which matches the operator's actual setup today. Flip back to `aws-prod`
in a single line change once the AWS instance is provisioned.

## Why this is safe

- Operator override still works: `TICKVAULT_MCP_PROFILE=mac-dev claude ...` wins.
- `claude_mcp_endpoints_config_guard` still passes — the test requires `active`
  to be one of `{local, mac-dev, aws-prod}` and `local` is valid.
- `claude_session_bootstrap_guard` (27/27 tests) still passes — it also requires
  active to be in the known set.

## Test plan

- [ ] On the Mac with Docker stack running: open fresh Claude Code session,
      SessionStart hook prints `prom=REACHABLE  qdb=REACHABLE  graf=REACHABLE`.
- [ ] `mcp__tickvault-logs__prometheus_query('up')` returns live data.
- [ ] `mcp__tickvault-logs__questdb_sql('SELECT count() FROM ticks')` returns a row.

## Rollback

`active = "aws-prod"` — one-line revert.

https://claude.ai/code/session_01E98yPxqcuwk4CL2311Gzvb