### PR TITLE
fix: unblock nifty constituency CSVs + silence I-P1-11 false-alarm

### DIFF
--- a/.claude/rules/project/security-id-uniqueness.md
+++ b/.claude/rules/project/security-id-uniqueness.md
@@ -85,8 +85,14 @@ one of them, leading to:
 7. **Prometheus visibility** — `InstrumentRegistry::cross_segment_collisions()`
    getter exposes the count. `subscription_planner` emits gauges
    `tv_instrument_registry_cross_segment_collisions` and
-   `tv_instrument_registry_total_entries`. Construction WARN upgraded
-   to `error!` so Loki routes it to Telegram.
+   `tv_instrument_registry_total_entries`. Construction log is at
+   `info!` level (downgraded 2026-04-19): both entries are stored
+   safely in `by_composite` and every production caller uses
+   `get_with_segment(id, segment)`, so this is not a data-loss event
+   and does not warrant a Telegram page. Operators see the count via
+   `/health` and `make doctor` (which read the gauge), not via a
+   per-boot alert. Ratchet: `test_cross_segment_log_level_is_info_not_error`
+   in `instrument_registry.rs` blocks regressions back to `error!`.
 
 ## Dashboard enforcement
 

--- a/crates/common/src/instrument_registry.rs
+++ b/crates/common/src/instrument_registry.rs
@@ -211,13 +211,17 @@ impl InstrumentRegistry {
                 instrument.clone(),
             );
 
-            // Legacy index: keyed on security_id alone; collisions fire
-            // an ERROR log (routed to Telegram by Loki) and only one
-            // entry wins (second-seen overwrites). The count is
-            // exposed via the `cross_segment_collisions()` getter so
-            // callers in crates that depend on `metrics` can emit a
-            // Prometheus counter without this common crate taking a
-            // new dependency.
+            // Legacy index: keyed on security_id alone. When two Dhan
+            // instruments share the same numeric id across segments
+            // (e.g. NIFTY id=13 IDX_I + ABB id=13 NSE_EQ), the second
+            // insert overwrites the first in THIS map. The authoritative
+            // `by_composite` map above has already stored BOTH entries
+            // safely — no data is lost. We log at INFO (not ERROR, not
+            // WARN) because every production caller looks up via
+            // `get_with_segment(id, segment)`; the legacy `get(id)`
+            // API is only used by test assertions. The count is exposed
+            // via `cross_segment_collisions()` for operator visibility
+            // (make doctor / /health surface it as a gauge).
             if let Some(prev) = map.insert(instrument.security_id, instrument.clone())
                 && prev.exchange_segment != instrument.exchange_segment
             {
@@ -227,7 +231,7 @@ impl InstrumentRegistry {
                     prev.exchange_segment,
                     instrument.exchange_segment,
                 ));
-                tracing::error!(
+                tracing::info!(
                     code = crate::error_code::ErrorCode::InstrumentP1CrossSegmentCollision.code_str(),
                     severity = crate::error_code::ErrorCode::InstrumentP1CrossSegmentCollision.severity().as_str(),
                     security_id = instrument.security_id,
@@ -235,13 +239,10 @@ impl InstrumentRegistry {
                     new_segment = ?instrument.exchange_segment,
                     prev_symbol = %prev.underlying_symbol,
                     new_symbol = %instrument.underlying_symbol,
-                    "I-P1-11: InstrumentRegistry cross-segment security_id \
-                     collision — BOTH entries stored in composite index; \
-                     legacy get(id) callers will receive whichever entry \
-                     won the HashMap insert race. Operator action: run \
-                     `SELECT segment, security_id FROM ticks GROUP BY segment, \
-                     security_id HAVING count() > 0` to confirm both segments \
-                     are receiving live ticks."
+                    "I-P1-11: Dhan id reused across segments — BOTH entries \
+                     stored safely in composite (id, segment) index. No data \
+                     loss. Production callers use get_with_segment(); legacy \
+                     get(id) is test-only."
                 );
             }
         }
@@ -597,6 +598,39 @@ mod tests {
         assert_eq!(registry.len(), 0);
         assert!(registry.get(13).is_none());
         assert!(!registry.contains(13));
+    }
+
+    /// Ratchet: the I-P1-11 cross-segment event is NOT a data loss —
+    /// `by_composite` stores both entries safely and every production
+    /// caller uses `get_with_segment`. This test blocks any future
+    /// regression that bumps the log back up to `error!` (which would
+    /// route to Telegram via Loki and spam operators every boot for a
+    /// benign Dhan CSV id reuse like NIFTY id=13 + ABB id=13).
+    #[test]
+    fn test_cross_segment_log_level_is_info_not_error() {
+        let source = include_str!("instrument_registry.rs");
+        // Anchor on a substring unique to the production log call site
+        // (the test's own string literals intentionally differ).
+        let prod_msg = "Dhan id reused across segments";
+        let idx = source
+            .find(prod_msg)
+            .expect("I-P1-11 production log message must exist verbatim");
+        let window_start = idx.saturating_sub(1500);
+        let window = &source[window_start..idx];
+        assert!(
+            window.contains("tracing::info!"),
+            "I-P1-11 cross-segment log must be info!, not error! or warn! \
+             — composite index stores both entries, no data loss. Window: {window}"
+        );
+        let lines_before: Vec<&str> = window.lines().rev().take(30).collect();
+        for line in &lines_before {
+            assert!(
+                !line.trim_start().starts_with("tracing::error!"),
+                "Do not restore tracing::error! for I-P1-11 — it is not a \
+                 data-loss event; downgrade kept the Telegram alert channel \
+                 clear for real errors. Offending line: {line}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/index_constituency/csv_downloader.rs
+++ b/crates/core/src/index_constituency/csv_downloader.rs
@@ -119,6 +119,11 @@ async fn download_single_csv(client: &Client, name: &str, url: &str) -> Result<S
             let response = client
                 .get(&url)
                 .header("Accept", "text/csv, application/csv, text/plain, */*")
+                // niftyindices.com gates CSV downloads behind a same-origin
+                // Referer; without it, Cloudflare returns an HTML challenge
+                // page (HTTP 200 + HTML body), which the `<`/`<!DOCTYPE`
+                // check below rejects as "received HTML instead of CSV".
+                .header("Referer", INDEX_CONSTITUENCY_BASE_URL)
                 .send()
                 .await?;
 
@@ -173,6 +178,22 @@ mod tests {
         assert_eq!(
             url,
             "https://www.niftyindices.com/IndexConstituent/ind_nifty50list.csv"
+        );
+    }
+
+    /// Ratchet: niftyindices.com serves CSVs only when the request carries
+    /// a same-origin Referer. Without it Cloudflare returns an HTML WAF
+    /// challenge page and every constituency download fails with
+    /// "received HTML instead of CSV". This source-scan test blocks
+    /// regressions by asserting the `.header("Referer", ...)` call is
+    /// still present in the single request builder.
+    #[test]
+    fn test_single_csv_request_includes_referer_header() {
+        let source = include_str!("csv_downloader.rs");
+        assert!(
+            source.contains(".header(\"Referer\", INDEX_CONSTITUENCY_BASE_URL)"),
+            "Referer header must be set on the single CSV request — \
+             niftyindices.com returns HTML without it"
         );
     }
 


### PR DESCRIPTION
## Summary

Two real issues visible in today's live `data/logs/` on Parthiban's Mac (15:57 IST 2026-04-19):

1. **14 nifty constituency CSV downloads failing** with `received HTML instead of CSV`. Root cause: niftyindices.com gates CSV serving behind a same-origin `Referer` header — Cloudflare returns an HTML WAF challenge otherwise. Fix: add `Referer: https://www.niftyindices.com/` to the single CSV request + ratchet test scanning the source for the header literal.

2. **I-P1-11 firing as ERROR every boot** for NIFTY id=13 (IdxI vs NSE_EQ ABB) and BANKNIFTY id=25 (IdxI vs NSE_EQ ADANIENT). Not a data-loss event: `by_composite: HashMap<(SecurityId, ExchangeSegment), _>` stores both entries safely. Grep of production code: zero callers use `registry.get(id)` without segment — every hit is inside `#[cfg(test)]`. Fix: downgrade to `info!` with accurate wording + ratchet test blocking regression back to `error!`. Rule doc updated.

## Why it matters

- CSV fix: restores 14 missing indices in the constituency map; removes 40+ WARN log lines per boot.
- I-P1-11 fix: stops Telegram spam for a benign Dhan CSV id reuse that will happen every boot forever. Operator still sees the count via `/health` and `cross_segment_collisions()` gauge.

## Test plan

- [x] `test_single_csv_request_includes_referer_header` (new source-scan ratchet)
- [x] `test_cross_segment_log_level_is_info_not_error` (new source-scan ratchet)
- [x] `cargo test -p tickvault-common --lib` — 583/583 pass
- [x] `cargo test -p tickvault-core --lib index_constituency` — 71/71 pass
- [x] `cargo check -p tickvault-common -p tickvault-core --tests` — clean
- [ ] Verify on Mac: 14 currently-failing indices return real CSV after next boot
- [ ] Verify on Mac: no `error!` log fires for I-P1-11; `info!` appears instead; gauge still reports the count

https://claude.ai/code/session_01MWnRXqLXnNFUkbb7dQ1Fmg