### PR TITLE
fix(core,trading,app): precise ATM security_id/display_name + log-noise reductions

### DIFF
--- a/crates/app/src/boot_helpers.rs
+++ b/crates/app/src/boot_helpers.rs
@@ -139,21 +139,83 @@ pub fn format_violation_details(details: &[ViolationDetail]) -> Vec<String> {
 }
 
 /// Formats `CrossMatchMismatch` records into pre-formatted Telegram lines.
+///
+/// Prefers the **expanded per-field Δ format** when `field_deltas` is
+/// non-empty:
+///
+/// ```text
+/// • RELIANCE (NSE_EQ) 1m @ 2026-04-20 10:15 IST
+///     open      : hist=2847.50 live=2847.00  Δ=+0.50
+///     volume    : hist=5000000 live=4999800  Δ=+200
+/// ```
+///
+/// Falls back to the compact legacy Hist+Live+Diff format when
+/// `field_deltas` is empty — which happens for `missing_live` rows (no
+/// live side to delta against) and for test fixtures pre-dating Pass E.
 pub fn format_cross_match_details(details: &[CrossMatchMismatch]) -> Vec<String> {
     details
         .iter()
         .map(|d| {
-            let mut line = format!(
-                "\u{2022} {} ({}) {} @ {}\n  Hist: {}",
-                d.symbol, d.segment, d.timeframe, d.timestamp_ist, d.hist_values
+            let header = format!(
+                "\u{2022} {} ({}) {} @ {}",
+                d.symbol, d.segment, d.timeframe, d.timestamp_ist
             );
-            line.push_str(&format!("\n  Live: {}", d.live_values));
-            if !d.diff_summary.is_empty() {
-                line.push_str(&format!("\n  Diff: {}", d.diff_summary));
+            if d.field_deltas.is_empty() {
+                // Legacy / missing_live path — compact display.
+                let mut line = header;
+                line.push_str(&format!("\n  Hist: {}", d.hist_values));
+                line.push_str(&format!("\n  Live: {}", d.live_values));
+                if !d.diff_summary.is_empty() {
+                    line.push_str(&format!("\n  Diff: {}", d.diff_summary));
+                }
+                return line;
+            }
+            // Expanded per-field Δ format (Pass E — Parthiban directive
+            // 2026-04-20: one line per OHLCV field with hist/live/Δ).
+            let mut line = header;
+            for f in &d.field_deltas {
+                line.push_str("\n  ");
+                line.push_str(&format_field_delta_line(f));
             }
             line
         })
         .collect()
+}
+
+/// Formats a single `FieldDelta` as one Telegram line:
+///   `open      : hist=2847.50 live=2847.00  Δ=+0.50`
+///
+/// Number rendering adapts to the field type:
+/// - `is_integer = true`  (volume / OI) → locale-free integer display
+/// - `is_integer = false` (OHLC prices) → two-decimal fixed-point
+///
+/// The Δ is always signed (`+` or `-`) so the direction is at-a-glance.
+fn format_field_delta_line(f: &tickvault_core::historical::cross_verify::FieldDelta) -> String {
+    // Field name padded to 13 chars so the colon aligns down the list
+    // (longest name is "open_interest" = 13). Monospace Telegram font
+    // honours this alignment.
+    let render = |v: f64| -> String {
+        if f.is_integer {
+            // APPROVED: f64→i64 cast — volumes/OI were built from i64
+            // before widening to f64 for the delta. Round-trip-safe for
+            // all representable i64 values up to 2^53.
+            format!("{}", v as i64)
+        } else {
+            format!("{v:.2}")
+        }
+    };
+    let delta_str = if f.is_integer {
+        format!("{:+}", f.delta as i64)
+    } else {
+        format!("{:+.2}", f.delta)
+    };
+    format!(
+        "{name:<13}: hist={hist} live={live}  \u{0394}={delta}",
+        name = f.field,
+        hist = render(f.hist),
+        live = render(f.live),
+        delta = delta_str,
+    )
 }
 
 /// Computes the sleep duration until the given market close time (IST).
@@ -710,6 +772,10 @@ mod tests {
             hist_values: hist_values.to_string(),
             live_values: live_values.to_string(),
             diff_summary: diff_summary.to_string(),
+            // These fixture tests predate Pass E's `field_deltas` and only
+            // exercise the compact-legacy rendering path (empty vec forces
+            // the formatter into that branch).
+            field_deltas: Vec::new(),
         }
     }
 
@@ -1237,6 +1303,120 @@ mod tests {
         let lines: Vec<&str> = result[0].lines().collect();
         assert!(lines.len() >= 3);
         assert!(lines[0].contains("SYM"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Pass E: expanded per-field Δ format (Parthiban directive 2026-04-20)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_format_cross_match_details_expanded_per_field_format() {
+        use tickvault_core::historical::cross_verify::FieldDelta;
+        let mismatch = CrossMatchMismatch {
+            symbol: "RELIANCE".to_string(),
+            segment: "NSE_EQ".to_string(),
+            timeframe: "1m".to_string(),
+            timestamp_ist: "2026-04-20 10:15 IST".to_string(),
+            mismatch_type: "price_diff".to_string(),
+            hist_values: "O=2847.50 H=2850.00 L=2845.00 C=2847.00 V=125000".to_string(),
+            live_values: "O=2847.00 H=2850.00 L=2845.00 C=2847.00 V=125200".to_string(),
+            diff_summary: "O(+0.50) V(+200)".to_string(),
+            field_deltas: vec![
+                FieldDelta {
+                    field: "open".to_string(),
+                    hist: 2847.50,
+                    live: 2847.00,
+                    delta: -0.50,
+                    is_integer: false,
+                },
+                FieldDelta {
+                    field: "volume".to_string(),
+                    hist: 125_000.0,
+                    live: 125_200.0,
+                    delta: 200.0,
+                    is_integer: true,
+                },
+            ],
+        };
+        let result = format_cross_match_details(std::slice::from_ref(&mismatch));
+        assert_eq!(result.len(), 1);
+        let rendered = &result[0];
+
+        // Header line preserved.
+        assert!(rendered.contains("RELIANCE"), "header present: {rendered}");
+        assert!(rendered.contains("1m @ 2026-04-20 10:15 IST"));
+
+        // One line per field with hist/live/Δ — NOT the compact Hist:/Live: form.
+        assert!(
+            rendered.contains("open"),
+            "field name 'open' must appear: {rendered}"
+        );
+        assert!(
+            rendered.contains("hist=2847.50"),
+            "price rendered to 2 decimals: {rendered}"
+        );
+        assert!(
+            rendered.contains("live=2847.00"),
+            "price live value: {rendered}"
+        );
+        assert!(
+            rendered.contains("\u{0394}=-0.50"),
+            "signed delta with Δ symbol: {rendered}"
+        );
+
+        // Volume uses integer format (no trailing .00, no scientific notation).
+        assert!(
+            rendered.contains("hist=125000"),
+            "volume as integer: {rendered}"
+        );
+        assert!(
+            rendered.contains("\u{0394}=+200"),
+            "integer delta is positive with +: {rendered}"
+        );
+
+        // Compact legacy `Hist:` / `Live:` / `Diff:` labels are SUPPRESSED
+        // when field_deltas is populated — we render the expanded form only.
+        assert!(
+            !rendered.contains("Hist:"),
+            "expanded format must not also show compact Hist: line: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Diff:"),
+            "expanded format must not also show compact Diff: line: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_format_cross_match_details_missing_live_keeps_legacy_compact_format() {
+        // missing_live rows have empty field_deltas by construction — the
+        // formatter must fall back to the compact Hist: + Live: form so the
+        // operator still sees "[MISSING — no live data for this candle]".
+        let mismatch = CrossMatchMismatch {
+            symbol: "NIFTY".to_string(),
+            segment: "IDX_I".to_string(),
+            timeframe: "5m".to_string(),
+            timestamp_ist: "2026-04-20 11:30 IST".to_string(),
+            mismatch_type: "missing_live".to_string(),
+            hist_values: "O=24500.0 H=24510.0 L=24495.0 C=24505.0 V=0".to_string(),
+            live_values: "[MISSING — no live data for this candle]".to_string(),
+            diff_summary: String::new(),
+            field_deltas: Vec::new(),
+        };
+        let result = format_cross_match_details(std::slice::from_ref(&mismatch));
+        let rendered = &result[0];
+        assert!(
+            rendered.contains("Hist:"),
+            "compact Hist: expected: {rendered}"
+        );
+        assert!(
+            rendered.contains("[MISSING"),
+            "missing-live marker preserved: {rendered}"
+        );
+        // No Δ lines — nothing to delta against.
+        assert!(
+            !rendered.contains("\u{0394}="),
+            "no Δ lines without live side: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2293,28 +2293,45 @@ async fn main() -> Result<()> {
 
                 let (atm_ce, atm_pe): (Option<(u32, String)>, Option<(u32, String)>) =
                     if let Some(sel) = selection {
-                        // ATM CE = first call in selection (ATM index), PE = first put
-                        let ce = sel.call_security_ids.first().map(|&sid| {
-                            (
-                                sid,
+                        // CRITICAL: use the dedicated `atm_ce_security_id` /
+                        // `atm_pe_security_id` fields — NOT `.first()` on the
+                        // range vectors. `.first()` returns the LOWEST strike
+                        // in the ATM ± N band, not the ATM itself, so pairing
+                        // it with the center-strike label produced
+                        // Telegram messages like
+                        // `BANKNIFTY-Apr2026-56700-PE (SID 67481)` where the
+                        // SID actually pointed at strike 54300. See
+                        // `depth_strike_selector::DepthStrikeSelection` docs.
+                        //
+                        // LABEL POLICY: prefer the Dhan CSV `display_name`
+                        // (e.g. "BANKNIFTY 28 APR 54300 PUT") over the
+                        // synthesized `UNDERLYING-MmmYYYY-STRIKE-SIDE`
+                        // format, because it matches Dhan's own web UI
+                        // character-for-character. Fall back to the
+                        // synthesized label only if the registry lookup
+                        // didn't populate `display_name` (should not
+                        // happen for contracts present in the CSV).
+                        let ce = sel.atm_ce_security_id.map(|sid| {
+                            let label = sel.atm_ce_display_name.clone().unwrap_or_else(|| {
                                 build_precise_label(
                                     underlying,
                                     sel.expiry_date,
                                     sel.atm_strike,
                                     "CE",
-                                ),
-                            )
+                                )
+                            });
+                            (sid, label)
                         });
-                        let pe = sel.put_security_ids.first().map(|&sid| {
-                            (
-                                sid,
+                        let pe = sel.atm_pe_security_id.map(|sid| {
+                            let label = sel.atm_pe_display_name.clone().unwrap_or_else(|| {
                                 build_precise_label(
                                     underlying,
                                     sel.expiry_date,
                                     sel.atm_strike,
                                     "PE",
-                                ),
-                            )
+                                )
+                            });
+                            (sid, label)
                         });
                         (ce, pe)
                     } else {
@@ -3099,6 +3116,13 @@ async fn main() -> Result<()> {
                             .expiry
                             .map_or_else(|| "?".to_string(), |e| e.format("%b%Y").to_string());
 
+                        // Format a rebalance contract line for Telegram. Prefer
+                        // the Dhan CSV `display_name` (e.g.
+                        // "BANKNIFTY 28 APR 54300 PUT (SID 67481)") — it
+                        // matches Dhan's web UI verbatim and is the string the
+                        // operator is most likely to search for. Fall back to
+                        // the synthesized `UNDERLYING-MmmYYYY-STRIKE-SIDE`
+                        // only if the registry lookup didn't populate it.
                         let fmt_contract = |atm: &Option<
                             tickvault_core::instrument::depth_strike_selector::AtmIds,
                         >,
@@ -3106,15 +3130,19 @@ async fn main() -> Result<()> {
                          -> String {
                             match atm {
                                 Some(ids) => {
-                                    let sid = if opt == "CE" {
-                                        ids.ce_id
+                                    let (sid, display) = if opt == "CE" {
+                                        (ids.ce_id, ids.ce_display_name.as_deref())
                                     } else {
-                                        ids.pe_id.unwrap_or(0)
+                                        (ids.pe_id.unwrap_or(0), ids.pe_display_name.as_deref())
                                     };
-                                    format!(
-                                        "{}-{}-{:.0}-{} ({})",
-                                        ul, expiry_str, ids.strike, opt, sid
-                                    )
+                                    if let Some(name) = display {
+                                        format!("{name} (SID {sid})")
+                                    } else {
+                                        format!(
+                                            "{}-{}-{:.0}-{} ({})",
+                                            ul, expiry_str, ids.strike, opt, sid
+                                        )
+                                    }
                                 }
                                 None => "—".to_string(),
                             }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4328,30 +4328,63 @@ fn spawn_historical_candle_fetch(
                     reason: "no live data in materialized views".to_string(),
                     candles_compared: cross_match.candles_compared,
                 });
-            } else if cross_match.passed {
-                bg_notifier.notify(NotificationEvent::CandleCrossMatchPassed {
-                    timeframes_checked: cross_match.timeframes_checked,
-                    candles_compared: cross_match.candles_compared,
-                });
             } else {
-                // Build per-timeframe summary for Telegram (e.g., "1m: 3 | 5m: 0 | 15m: 1")
-                let tf_summary: String = cross_match
-                    .per_timeframe_mismatches
-                    .iter()
-                    .map(|(tf, count)| format!("{tf}: {count}"))
-                    .collect::<Vec<_>>()
-                    .join(" | ");
-                let mut details = format_cross_match_details(&cross_match.mismatch_details);
-                // Prepend per-timeframe summary as first line
-                if !tf_summary.is_empty() {
-                    details.insert(0, format!("Per-timeframe: {tf_summary}"));
+                // Compute the "TODAY ONLY: YYYY-MM-DD HH:MM–HH:MM IST" label
+                // once and pass to both pass/fail notifications so the operator
+                // immediately sees which trading session the OK/FAIL covers.
+                // The start/end SQL literals on `today_window` look like
+                // `'2026-04-20T09:15:00.000000Z'` — we strip the quotes + the
+                // date + `.000000Z` suffix to render a human-readable
+                // `HH:MM` slice of the IST wall clock.
+                let today_ist_label = {
+                    let date_str = today_window.today_ist.format("%Y-%m-%d").to_string();
+                    let hm = |sql: &str| -> String {
+                        sql.trim_matches('\'')
+                            .split('T')
+                            .nth(1)
+                            .and_then(|t| {
+                                t.split(':')
+                                    .collect::<Vec<_>>()
+                                    .get(..2)
+                                    .map(|s| s.join(":"))
+                            })
+                            .unwrap_or_else(|| "??:??".to_string())
+                    };
+                    format!(
+                        "{date} {start}–{end} IST",
+                        date = date_str,
+                        start = hm(&today_window.start_sql),
+                        end = hm(&today_window.end_sql),
+                    )
+                };
+
+                if cross_match.passed {
+                    bg_notifier.notify(NotificationEvent::CandleCrossMatchPassed {
+                        timeframes_checked: cross_match.timeframes_checked,
+                        candles_compared: cross_match.candles_compared,
+                        today_ist_label,
+                    });
+                } else {
+                    // Build per-timeframe summary for Telegram (e.g., "1m: 3 | 5m: 0 | 15m: 1")
+                    let tf_summary: String = cross_match
+                        .per_timeframe_mismatches
+                        .iter()
+                        .map(|(tf, count)| format!("{tf}: {count}"))
+                        .collect::<Vec<_>>()
+                        .join(" | ");
+                    let mut details = format_cross_match_details(&cross_match.mismatch_details);
+                    // Prepend per-timeframe summary as first line
+                    if !tf_summary.is_empty() {
+                        details.insert(0, format!("Per-timeframe: {tf_summary}"));
+                    }
+                    bg_notifier.notify(NotificationEvent::CandleCrossMatchFailed {
+                        candles_compared: cross_match.candles_compared,
+                        mismatches: cross_match.mismatches,
+                        missing_live: cross_match.missing_live,
+                        mismatch_details: details,
+                        today_ist_label,
+                    });
                 }
-                bg_notifier.notify(NotificationEvent::CandleCrossMatchFailed {
-                    candles_compared: cross_match.candles_compared,
-                    mismatches: cross_match.mismatches,
-                    missing_live: cross_match.missing_live,
-                    mismatch_details: details,
-                });
             }
 
             info!(

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4233,16 +4233,26 @@ fn spawn_historical_candle_fetch(
         // Cross-verify + cross-match: TODAY-ONLY window gating
         //
         // Gate both operations on:
-        //  1. `is_trading_day` — weekend / NSE holiday → skip both with a
-        //     typed SKIPPED notification so operator gets closure on Telegram.
+        //  1. `is_trading_day` — weekend / NSE holiday → skip with a typed
+        //     SKIPPED notification so operator gets closure on Telegram.
         //  2. `TodayIstWindow::from_now()` — pre-market (before 09:15 IST)
-        //     returns None → skip both (nothing to verify yet).
+        //     on a trading day → SILENT skip (INFO log only, NO Telegram).
+        //     Per Parthiban directive 2026-04-20:
+        //       "pre market cross verification should never ever be done
+        //        especially on trading days"
+        //     Verification needs live data; running it pre-market is
+        //     guaranteed-empty noise. The post-market timer will fire it
+        //     correctly once live ticks land.
+        //  3. Once-per-day success cache —
+        //     `cross_verify_already_succeeded_today` checks for a marker
+        //     file written after BOTH verify + match passed earlier today.
+        //     Per Parthiban directive 2026-04-20:
+        //       "even for post verification also only once in a day until
+        //        it achieves success verification should be done"
+        //     If today already succeeded, skip silently.
         //
         // Otherwise pass the window to both functions so their SQL WHERE
-        // clauses are narrowed to today's 09:15-15:30 IST session. Fixes the
-        // "12 days of accumulated data falsely passing" bug where the old
-        // `dateadd('d', -3, now())` window compared multi-day Dhan-sourced
-        // aggregates against the same-day Dhan REST fetch (vacuous OK).
+        // clauses are narrowed to today's 09:15-15:30 IST session.
         // -----------------------------------------------------------------
         let today_window = if is_trading_day {
             tickvault_core::historical::cross_verify::TodayIstWindow::from_now()
@@ -4251,24 +4261,46 @@ fn spawn_historical_candle_fetch(
         };
 
         let Some(today_window) = today_window else {
-            let reason = if !is_trading_day {
-                "weekend or holiday — not a trading day".to_string()
+            if !is_trading_day {
+                // Weekend / holiday — operator-visible SKIPPED notification.
+                let reason = "weekend or holiday — not a trading day".to_string();
+                info!(
+                    instruments_fetched = summary.instruments_fetched,
+                    instruments_failed = summary.instruments_failed,
+                    total_candles = summary.total_candles,
+                    %reason,
+                    "cross-verify + cross-match SKIPPED"
+                );
+                bg_notifier.notify(NotificationEvent::CandleCrossMatchSkipped {
+                    reason,
+                    candles_compared: 0,
+                });
             } else {
-                "pre-market (before 09:15 IST) — no live data yet".to_string()
-            };
-            info!(
-                instruments_fetched = summary.instruments_fetched,
-                instruments_failed = summary.instruments_failed,
-                total_candles = summary.total_candles,
-                %reason,
-                "cross-verify + cross-match SKIPPED"
-            );
-            bg_notifier.notify(NotificationEvent::CandleCrossMatchSkipped {
-                reason,
-                candles_compared: 0,
-            });
+                // Pre-market on a trading day — silent skip per Parthiban
+                // directive. INFO log only; NO Telegram notification.
+                info!(
+                    instruments_fetched = summary.instruments_fetched,
+                    instruments_failed = summary.instruments_failed,
+                    total_candles = summary.total_candles,
+                    "cross-verify + cross-match SILENTLY skipped — pre-market on trading day (will run post-market)"
+                );
+            }
             return;
         };
+
+        // Once-per-day success idempotency. The marker is written below
+        // after BOTH verify + match succeed. Crash-recovery boots and
+        // mid-day restarts therefore won't re-fire the verification.
+        if tickvault_core::historical::cross_verify::cross_verify_already_succeeded_today(
+            today_window.today_ist,
+        ) {
+            info!(
+                today_ist = %today_window.today_ist,
+                marker = ?tickvault_core::historical::cross_verify::cross_verify_success_marker_path(today_window.today_ist),
+                "cross-verify SILENTLY skipped — today's verification already succeeded earlier (marker present)"
+            );
+            return;
+        }
 
         // -----------------------------------------------------------------
         // Cross-verify candle integrity in QuestDB
@@ -4387,12 +4419,40 @@ fn spawn_historical_candle_fetch(
                 }
             }
 
+            // Once-per-day success marker. Both verify AND cross-match must
+            // pass; on success, write a file marker so subsequent restarts
+            // today skip the verification entirely. If either is not-passed
+            // (or skipped due to no live data), do NOT mark — next run will
+            // retry from scratch. Per Parthiban directive 2026-04-20:
+            // "only once in a day until it achieves success".
+            let full_success = verify_report.passed && cross_match.passed;
+            if full_success {
+                match tickvault_core::historical::cross_verify::mark_cross_verify_success(
+                    today_window.today_ist,
+                ) {
+                    Ok(()) => {
+                        info!(
+                            today_ist = %today_window.today_ist,
+                            "cross-verify success marker written — today's verification will not run again"
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            today_ist = %today_window.today_ist,
+                            "failed to write cross-verify success marker (verification still passed; next restart will re-run)"
+                        );
+                    }
+                }
+            }
+
             info!(
                 instruments_fetched = summary.instruments_fetched,
                 instruments_failed = summary.instruments_failed,
                 total_candles = summary.total_candles,
                 verification_passed = verify_report.passed,
                 cross_match_passed = cross_match.passed,
+                full_success_marker_written = full_success,
                 today_ist = %today_window.today_ist,
                 window_start = %today_window.start_sql,
                 window_end = %today_window.end_sql,

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4230,9 +4230,51 @@ fn spawn_historical_candle_fetch(
         }
 
         // -----------------------------------------------------------------
+        // Cross-verify + cross-match: TODAY-ONLY window gating
+        //
+        // Gate both operations on:
+        //  1. `is_trading_day` — weekend / NSE holiday → skip both with a
+        //     typed SKIPPED notification so operator gets closure on Telegram.
+        //  2. `TodayIstWindow::from_now()` — pre-market (before 09:15 IST)
+        //     returns None → skip both (nothing to verify yet).
+        //
+        // Otherwise pass the window to both functions so their SQL WHERE
+        // clauses are narrowed to today's 09:15-15:30 IST session. Fixes the
+        // "12 days of accumulated data falsely passing" bug where the old
+        // `dateadd('d', -3, now())` window compared multi-day Dhan-sourced
+        // aggregates against the same-day Dhan REST fetch (vacuous OK).
+        // -----------------------------------------------------------------
+        let today_window = if is_trading_day {
+            tickvault_core::historical::cross_verify::TodayIstWindow::from_now()
+        } else {
+            None
+        };
+
+        let Some(today_window) = today_window else {
+            let reason = if !is_trading_day {
+                "weekend or holiday — not a trading day".to_string()
+            } else {
+                "pre-market (before 09:15 IST) — no live data yet".to_string()
+            };
+            info!(
+                instruments_fetched = summary.instruments_fetched,
+                instruments_failed = summary.instruments_failed,
+                total_candles = summary.total_candles,
+                %reason,
+                "cross-verify + cross-match SKIPPED"
+            );
+            bg_notifier.notify(NotificationEvent::CandleCrossMatchSkipped {
+                reason,
+                candles_compared: 0,
+            });
+            return;
+        };
+
+        // -----------------------------------------------------------------
         // Cross-verify candle integrity in QuestDB
         // -----------------------------------------------------------------
-        let verify_report = verify_candle_integrity(&bg_questdb_config, &bg_registry).await;
+        let verify_report =
+            verify_candle_integrity(&bg_questdb_config, &bg_registry, &today_window).await;
         let timeframe_details = format_timeframe_details(&verify_report);
         if verify_report.passed {
             bg_notifier.notify(NotificationEvent::CandleVerificationPassed {
@@ -4261,12 +4303,12 @@ fn spawn_historical_candle_fetch(
         }
 
         // -----------------------------------------------------------------
-        // Cross-match historical vs live candle data (trading day only —
-        // on non-trading days there's no live data to compare against)
+        // Cross-match historical vs live candle data
         // -----------------------------------------------------------------
-        if is_trading_day {
+        {
             let cross_match =
-                cross_match_historical_vs_live(&bg_questdb_config, &bg_registry).await;
+                cross_match_historical_vs_live(&bg_questdb_config, &bg_registry, &today_window)
+                    .await;
 
             if !cross_match.live_candles_present || cross_match.candles_compared == 0 {
                 // First run / fresh DB / post-market boot with no live ticks yet.
@@ -4318,24 +4360,11 @@ fn spawn_historical_candle_fetch(
                 total_candles = summary.total_candles,
                 verification_passed = verify_report.passed,
                 cross_match_passed = cross_match.passed,
-                "post-market historical fetch + cross-verification complete"
+                today_ist = %today_window.today_ist,
+                window_start = %today_window.start_sql,
+                window_end = %today_window.end_sql,
+                "post-market historical fetch + cross-verification complete (TODAY ONLY)"
             );
-        } else {
-            // Non-trading day: skip cross-match (no live data to compare).
-            // Emit the typed SKIPPED notification so the operator gets
-            // explicit closure on Telegram instead of silently missing
-            // the post-fetch cross-match step on weekends / holidays.
-            info!(
-                instruments_fetched = summary.instruments_fetched,
-                instruments_failed = summary.instruments_failed,
-                total_candles = summary.total_candles,
-                verification_passed = verify_report.passed,
-                "non-trading day historical fetch complete (cross-match skipped — no live data)"
-            );
-            bg_notifier.notify(NotificationEvent::CandleCrossMatchSkipped {
-                reason: "weekend or holiday — not a trading day".to_string(),
-                candles_compared: 0,
-            });
         }
     });
 

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -22,12 +22,13 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Utc};
 use reqwest::Client;
 use tracing::{debug, error, info, warn};
 
 use tickvault_common::config::QuestDbConfig;
 use tickvault_common::constants::{
-    CANDLES_PER_TRADING_DAY, QUESTDB_TABLE_HISTORICAL_CANDLES, TIMEFRAME_1M,
+    CANDLES_PER_TRADING_DAY, IST_UTC_OFFSET_SECONDS, QUESTDB_TABLE_HISTORICAL_CANDLES, TIMEFRAME_1M,
 };
 use tickvault_common::instrument_registry::InstrumentRegistry;
 
@@ -215,6 +216,101 @@ const CROSS_MATCH_TIMEFRAMES: &[(&str, &str)] = &[
     ("60m", "candles_1h"),
     ("1d", "candles_1d"),
 ];
+
+// ---------------------------------------------------------------------------
+// Today-only SQL window (fixes "12 days accumulated data falsely passing" bug)
+// ---------------------------------------------------------------------------
+
+/// Today's IST trading-session SQL window, ready to drop into WHERE clauses.
+///
+/// **Why this exists:** before 2026-04-20 the cross-verify queries used a
+/// rolling `ts > dateadd('d', -3, now())` 3-day window. Because QuestDB data
+/// is persistent across app restarts (Docker volume), that window captured
+/// ticks from MANY prior trading sessions. Cross-match compared 12+ days of
+/// accumulated live ticks against the REST historical fetch — which trivially
+/// "passed" because both data sources come from Dhan. The OK was legitimate
+/// but meaningless for verifying TODAY's session.
+///
+/// `ts` in QuestDB was stored as IST-epoch (WebSocket LTT is IST epoch seconds
+/// per `data-integrity.md`). A literal like `'2026-04-20T09:15:00.000000Z'`
+/// is parsed by QuestDB as UTC-epoch for 09:15 on that date — which exactly
+/// matches the IST-epoch representation we stored for the IST 09:15 tick,
+/// because both share the same numeric value (IST wall clock treated as UTC).
+///
+/// The window is `[today_0915_ist, min(now_ist, today_1530_ist)]` so that:
+/// - During market hours → compare only what live has produced so far
+/// - Post-market → compare the full 09:15-15:30 session
+/// - Pre-market (before 09:15) → `from_utc` returns `None`
+///
+/// Production caller builds this via [`TodayIstWindow::from_now`]. Tests
+/// drive determinism via [`TodayIstWindow::from_utc`].
+#[derive(Debug, Clone)]
+pub struct TodayIstWindow {
+    /// IST date of "today" (used for Telegram labels like "TODAY ONLY: 2026-04-20").
+    pub today_ist: NaiveDate,
+    /// SQL-ready timestamp literal for window start (including quotes).
+    /// Example: `'2026-04-20T09:15:00.000000Z'`.
+    pub start_sql: String,
+    /// SQL-ready timestamp literal for window end (including quotes).
+    /// Example: `'2026-04-20T15:30:00.000000Z'` or earlier during the session.
+    pub end_sql: String,
+}
+
+impl TodayIstWindow {
+    /// Computes today's IST trading-session window from the current UTC time.
+    /// Returns `None` before 09:15 IST (no window exists yet).
+    pub fn from_now() -> Option<Self> {
+        Self::from_utc(Utc::now())
+    }
+
+    /// Computes today's IST trading-session window from a given UTC instant.
+    /// Pure function — suitable for deterministic tests.
+    pub fn from_utc(now_utc: DateTime<Utc>) -> Option<Self> {
+        // APPROVED: IST_UTC_OFFSET_SECONDS (19800) is a compile-time provable
+        // valid FixedOffset — same pattern as trading_calendar::ist_fixed_offset.
+        let ist = FixedOffset::east_opt(IST_UTC_OFFSET_SECONDS)?;
+        let now_ist = now_utc.with_timezone(&ist);
+        let today_ist = now_ist.date_naive();
+        let start_naive: NaiveDateTime = today_ist.and_hms_opt(9, 15, 0)?;
+        let market_end_naive: NaiveDateTime = today_ist.and_hms_opt(15, 30, 0)?;
+        let now_naive = now_ist.naive_local();
+        // Pre-market: nothing to compare yet.
+        if now_naive < start_naive {
+            return None;
+        }
+        let effective_end = if now_naive < market_end_naive {
+            now_naive
+        } else {
+            market_end_naive
+        };
+        Some(Self {
+            today_ist,
+            start_sql: format!("'{}'", start_naive.format("%Y-%m-%dT%H:%M:%S.000000Z")),
+            end_sql: format!("'{}'", effective_end.format("%Y-%m-%dT%H:%M:%S.000000Z")),
+        })
+    }
+
+    /// Returns the SQL fragment `ts >= '...' AND ts <= '...'` suitable for
+    /// dropping into any WHERE clause. Replaces the old
+    /// `ts > dateadd('d', -3, now())` 3-day window.
+    pub fn where_clause(&self) -> String {
+        format!(
+            "ts >= {start} AND ts <= {end}",
+            start = self.start_sql,
+            end = self.end_sql,
+        )
+    }
+
+    /// Same as [`where_clause`] but prefixed with a table alias
+    /// (e.g. `"h"` → `h.ts >= '...' AND h.ts <= '...'`).
+    pub fn where_clause_aliased(&self, alias: &str) -> String {
+        format!(
+            "{alias}.ts >= {start} AND {alias}.ts <= {end}",
+            start = self.start_sql,
+            end = self.end_sql,
+        )
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Pure Helper Functions (extracted for testability)
@@ -714,6 +810,7 @@ fn failed_report() -> CrossVerificationReport {
 pub async fn verify_candle_integrity(
     questdb_config: &QuestDbConfig,
     registry: &InstrumentRegistry,
+    today_window: &TodayIstWindow,
 ) -> CrossVerificationReport {
     let base_url = format!(
         "http://{}:{}/exec",
@@ -731,15 +828,22 @@ pub async fn verify_candle_integrity(
         }
     };
 
+    // Today's IST trading-session window — replaces the old rolling 3-day
+    // `dateadd('d', -3, now())` bound, which (because QuestDB persists across
+    // app restarts via Docker volume) captured up to 12 prior sessions'
+    // accumulated ticks. See `TodayIstWindow` docstring for the full rationale.
+    let ts_filter = today_window.where_clause();
+
     // --- Step 1: Per-timeframe coverage query ---
     // Groups by (timeframe, security_id) to get counts per instrument per timeframe.
-    // Use 3-day window to ensure daily candles (stamped at IST midnight = hour 0)
-    // are always captured regardless of when verification runs.
-    // Intraday candles from today are also within this window.
+    // Narrowed to TODAY ONLY (09:15-15:30 IST). Daily candles (stamped at IST
+    // midnight = hour 0 of the NEXT calendar day in the old semantics) are
+    // intentionally NOT captured by this intraday window — the daily cross-check
+    // happens on a separate path post-close.
     let coverage_query = format!(
         "SELECT timeframe, security_id, count() as candle_count \
          FROM {} \
-         WHERE ts > dateadd('d', -3, now()) \
+         WHERE {ts_filter} \
          GROUP BY timeframe, security_id \
          ORDER BY timeframe, candle_count DESC",
         QUESTDB_TABLE_HISTORICAL_CANDLES
@@ -791,7 +895,7 @@ pub async fn verify_candle_integrity(
     // --- Step 3: OHLC consistency check (high < low) with details ---
     let ohlc_count_query = format!(
         "SELECT count() FROM {} \
-         WHERE ts > dateadd('d', -3, now()) AND high < low",
+         WHERE {ts_filter} AND high < low",
         QUESTDB_TABLE_HISTORICAL_CANDLES
     );
 
@@ -801,7 +905,7 @@ pub async fn verify_candle_integrity(
         let ohlc_detail_query = format!(
             "SELECT security_id, segment, timeframe, ts, open, high, low, close, volume \
              FROM {} \
-             WHERE ts > dateadd('d', -3, now()) AND high < low \
+             WHERE {ts_filter} AND high < low \
              LIMIT {}",
             QUESTDB_TABLE_HISTORICAL_CANDLES, MAX_VIOLATION_DETAILS
         );
@@ -827,7 +931,7 @@ pub async fn verify_candle_integrity(
     // --- Step 4: Data integrity check (non-positive prices) with details ---
     let data_count_query = format!(
         "SELECT count() FROM {} \
-         WHERE ts > dateadd('d', -3, now()) \
+         WHERE {ts_filter} \
          AND (open <= 0 OR high <= 0 OR low <= 0 OR close <= 0)",
         QUESTDB_TABLE_HISTORICAL_CANDLES
     );
@@ -838,7 +942,7 @@ pub async fn verify_candle_integrity(
         let data_detail_query = format!(
             "SELECT security_id, segment, timeframe, ts, open, high, low, close, volume \
              FROM {} \
-             WHERE ts > dateadd('d', -3, now()) \
+             WHERE {ts_filter} \
              AND (open <= 0 OR high <= 0 OR low <= 0 OR close <= 0) \
              LIMIT {}",
             QUESTDB_TABLE_HISTORICAL_CANDLES, MAX_VIOLATION_DETAILS
@@ -870,7 +974,7 @@ pub async fn verify_candle_integrity(
     // Any candle at 15:30+ is a violation regardless of timeframe.
     let ts_count_query = format!(
         "SELECT count() FROM {} \
-         WHERE ts > dateadd('d', -3, now()) \
+         WHERE {ts_filter} \
          AND timeframe != '1d' \
          AND (hour(ts) < 9 OR hour(ts) > 15 \
               OR (hour(ts) = 9 AND minute(ts) < 15) \
@@ -884,7 +988,7 @@ pub async fn verify_candle_integrity(
         let ts_detail_query = format!(
             "SELECT security_id, segment, timeframe, ts, open, high, low, close, volume \
              FROM {} \
-             WHERE ts > dateadd('d', -3, now()) \
+             WHERE {ts_filter} \
              AND timeframe != '1d' \
              AND (hour(ts) < 9 OR hour(ts) > 15 \
                   OR (hour(ts) = 9 AND minute(ts) < 15) \
@@ -916,7 +1020,7 @@ pub async fn verify_candle_integrity(
     // NSE is closed on weekends — no trading, no settlement, no data.
     let weekend_count_query = format!(
         "SELECT count() FROM {} \
-         WHERE ts > dateadd('d', -3, now()) \
+         WHERE {ts_filter} \
          AND (day_of_week(ts) = 6 OR day_of_week(ts) = 7)",
         QUESTDB_TABLE_HISTORICAL_CANDLES
     );
@@ -927,7 +1031,7 @@ pub async fn verify_candle_integrity(
         let weekend_detail_query = format!(
             "SELECT security_id, segment, timeframe, ts, open, high, low, close, volume \
              FROM {} \
-             WHERE ts > dateadd('d', -3, now()) \
+             WHERE {ts_filter} \
              AND (day_of_week(ts) = 6 OR day_of_week(ts) = 7) \
              LIMIT {}",
             QUESTDB_TABLE_HISTORICAL_CANDLES, MAX_VIOLATION_DETAILS
@@ -1023,6 +1127,7 @@ pub async fn verify_candle_integrity(
 pub async fn cross_match_historical_vs_live(
     questdb_config: &QuestDbConfig,
     registry: &InstrumentRegistry,
+    today_window: &TodayIstWindow,
 ) -> CrossMatchReport {
     let base_url = format!(
         "http://{}:{}/exec",
@@ -1039,6 +1144,12 @@ pub async fn cross_match_historical_vs_live(
             return failed_cross_match_report();
         }
     };
+
+    // Today's IST trading-session window (see `TodayIstWindow`). `ts_filter`
+    // for unaliased queries (bare `candles_*` live tables); `ts_filter_h` for
+    // LEFT-JOIN queries that alias `historical_candles` as `h`.
+    let ts_filter = today_window.where_clause();
+    let ts_filter_h = today_window.where_clause_aliased("h");
 
     let mut total_compared = 0_usize;
     let mut total_mismatches = 0_usize;
@@ -1087,10 +1198,7 @@ pub async fn cross_match_historical_vs_live(
         // we still run the per-timeframe LEFT JOIN below for completeness
         // but the caller will refuse to emit "OK" without at least one
         // timeframe reporting live rows.
-        let live_count_query = format!(
-            "SELECT count() FROM {} WHERE ts > dateadd('d', -3, now())",
-            live_table
-        );
+        let live_count_query = format!("SELECT count() FROM {} WHERE {ts_filter}", live_table);
         let live_tf_rows = extract_count(&client, &base_url, &live_count_query).await;
         if live_tf_rows > 0 {
             live_candles_present = true;
@@ -1100,7 +1208,7 @@ pub async fn cross_match_historical_vs_live(
         let count_query = format!(
             "SELECT count() FROM {} h \
              LEFT JOIN {} m ON h.security_id = m.security_id AND h.ts = m.ts AND h.segment = m.segment \
-             WHERE h.timeframe = '{}' AND h.ts > dateadd('d', -3, now())",
+             WHERE h.timeframe = '{}' AND {ts_filter_h}",
             QUESTDB_TABLE_HISTORICAL_CANDLES, live_table, hist_tf
         );
 
@@ -1121,7 +1229,7 @@ pub async fn cross_match_historical_vs_live(
                     h.open_interest, m.open_interest \
              FROM {} h \
              LEFT JOIN {} m ON h.security_id = m.security_id AND h.ts = m.ts AND h.segment = m.segment \
-             WHERE h.timeframe = '{}' AND h.ts > dateadd('d', -3, now()) \
+             WHERE h.timeframe = '{}' AND {ts_filter_h} \
              AND (m.open IS NULL \
                   OR abs(h.open - m.open) > {eps} \
                   OR abs(h.high - m.high) > {eps} \
@@ -1369,6 +1477,149 @@ async fn parse_cross_match_rows_with_oi(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // TodayIstWindow — today-only SQL window (fixes "12 days accumulated" bug)
+    // -----------------------------------------------------------------------
+
+    /// Build a UTC instant equivalent to an IST wall-clock time on the given date.
+    fn utc_at_ist(year: i32, month: u32, day: u32, ist_h: u32, ist_m: u32) -> DateTime<Utc> {
+        // IST is UTC+5:30 → subtract 5:30 from IST wall-clock to get UTC.
+        let naive_ist = NaiveDate::from_ymd_opt(year, month, day)
+            .expect("valid date")
+            .and_hms_opt(ist_h, ist_m, 0)
+            .expect("valid time");
+        let naive_utc = naive_ist - chrono::Duration::seconds(i64::from(IST_UTC_OFFSET_SECONDS));
+        DateTime::<Utc>::from_naive_utc_and_offset(naive_utc, Utc)
+    }
+
+    #[test]
+    fn test_today_ist_window_pre_market_returns_none() {
+        // 09:14 IST — 1 minute before market open — should return None.
+        let now = utc_at_ist(2026, 4, 20, 9, 14);
+        assert!(TodayIstWindow::from_utc(now).is_none());
+    }
+
+    #[test]
+    fn test_today_ist_window_at_market_open_returns_some_at_boundary() {
+        // Exactly 09:15 IST — boundary, should be Some with start == end.
+        let now = utc_at_ist(2026, 4, 20, 9, 15);
+        let w = TodayIstWindow::from_utc(now).expect("at boundary is inclusive");
+        assert_eq!(w.today_ist, NaiveDate::from_ymd_opt(2026, 4, 20).unwrap());
+        assert!(w.start_sql.contains("T09:15:00"));
+        // now == start → effective_end == start
+        assert_eq!(w.start_sql, w.end_sql);
+    }
+
+    #[test]
+    fn test_today_ist_window_mid_session_clamps_end_to_now() {
+        // 12:00 IST — mid-session — window end should be 12:00, not 15:30.
+        let now = utc_at_ist(2026, 4, 20, 12, 0);
+        let w = TodayIstWindow::from_utc(now).expect("mid-session window exists");
+        assert!(w.start_sql.contains("T09:15:00"));
+        assert!(w.end_sql.contains("T12:00:00"));
+    }
+
+    #[test]
+    fn test_today_ist_window_post_market_clamps_end_to_1530() {
+        // 18:00 IST — post-market — end should be 15:30, not 18:00.
+        let now = utc_at_ist(2026, 4, 20, 18, 0);
+        let w = TodayIstWindow::from_utc(now).expect("post-market window exists");
+        assert!(w.start_sql.contains("T09:15:00"));
+        assert!(
+            w.end_sql.contains("T15:30:00"),
+            "post-market end must clamp to 15:30: {}",
+            w.end_sql
+        );
+    }
+
+    #[test]
+    fn test_today_ist_window_at_market_close_returns_full_session() {
+        // Exactly 15:30 IST — close boundary — should clamp to 15:30.
+        let now = utc_at_ist(2026, 4, 20, 15, 30);
+        let w = TodayIstWindow::from_utc(now).expect("close boundary window exists");
+        assert!(w.end_sql.contains("T15:30:00"));
+    }
+
+    #[test]
+    fn test_today_ist_window_where_clause_format() {
+        let now = utc_at_ist(2026, 4, 20, 12, 0);
+        let w = TodayIstWindow::from_utc(now).unwrap();
+        let clause = w.where_clause();
+        assert!(clause.starts_with("ts >= '"), "got: {clause}");
+        assert!(
+            clause.contains(" AND ts <= '"),
+            "clause must be bounded both sides: {clause}"
+        );
+        assert!(clause.contains("2026-04-20T09:15:00"));
+        assert!(clause.contains("2026-04-20T12:00:00"));
+    }
+
+    #[test]
+    fn test_today_ist_window_where_clause_aliased_format() {
+        let now = utc_at_ist(2026, 4, 20, 12, 0);
+        let w = TodayIstWindow::from_utc(now).unwrap();
+        let clause = w.where_clause_aliased("h");
+        assert!(clause.starts_with("h.ts >= '"), "got: {clause}");
+        assert!(clause.contains(" AND h.ts <= '"));
+        // Every `ts` reference must carry the `h.` alias — there should be
+        // exactly two (one for `>=`, one for `<=`) and no bare ones.
+        assert_eq!(
+            clause.matches("h.ts").count(),
+            2,
+            "expected exactly 2 h.ts references: {clause}"
+        );
+    }
+
+    #[test]
+    fn test_today_ist_window_is_stable_across_day_boundary() {
+        // 2026-04-20 23:59 UTC == 2026-04-21 05:29 IST — still today-ist = 21,
+        // but 05:29 is pre-market → None.
+        let now = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDate::from_ymd_opt(2026, 4, 20)
+                .unwrap()
+                .and_hms_opt(23, 59, 0)
+                .unwrap(),
+            Utc,
+        );
+        assert!(
+            TodayIstWindow::from_utc(now).is_none(),
+            "pre-market on the NEXT IST day must return None"
+        );
+    }
+
+    #[test]
+    fn test_today_ist_window_rolls_over_at_ist_midnight() {
+        // 18:45 UTC on 2026-04-20 == 00:15 IST on 2026-04-21.
+        // That's pre-market on 2026-04-21 IST → None, and `today_ist` would
+        // be 21 if a window existed.
+        let now = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDate::from_ymd_opt(2026, 4, 20)
+                .unwrap()
+                .and_hms_opt(18, 45, 0)
+                .unwrap(),
+            Utc,
+        );
+        assert!(TodayIstWindow::from_utc(now).is_none());
+    }
+
+    #[test]
+    fn test_today_ist_window_sql_literal_microsecond_padding() {
+        let now = utc_at_ist(2026, 4, 20, 12, 0);
+        let w = TodayIstWindow::from_utc(now).unwrap();
+        // QuestDB timestamp literal requires the `.000000Z` suffix
+        // (microsecond precision) — don't drop it, QuestDB is strict.
+        assert!(
+            w.start_sql.contains(".000000Z"),
+            "start must carry microsecond suffix: {}",
+            w.start_sql
+        );
+        assert!(
+            w.end_sql.contains(".000000Z"),
+            "end must carry microsecond suffix: {}",
+            w.end_sql
+        );
+    }
 
     #[test]
     fn test_cross_verification_report_default_values() {
@@ -1770,7 +2021,9 @@ mod tests {
             ilp_port: 1,
         };
         let registry = InstrumentRegistry::empty();
-        let report = verify_candle_integrity(&config, &registry).await;
+        let window = TodayIstWindow::from_utc(utc_at_ist(2026, 4, 20, 12, 0))
+            .expect("mid-session test window");
+        let report = verify_candle_integrity(&config, &registry, &window).await;
         assert!(!report.passed);
         assert_eq!(report.instruments_checked, 0);
     }
@@ -1784,7 +2037,9 @@ mod tests {
             ilp_port: 1,
         };
         let registry = InstrumentRegistry::empty();
-        let report = cross_match_historical_vs_live(&config, &registry).await;
+        let window = TodayIstWindow::from_utc(utc_at_ist(2026, 4, 20, 12, 0))
+            .expect("mid-session test window");
+        let report = cross_match_historical_vs_live(&config, &registry, &window).await;
         assert!(!report.passed);
         assert_eq!(report.candles_compared, 0);
     }

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -313,6 +313,44 @@ impl TodayIstWindow {
 }
 
 // ---------------------------------------------------------------------------
+// Once-per-day success cache (Parthiban directive, 2026-04-20):
+// "post verification only once per day until it achieves success"
+// ---------------------------------------------------------------------------
+
+/// Returns the on-disk marker path used to record that today's cross-
+/// verification + cross-match BOTH succeeded. Filename embeds the IST
+/// trading date so a single file is naturally per-day. Lives under
+/// `data/cache/` alongside other one-shot daily markers.
+pub fn cross_verify_success_marker_path(today_ist: NaiveDate) -> std::path::PathBuf {
+    std::path::PathBuf::from("data/cache").join(format!(
+        "cross-verify-success-{}.marker",
+        today_ist.format("%Y-%m-%d")
+    ))
+}
+
+/// `true` when today's cross-verification has already succeeded earlier
+/// in the same trading day (marker file present). The caller skips the
+/// whole post-market verification block when this returns true — fixes
+/// the "every restart re-runs the verification even though it already
+/// passed" failure mode that blew up the operator's Telegram on
+/// crash-recovery boots.
+pub fn cross_verify_already_succeeded_today(today_ist: NaiveDate) -> bool {
+    cross_verify_success_marker_path(today_ist).exists()
+}
+
+/// Records that today's cross-verification + cross-match both passed.
+/// Best-effort: returns the std::io error so the caller can decide
+/// whether to surface it; not panicking lets the verification still
+/// "succeed" in the operator's eyes even if disk write fails.
+pub fn mark_cross_verify_success(today_ist: NaiveDate) -> std::io::Result<()> {
+    let path = cross_verify_success_marker_path(today_ist);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, today_ist.to_string())
+}
+
+// ---------------------------------------------------------------------------
 // Pure Helper Functions (extracted for testability)
 // ---------------------------------------------------------------------------
 
@@ -1665,6 +1703,69 @@ mod tests {
             "end must carry microsecond suffix: {}",
             w.end_sql
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Once-per-day success marker (Parthiban directive 2026-04-20:
+    //   "only once in a day until it achieves success")
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_cross_verify_success_marker_path_includes_date() {
+        let date = NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+        let path = cross_verify_success_marker_path(date);
+        let s = path.to_string_lossy();
+        assert!(
+            s.contains("cross-verify-success-2026-04-20"),
+            "marker filename must embed the IST date so it's per-day; got: {s}"
+        );
+        assert!(
+            s.ends_with(".marker"),
+            "marker file extension expected; got: {s}"
+        );
+    }
+
+    #[test]
+    fn test_cross_verify_success_marker_path_changes_per_day() {
+        let d1 = NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+        let d2 = NaiveDate::from_ymd_opt(2026, 4, 21).unwrap();
+        assert_ne!(
+            cross_verify_success_marker_path(d1),
+            cross_verify_success_marker_path(d2),
+            "marker path must be per-day so yesterday's success doesn't shadow today"
+        );
+    }
+
+    #[test]
+    fn test_cross_verify_already_succeeded_today_false_when_marker_absent() {
+        // A date so far in the future no marker can ever exist on-disk.
+        let date = NaiveDate::from_ymd_opt(2099, 12, 31).unwrap();
+        assert!(
+            !cross_verify_already_succeeded_today(date),
+            "no marker file → should return false"
+        );
+    }
+
+    #[test]
+    fn test_mark_cross_verify_success_then_already_succeeded_returns_true() {
+        // Use today's date for a real round-trip — write then check then
+        // delete to leave the working tree clean for subsequent runs.
+        // Best-effort cleanup; if the test crashes mid-way the marker is
+        // for "today" anyway and is harmless next time.
+        let date = NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+        let marker = cross_verify_success_marker_path(date);
+        // Pre-clean in case a stale marker from a previous test exists.
+        let _ = std::fs::remove_file(&marker);
+        assert!(!cross_verify_already_succeeded_today(date));
+
+        mark_cross_verify_success(date).expect("write marker");
+        assert!(
+            cross_verify_already_succeeded_today(date),
+            "after writing marker, idempotency check must return true"
+        );
+
+        // Cleanup — leave repo clean for re-runs.
+        let _ = std::fs::remove_file(&marker);
     }
 
     #[test]

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -60,6 +60,30 @@ pub struct ViolationDetail {
 // Cross-Match Types — Historical vs Live comparison
 // ---------------------------------------------------------------------------
 
+/// Per-field delta for expanded Telegram display. One entry per differing
+/// OHLCV (+OI) field, carrying both sides' raw values and `live - hist`.
+/// Produced by `classify_cross_match_row` alongside `diff_summary` so the
+/// Telegram formatter can render one explicit line per field:
+///     `open      : hist=2847.50 live=2847.00  Δ=+0.50`
+/// (Pre-2026-04-20 formats conflated all deltas onto one `H(-1.5) V(+200)`
+/// line — concise but hard to scan at a glance when multiple fields move.)
+#[derive(Debug, Clone)]
+pub struct FieldDelta {
+    /// Full human-readable field name: "open", "high", "low", "close",
+    /// "volume", "open_interest". Kept long-form so Telegram rendering
+    /// is unambiguous — no "O vs OI" confusion.
+    pub field: String,
+    /// Value from Dhan REST historical fetch.
+    pub hist: f64,
+    /// Value from live WebSocket-sourced materialized view.
+    pub live: f64,
+    /// `live - hist`. Positive = live exceeds historical.
+    pub delta: f64,
+    /// Hint for renderer: `true` for volume/OI (format as integer),
+    /// `false` for OHLC prices (format with 2 decimals).
+    pub is_integer: bool,
+}
+
 /// A single candle mismatch between historical API data and live materialized view.
 #[derive(Debug, Clone)]
 pub struct CrossMatchMismatch {
@@ -80,6 +104,15 @@ pub struct CrossMatchMismatch {
     pub live_values: String,
     /// Field-level diff summary (e.g., "H(-1.5) V(-6500)").
     pub diff_summary: String,
+    /// Structured per-field deltas — one entry per differing field.
+    /// Empty for `missing_live` rows (no live values to compare).
+    /// Populated alongside `diff_summary` in `classify_cross_match_row`
+    /// so the Telegram formatter can render one line per field:
+    ///   `open      : hist=2847.50 live=2847.00  Δ=+0.50`
+    /// Complements the compact `diff_summary` (`"O(+0.50)"`) without
+    /// replacing it — both are surfaced in logs; Telegram renders the
+    /// expanded form for operator readability.
+    pub field_deltas: Vec<FieldDelta>,
 }
 
 /// Summary of historical vs live candle cross-match.
@@ -628,6 +661,20 @@ fn classify_cross_match_row(
         oi_mismatch,
     });
 
+    let field_deltas = build_field_deltas(
+        hist,
+        live,
+        &FieldDeltaFlags {
+            d_open,
+            d_high,
+            d_low,
+            d_close,
+            epsilon: CROSS_MATCH_PRICE_EPSILON,
+            volume_mismatch,
+            oi_mismatch,
+        },
+    );
+
     Some(CrossMatchMismatch {
         symbol: ctx.symbol,
         segment: ctx.segment,
@@ -637,7 +684,94 @@ fn classify_cross_match_row(
         hist_values: hist.format_with_oi(),
         live_values: live.format_with_oi(),
         diff_summary,
+        field_deltas,
     })
+}
+
+/// Flags driving `build_field_deltas` — mirrors `DiffSummaryParams` so both
+/// the compact summary and the expanded per-field delta list are computed
+/// from the same price/volume/OI deltas.
+struct FieldDeltaFlags {
+    d_open: f64,
+    d_high: f64,
+    d_low: f64,
+    d_close: f64,
+    epsilon: f64,
+    volume_mismatch: bool,
+    oi_mismatch: bool,
+}
+
+/// Produces one `FieldDelta` per differing OHLCV (+OI) field. Kept pure +
+/// mirrors `build_diff_summary` field ordering so Telegram output reads
+/// top-to-bottom in the same order as compact logs (open → high → low →
+/// close → volume → open_interest).
+fn build_field_deltas(
+    hist: CandleValues,
+    live: CandleValues,
+    flags: &FieldDeltaFlags,
+) -> Vec<FieldDelta> {
+    let mut out: Vec<FieldDelta> = Vec::new();
+    if flags.d_open.abs() > flags.epsilon {
+        out.push(FieldDelta {
+            field: "open".to_string(),
+            hist: hist.open,
+            live: live.open,
+            delta: flags.d_open,
+            is_integer: false,
+        });
+    }
+    if flags.d_high.abs() > flags.epsilon {
+        out.push(FieldDelta {
+            field: "high".to_string(),
+            hist: hist.high,
+            live: live.high,
+            delta: flags.d_high,
+            is_integer: false,
+        });
+    }
+    if flags.d_low.abs() > flags.epsilon {
+        out.push(FieldDelta {
+            field: "low".to_string(),
+            hist: hist.low,
+            live: live.low,
+            delta: flags.d_low,
+            is_integer: false,
+        });
+    }
+    if flags.d_close.abs() > flags.epsilon {
+        out.push(FieldDelta {
+            field: "close".to_string(),
+            hist: hist.close,
+            live: live.close,
+            delta: flags.d_close,
+            is_integer: false,
+        });
+    }
+    if flags.volume_mismatch {
+        // APPROVED: cast — volumes stored as i64, hist<=9e18 by volume-range invariant.
+        let h_vol_f = hist.volume as f64;
+        let m_vol_f = live.volume as f64;
+        out.push(FieldDelta {
+            field: "volume".to_string(),
+            hist: h_vol_f,
+            live: m_vol_f,
+            delta: m_vol_f - h_vol_f,
+            is_integer: true,
+        });
+    }
+    if flags.oi_mismatch {
+        // APPROVED: cast — OI stored as i64.
+        let h_oi_f = hist.oi as f64;
+        let m_oi_f = live.oi as f64;
+        out.push(FieldDelta {
+            field: "open_interest".to_string(),
+            hist: h_oi_f,
+            live: m_oi_f,
+            delta: m_oi_f - h_oi_f,
+            is_integer: true,
+        });
+    }
+    out
 }
 
 /// Builds a `CrossMatchMismatch` for when live data is missing.
@@ -651,6 +785,9 @@ fn build_missing_live_mismatch(ctx: CandleContext, hist: CandleValues) -> CrossM
         hist_values: hist.format_with_oi(),
         live_values: "[MISSING — no live data for this candle]".to_string(),
         diff_summary: String::new(),
+        // No live side to compare against → no per-field deltas.
+        // Renderer falls back to the compact Hist+Live format.
+        field_deltas: Vec::new(),
     }
 }
 
@@ -1943,9 +2080,26 @@ mod tests {
             hist_values: "O=3520.0 H=3535.0 L=3518.0 C=3530.0 V=45000".to_string(),
             live_values: "O=3520.0 H=3535.0 L=3518.0 C=3528.5 V=42100".to_string(),
             diff_summary: "C(-1.5) V(-2900)".to_string(),
+            field_deltas: vec![
+                FieldDelta {
+                    field: "close".to_string(),
+                    hist: 3530.0,
+                    live: 3528.5,
+                    delta: -1.5,
+                    is_integer: false,
+                },
+                FieldDelta {
+                    field: "volume".to_string(),
+                    hist: 45000.0,
+                    live: 42100.0,
+                    delta: -2900.0,
+                    is_integer: true,
+                },
+            ],
         };
         assert_eq!(mismatch.mismatch_type, "price_diff");
         assert!(mismatch.diff_summary.contains("C(-1.5)"));
+        assert_eq!(mismatch.field_deltas.len(), 2);
     }
 
     #[test]
@@ -1959,9 +2113,13 @@ mod tests {
             hist_values: "O=23480.0 H=23510.0 L=23475.0 C=23505.0 V=0".to_string(),
             live_values: "[MISSING — no live data for this candle]".to_string(),
             diff_summary: String::new(),
+            // missing_live rows carry no per-field deltas — renderer
+            // falls back to the compact Hist+Live format.
+            field_deltas: Vec::new(),
         };
         assert_eq!(mismatch.mismatch_type, "missing_live");
         assert!(mismatch.live_values.contains("MISSING"));
+        assert!(mismatch.field_deltas.is_empty());
     }
 
     #[test]

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -1494,14 +1494,14 @@ mod tests {
     }
 
     #[test]
-    fn test_today_ist_window_pre_market_returns_none() {
+    fn test_from_utc_pre_market_returns_none() {
         // 09:14 IST — 1 minute before market open — should return None.
         let now = utc_at_ist(2026, 4, 20, 9, 14);
         assert!(TodayIstWindow::from_utc(now).is_none());
     }
 
     #[test]
-    fn test_today_ist_window_at_market_open_returns_some_at_boundary() {
+    fn test_from_utc_at_market_open_returns_some_at_boundary() {
         // Exactly 09:15 IST — boundary, should be Some with start == end.
         let now = utc_at_ist(2026, 4, 20, 9, 15);
         let w = TodayIstWindow::from_utc(now).expect("at boundary is inclusive");
@@ -1572,7 +1572,15 @@ mod tests {
     }
 
     #[test]
-    fn test_today_ist_window_is_stable_across_day_boundary() {
+    fn test_from_now_returns_some_during_market_or_none_otherwise() {
+        // Smoke-covers `from_now`: the wrapper over `from_utc(Utc::now())`.
+        // We can't assert a specific value since "now" depends on CI clock,
+        // but we can assert it doesn't panic and returns the Option shape.
+        let _ = TodayIstWindow::from_now();
+    }
+
+    #[test]
+    fn test_from_utc_is_stable_across_day_boundary() {
         // 2026-04-20 23:59 UTC == 2026-04-21 05:29 IST — still today-ist = 21,
         // but 05:29 is pre-market → None.
         let now = DateTime::<Utc>::from_naive_utc_and_offset(

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -1151,6 +1151,44 @@ pub async fn cross_match_historical_vs_live(
     let ts_filter = today_window.where_clause();
     let ts_filter_h = today_window.where_clause_aliased("h");
 
+    // First-fetch gate (Parthiban directive, 2026-04-20): if today's live
+    // `candles_1m` view has ZERO rows, there is nothing meaningful to
+    // compare against — it's a first fetch, a fresh DB, or a post-market
+    // boot before the next session. Skip the entire cross-match with a
+    // clear `live_candles_present = false` signal so the caller emits the
+    // typed SKIPPED Telegram notification instead of running the full
+    // LEFT-JOIN pipeline against an empty live side (which would "succeed"
+    // vacuously with zero rows compared).
+    //
+    // The cheaper `candles_1m` probe is authoritative — if 1m is empty, no
+    // higher timeframe can possibly have data.
+    let live_probe_query = format!("SELECT count() FROM candles_1m WHERE {ts_filter}");
+    let live_probe_rows = extract_count(&client, &base_url, &live_probe_query).await;
+    if live_probe_rows == 0 {
+        info!(
+            today_ist = %today_window.today_ist,
+            window_start = %today_window.start_sql,
+            window_end = %today_window.end_sql,
+            "cross-match SKIPPED — zero live 1m candles for today's window \
+             (first fetch / fresh DB / pre-live-data boot)"
+        );
+        return CrossMatchReport {
+            timeframes_checked: 0,
+            candles_compared: 0,
+            mismatches: 0,
+            missing_live: 0,
+            missing_historical: 0,
+            oi_mismatches: 0,
+            mismatch_details: Vec::new(),
+            missing_views: Vec::new(),
+            per_timeframe_mismatches: Vec::new(),
+            passed: false,
+            // `false` → caller's main.rs:4285 branch fires the typed
+            // `CandleCrossMatchSkipped` Telegram notification.
+            live_candles_present: false,
+        };
+    }
+
     let mut total_compared = 0_usize;
     let mut total_mismatches = 0_usize;
     let mut total_missing_live = 0_usize;

--- a/crates/core/src/instrument/depth_rebalancer.rs
+++ b/crates/core/src/instrument/depth_rebalancer.rs
@@ -344,9 +344,29 @@ pub async fn run_depth_rebalancer(
                 current_spot,
                 DEPTH_REBALANCE_STRIKE_THRESHOLD,
             ) {
-                // Look up old/new ATM CE/PE security IDs + strike for the notification.
-                let new_atm_ids = find_atm_security_ids(chain, current_spot);
-                let prev_atm_ids = find_atm_security_ids(chain, prev_atm);
+                // Look up old/new ATM CE/PE security IDs + strike for the
+                // notification. Enrich with Dhan CSV `display_name` so the
+                // Telegram rebalance alert shows the exact contract label
+                // Dhan's web UI shows (e.g. "BANKNIFTY 28 APR 54300 PUT")
+                // instead of the synthesized symbol_name.
+                let mut new_atm_ids = find_atm_security_ids(chain, current_spot);
+                let mut prev_atm_ids = find_atm_security_ids(chain, prev_atm);
+                if let Some(ref mut ids) = new_atm_ids {
+                    ids.fill_display_names_from_universe(universe.as_ref());
+                }
+                if let Some(ref mut ids) = prev_atm_ids {
+                    ids.fill_display_names_from_universe(universe.as_ref());
+                }
+
+                info!(
+                    symbol,
+                    previous_spot = prev_atm,
+                    current_spot,
+                    new_atm = ?new_atm_ids,
+                    prev_atm_ids = ?prev_atm_ids,
+                    %expiry,
+                    "depth rebalance triggered — ATM drifted beyond threshold"
+                );
 
                 let event = RebalanceEvent {
                     underlying: symbol.clone(), // O(1) EXEMPT: rebalance event
@@ -357,16 +377,6 @@ pub async fn run_depth_rebalancer(
                     drift_strikes: DEPTH_REBALANCE_STRIKE_THRESHOLD,
                     expiry: Some(expiry),
                 };
-
-                info!(
-                    symbol,
-                    previous_spot = prev_atm,
-                    current_spot,
-                    ?new_atm_ids,
-                    ?prev_atm_ids,
-                    %expiry,
-                    "depth rebalance triggered — ATM drifted beyond threshold"
-                );
 
                 // Update tracked ATM
                 previous_atm.insert(symbol.clone(), current_spot); // O(1) EXEMPT: rebalance
@@ -460,11 +470,15 @@ mod tests {
                 ce_id: 35246,
                 pe_id: Some(35247),
                 strike: 23600.0,
+                ce_display_name: None,
+                pe_display_name: None,
             }),
             prev_atm: Some(AtmIds {
                 ce_id: 35100,
                 pe_id: Some(35101),
                 strike: 23450.0,
+                ce_display_name: None,
+                pe_display_name: None,
             }),
             current_spot: 23620.0,
             previous_spot: 23430.0,

--- a/crates/core/src/instrument/depth_strike_selector.rs
+++ b/crates/core/src/instrument/depth_strike_selector.rs
@@ -720,7 +720,7 @@ mod tests {
     }
 
     #[test]
-    fn atmids_fill_display_names_from_universe_populates_both_sides() {
+    fn test_fill_display_names_from_universe_atmids_populates_both_sides() {
         use std::collections::HashMap;
         use tickvault_common::instrument_types::{
             DerivativeContract, DhanInstrumentKind, FnoUniverse, UniverseBuildMetadata,
@@ -815,7 +815,7 @@ mod tests {
     }
 
     #[test]
-    fn fill_display_names_uses_registry_display_name() {
+    fn test_fill_display_names_from_universe_uses_registry_display_name() {
         use std::collections::HashMap;
         use tickvault_common::instrument_types::{
             DerivativeContract, DhanInstrumentKind, FnoUniverse, UniverseBuildMetadata,

--- a/crates/core/src/instrument/depth_strike_selector.rs
+++ b/crates/core/src/instrument/depth_strike_selector.rs
@@ -27,12 +27,44 @@ pub const DEPTH_REBALANCE_STRIKE_THRESHOLD: usize = 3;
 pub struct DepthStrikeSelection {
     /// The ATM strike price selected.
     pub atm_strike: f64,
-    /// Security IDs of selected call options (ATM ± N).
+    /// Security IDs of selected call options (ATM ± N), sorted by strike
+    /// ascending. `call_security_ids.first()` is the LOWEST strike in the
+    /// range (ATM − N), NOT the ATM strike. For the exact ATM pair use
+    /// `atm_ce_security_id` / `atm_pe_security_id` below.
     pub call_security_ids: Vec<SecurityId>,
-    /// Security IDs of selected put options (ATM ± N).
+    /// Security IDs of selected put options (ATM ± N), sorted by strike
+    /// ascending. See caveat above on `call_security_ids.first()`.
     pub put_security_ids: Vec<SecurityId>,
     /// All security IDs combined (calls + puts), ready for subscription.
     pub all_security_ids: Vec<SecurityId>,
+    /// Security ID of the CE contract AT the ATM strike (not the range-start).
+    /// `None` only if the chain is empty at the ATM index (should never happen
+    /// for a non-empty chain returned by `select_atm_strikes`).
+    ///
+    /// **Use this — NOT `call_security_ids.first()` — when building the
+    /// Telegram / log label for the ATM contract.** Getting these mixed up
+    /// produces a label/security_id mismatch (e.g. label says
+    /// `BANKNIFTY-Apr2026-56700-PE` while the security_id actually points
+    /// at `BANKNIFTY-Apr2026-54300-PE`), which poisons operator triage.
+    pub atm_ce_security_id: Option<SecurityId>,
+    /// Security ID of the PE contract AT the ATM strike (not the range-start).
+    /// `None` if no put exists at the exact ATM strike.
+    pub atm_pe_security_id: Option<SecurityId>,
+    /// Dhan CSV `display_name` for the ATM CE contract (e.g.
+    /// `"BANKNIFTY 28 APR 54300 CALL"`). Populated by
+    /// [`select_depth_instruments`] from
+    /// `FnoUniverse::derivative_contracts`. `None` if the registry lookup
+    /// fails (degrade gracefully — caller should fall back to the
+    /// synthesized `UNDERLYING-MmmYYYY-STRIKE-SIDE` label).
+    ///
+    /// Prefer this over the synthesized label in operator-facing surfaces
+    /// (Telegram, logs) because it matches exactly what Dhan's web UI and
+    /// order book show.
+    pub atm_ce_display_name: Option<String>,
+    /// Dhan CSV `display_name` for the ATM PE contract (e.g.
+    /// `"BANKNIFTY 28 APR 54300 PUT"`). Same semantics as
+    /// `atm_ce_display_name` above.
+    pub atm_pe_display_name: Option<String>,
     /// The underlying symbol these belong to.
     pub underlying_symbol: String,
     /// The expiry date of the selected chain.
@@ -67,6 +99,16 @@ pub fn select_atm_strikes(
     let atm_idx = find_atm_index(&chain.calls, spot_price);
     let atm_strike = chain.calls[atm_idx].strike_price;
 
+    // Capture the EXACT ATM CE + PE security IDs BEFORE the range expansion.
+    // Using `call_security_ids.first()` downstream would return the lowest
+    // strike in the range (ATM − N), not the ATM itself — a real bug that
+    // previously produced Telegram alerts like
+    // `BANKNIFTY-Apr2026-56700-PE (SID 67481)` where the SID actually
+    // pointed at strike 54300. The two identities are kept here so every
+    // caller can reliably grab the ATM pair without re-deriving it.
+    let atm_ce_security_id = Some(chain.calls[atm_idx].security_id);
+    let atm_pe_security_id = find_put_at_strike(&chain.puts, atm_strike).map(|p| p.security_id);
+
     // Select range: [atm_idx - N, atm_idx + N] clamped to chain bounds.
     let start = atm_idx.saturating_sub(strikes_each_side);
     let end = (atm_idx + strikes_each_side + 1).min(chain.calls.len());
@@ -92,9 +134,40 @@ pub fn select_atm_strikes(
         call_security_ids: call_ids,
         put_security_ids: put_ids,
         all_security_ids: all_ids,
+        atm_ce_security_id,
+        atm_pe_security_id,
+        // Filled in by `select_depth_instruments` (which has registry access)
+        // or by `fill_display_names_from_universe` for direct callers. Left
+        // as None here because `OptionChain` does not carry display_name.
+        atm_ce_display_name: None,
+        atm_pe_display_name: None,
         underlying_symbol: chain.underlying_symbol.clone(),
         expiry_date: chain.expiry_date,
     })
+}
+
+impl DepthStrikeSelection {
+    /// Populates `atm_ce_display_name` / `atm_pe_display_name` by looking
+    /// up the ATM security IDs in the universe's `derivative_contracts`
+    /// map. Idempotent — calling twice is safe.
+    ///
+    /// Used so that Telegram alerts and operator logs show the exact
+    /// Dhan-UI label (`"BANKNIFTY 28 APR 54300 PUT"`) instead of the
+    /// synthesized `symbol_name` (`"BANKNIFTY-Apr2026-54300-PE"`). The
+    /// two can be misleading to an operator scanning the web terminal in
+    /// parallel with Telegram.
+    pub fn fill_display_names_from_universe(&mut self, universe: &FnoUniverse) {
+        if let Some(sid) = self.atm_ce_security_id
+            && let Some(contract) = universe.derivative_contracts.get(&sid)
+        {
+            self.atm_ce_display_name = Some(contract.display_name.clone());
+        }
+        if let Some(sid) = self.atm_pe_security_id
+            && let Some(contract) = universe.derivative_contracts.get(&sid)
+        {
+            self.atm_pe_display_name = Some(contract.display_name.clone());
+        }
+    }
 }
 
 /// Selects depth strikes for multiple underlyings from the FnoUniverse.
@@ -161,10 +234,18 @@ pub fn select_depth_instruments(
         };
 
         // Select ATM ± N strikes
-        if let Some(selection) = select_atm_strikes(chain, spot, strikes_each_side) {
+        if let Some(mut selection) = select_atm_strikes(chain, spot, strikes_each_side) {
+            // Enrich with Dhan CSV `display_name` so every downstream
+            // operator surface (Telegram alert, info log, web panel) can
+            // show the exact string Dhan's UI shows for the same contract.
+            selection.fill_display_names_from_universe(universe);
             tracing::info!(
                 symbol,
                 atm_strike = selection.atm_strike,
+                atm_ce_sid = ?selection.atm_ce_security_id,
+                atm_pe_sid = ?selection.atm_pe_security_id,
+                atm_ce_display = ?selection.atm_ce_display_name,
+                atm_pe_display = ?selection.atm_pe_display_name,
                 calls = selection.call_security_ids.len(),
                 puts = selection.put_security_ids.len(),
                 total = selection.all_security_ids.len(),
@@ -200,7 +281,7 @@ pub fn should_rebalance(
 
 /// ATM contract identifiers at a given spot price — CE + PE security IDs
 /// and the actual ATM strike price from the chain (not the raw spot price).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AtmIds {
     /// CE security ID at ATM strike.
     pub ce_id: u32,
@@ -208,6 +289,30 @@ pub struct AtmIds {
     pub pe_id: Option<u32>,
     /// The actual strike price in the chain closest to spot.
     pub strike: f64,
+    /// Dhan CSV `display_name` for the CE contract, if the caller enriches
+    /// via [`AtmIds::fill_display_names_from_universe`]. `None` from bare
+    /// [`find_atm_security_ids`] which has no registry access.
+    pub ce_display_name: Option<String>,
+    /// Dhan CSV `display_name` for the PE contract. Same semantics as above.
+    pub pe_display_name: Option<String>,
+}
+
+impl AtmIds {
+    /// Populates `ce_display_name` / `pe_display_name` from the universe's
+    /// `derivative_contracts` map. Idempotent. Used so that rebalancer
+    /// Telegram messages can show the exact Dhan web-UI label
+    /// (e.g. `"BANKNIFTY 28 APR 54300 PUT"`) instead of the synthesized
+    /// `UNDERLYING-MmmYYYY-STRIKE-SIDE` format.
+    pub fn fill_display_names_from_universe(&mut self, universe: &FnoUniverse) {
+        if let Some(contract) = universe.derivative_contracts.get(&self.ce_id) {
+            self.ce_display_name = Some(contract.display_name.clone());
+        }
+        if let Some(pe_id) = self.pe_id
+            && let Some(contract) = universe.derivative_contracts.get(&pe_id)
+        {
+            self.pe_display_name = Some(contract.display_name.clone());
+        }
+    }
 }
 
 /// Returns the CE and PE security IDs + actual strike at the ATM nearest to `spot_price`.
@@ -226,6 +331,8 @@ pub fn find_atm_security_ids(chain: &OptionChain, spot_price: f64) -> Option<Atm
         ce_id,
         pe_id,
         strike,
+        ce_display_name: None,
+        pe_display_name: None,
     })
 }
 
@@ -543,6 +650,186 @@ mod tests {
             future_security_id: None,
         };
         assert!(find_atm_security_ids(&chain, 23200.0).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Regression: ATM CE/PE security_id fields must point at the ACTUAL ATM
+    // strike, not the lowest strike in the ATM ± N range. This is the bug
+    // that produced Telegram alerts like "BANKNIFTY-Apr2026-56700-PE (SID
+    // 67481)" where the SID actually pointed at strike 54300 (range-first,
+    // not ATM). The fix moved off `.first()` onto dedicated fields.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn atm_ce_security_id_is_exact_atm_not_range_first() {
+        // 49 strikes (ATM ± 24) — mirrors production DEPTH_ATM_STRIKES_EACH_SIDE.
+        // ATM is at index 24 of the 49-element range.
+        let strikes: Vec<f64> = (0..49).map(|i| 54000.0 + (i as f64) * 100.0).collect();
+        let chain = make_chain(
+            &strikes,
+            "BANKNIFTY",
+            NaiveDate::from_ymd_opt(2026, 4, 28).unwrap(),
+        );
+
+        // Spot near strike 56400 → ATM should be 56400 (index 24).
+        let selection = select_atm_strikes(&chain, 56400.0, 24).unwrap();
+
+        // ATM strike is 56400, and the CE security_id from make_chain is 10000 + 24 = 10024.
+        assert!((selection.atm_strike - 56400.0).abs() < 0.01);
+        assert_eq!(
+            selection.atm_ce_security_id,
+            Some(10024),
+            "atm_ce_security_id must point at the ATM strike (10024), \
+             NOT the range-first strike (10000)"
+        );
+        assert_eq!(
+            selection.atm_pe_security_id,
+            Some(20024),
+            "atm_pe_security_id must point at the ATM strike (20024), \
+             NOT the range-first strike (20000)"
+        );
+
+        // And prove the historical bug pattern — `.first()` returns the
+        // LOWEST strike in the range, which is NOT the ATM.
+        assert_eq!(
+            selection.call_security_ids.first().copied(),
+            Some(10000),
+            "call_security_ids.first() returns range-start (10000 = strike 54000), \
+             which is why it was wrong to use for the ATM label"
+        );
+        assert_ne!(
+            selection.call_security_ids.first().copied(),
+            selection.atm_ce_security_id,
+            "this assertion documents the exact bug: .first() != atm_ce_security_id"
+        );
+    }
+
+    #[test]
+    fn atm_ce_matches_find_atm_security_ids() {
+        // Cross-check: the new field and the standalone helper must agree.
+        let strikes: Vec<f64> = (0..49).map(|i| 54000.0 + (i as f64) * 100.0).collect();
+        let chain = make_chain(
+            &strikes,
+            "BANKNIFTY",
+            NaiveDate::from_ymd_opt(2026, 4, 28).unwrap(),
+        );
+        let sel = select_atm_strikes(&chain, 56400.0, 24).unwrap();
+        let via_helper = find_atm_security_ids(&chain, 56400.0).unwrap();
+        assert_eq!(sel.atm_ce_security_id, Some(via_helper.ce_id));
+        assert_eq!(sel.atm_pe_security_id, via_helper.pe_id);
+    }
+
+    #[test]
+    fn fill_display_names_uses_registry_display_name() {
+        use std::collections::HashMap;
+        use tickvault_common::instrument_types::{
+            DerivativeContract, DhanInstrumentKind, FnoUniverse, UniverseBuildMetadata,
+        };
+        use tickvault_common::types::{ExchangeSegment, OptionType};
+
+        let strikes: Vec<f64> = (0..5).map(|i| 23000.0 + (i as f64) * 100.0).collect();
+        let chain = make_chain(
+            &strikes,
+            "NIFTY",
+            NaiveDate::from_ymd_opt(2026, 4, 28).unwrap(),
+        );
+        // ATM @ 23200 → CE sid 10002, PE sid 20002 (from make_chain).
+        let mut sel = select_atm_strikes(&chain, 23200.0, 2).unwrap();
+
+        // Build a minimal universe with display_names for the ATM pair.
+        let mut derivative_contracts = HashMap::new();
+        let expiry = NaiveDate::from_ymd_opt(2026, 4, 28).unwrap();
+        derivative_contracts.insert(
+            10002_u32,
+            DerivativeContract {
+                security_id: 10002,
+                underlying_symbol: "NIFTY".to_string(),
+                instrument_kind: DhanInstrumentKind::OptionIndex,
+                exchange_segment: ExchangeSegment::NseFno,
+                expiry_date: expiry,
+                strike_price: 23200.0,
+                option_type: Some(OptionType::Call),
+                lot_size: 50,
+                tick_size: 0.05,
+                symbol_name: "NIFTY-Apr2026-23200-CE".to_string(),
+                display_name: "NIFTY 28 APR 23200 CALL".to_string(),
+            },
+        );
+        derivative_contracts.insert(
+            20002_u32,
+            DerivativeContract {
+                security_id: 20002,
+                underlying_symbol: "NIFTY".to_string(),
+                instrument_kind: DhanInstrumentKind::OptionIndex,
+                exchange_segment: ExchangeSegment::NseFno,
+                expiry_date: expiry,
+                strike_price: 23200.0,
+                option_type: Some(OptionType::Put),
+                lot_size: 50,
+                tick_size: 0.05,
+                symbol_name: "NIFTY-Apr2026-23200-PE".to_string(),
+                display_name: "NIFTY 28 APR 23200 PUT".to_string(),
+            },
+        );
+        let universe = FnoUniverse {
+            underlyings: HashMap::new(),
+            derivative_contracts,
+            instrument_info: HashMap::new(),
+            option_chains: HashMap::new(),
+            expiry_calendars: HashMap::new(),
+            subscribed_indices: Vec::new(),
+            build_metadata: UniverseBuildMetadata {
+                csv_source: "test".to_string(),
+                csv_row_count: 0,
+                parsed_row_count: 0,
+                index_count: 0,
+                equity_count: 0,
+                underlying_count: 0,
+                derivative_count: 0,
+                option_chain_count: 0,
+                build_duration: std::time::Duration::ZERO,
+                build_timestamp: chrono::Utc::now()
+                    .with_timezone(&chrono::FixedOffset::east_opt(19_800).unwrap()),
+            },
+        };
+
+        sel.fill_display_names_from_universe(&universe);
+        assert_eq!(
+            sel.atm_ce_display_name.as_deref(),
+            Some("NIFTY 28 APR 23200 CALL"),
+            "CE display_name must come from the registry, not be synthesized"
+        );
+        assert_eq!(
+            sel.atm_pe_display_name.as_deref(),
+            Some("NIFTY 28 APR 23200 PUT")
+        );
+    }
+
+    #[test]
+    fn atm_security_id_correct_near_chain_edge() {
+        // If ATM is near the start of the chain, the range gets clamped.
+        // `.first()` = lowest strike in clamped range.
+        // Dedicated field must still point at the true ATM strike.
+        let strikes: Vec<f64> = (0..20).map(|i| 23000.0 + (i as f64) * 100.0).collect();
+        let chain = make_chain(
+            &strikes,
+            "NIFTY",
+            NaiveDate::from_ymd_opt(2026, 4, 28).unwrap(),
+        );
+
+        // Spot near strike 23200 → ATM index = 2. Range-start clamps at 0.
+        let sel = select_atm_strikes(&chain, 23200.0, 10).unwrap();
+        assert!((sel.atm_strike - 23200.0).abs() < 0.01);
+        assert_eq!(
+            sel.atm_ce_security_id,
+            Some(10002),
+            "ATM CE at index 2 → security_id 10002 (make_chain baseline)"
+        );
+        assert_eq!(
+            sel.call_security_ids.first().copied(),
+            Some(10000),
+            "range-first when ATM is near edge is still 10000 (clamped)"
+        );
     }
 
     #[test]

--- a/crates/core/src/instrument/depth_strike_selector.rs
+++ b/crates/core/src/instrument/depth_strike_selector.rs
@@ -720,6 +720,101 @@ mod tests {
     }
 
     #[test]
+    fn atmids_fill_display_names_from_universe_populates_both_sides() {
+        use std::collections::HashMap;
+        use tickvault_common::instrument_types::{
+            DerivativeContract, DhanInstrumentKind, FnoUniverse, UniverseBuildMetadata,
+        };
+        use tickvault_common::types::{ExchangeSegment, OptionType};
+
+        let expiry = NaiveDate::from_ymd_opt(2026, 4, 28).unwrap();
+        let mut derivative_contracts = HashMap::new();
+        let mk = |sid: u32, strike: f64, ot: OptionType, dn: &str, sn: &str| DerivativeContract {
+            security_id: sid,
+            underlying_symbol: "BANKNIFTY".to_string(),
+            instrument_kind: DhanInstrumentKind::OptionIndex,
+            exchange_segment: ExchangeSegment::NseFno,
+            expiry_date: expiry,
+            strike_price: strike,
+            option_type: Some(ot),
+            lot_size: 15,
+            tick_size: 0.05,
+            symbol_name: sn.to_string(),
+            display_name: dn.to_string(),
+        };
+        derivative_contracts.insert(
+            67480_u32,
+            mk(
+                67480,
+                54300.0,
+                OptionType::Call,
+                "BANKNIFTY 28 APR 54300 CALL",
+                "BANKNIFTY-Apr2026-54300-CE",
+            ),
+        );
+        derivative_contracts.insert(
+            67481_u32,
+            mk(
+                67481,
+                54300.0,
+                OptionType::Put,
+                "BANKNIFTY 28 APR 54300 PUT",
+                "BANKNIFTY-Apr2026-54300-PE",
+            ),
+        );
+        let universe = FnoUniverse {
+            underlyings: HashMap::new(),
+            derivative_contracts,
+            instrument_info: HashMap::new(),
+            option_chains: HashMap::new(),
+            expiry_calendars: HashMap::new(),
+            subscribed_indices: Vec::new(),
+            build_metadata: UniverseBuildMetadata {
+                csv_source: "test".to_string(),
+                csv_row_count: 0,
+                parsed_row_count: 0,
+                index_count: 0,
+                equity_count: 0,
+                underlying_count: 0,
+                derivative_count: 0,
+                option_chain_count: 0,
+                build_duration: std::time::Duration::ZERO,
+                build_timestamp: chrono::Utc::now()
+                    .with_timezone(&chrono::FixedOffset::east_opt(19_800).unwrap()),
+            },
+        };
+
+        let mut atm = AtmIds {
+            ce_id: 67480,
+            pe_id: Some(67481),
+            strike: 54300.0,
+            ce_display_name: None,
+            pe_display_name: None,
+        };
+        atm.fill_display_names_from_universe(&universe);
+        assert_eq!(
+            atm.ce_display_name.as_deref(),
+            Some("BANKNIFTY 28 APR 54300 CALL")
+        );
+        assert_eq!(
+            atm.pe_display_name.as_deref(),
+            Some("BANKNIFTY 28 APR 54300 PUT")
+        );
+
+        // No registry entry → display_name stays None (no panic).
+        let mut missing = AtmIds {
+            ce_id: 99999,
+            pe_id: Some(99998),
+            strike: 99999.0,
+            ce_display_name: None,
+            pe_display_name: None,
+        };
+        missing.fill_display_names_from_universe(&universe);
+        assert_eq!(missing.ce_display_name, None);
+        assert_eq!(missing.pe_display_name, None);
+    }
+
+    #[test]
     fn fill_display_names_uses_registry_display_name() {
         use std::collections::HashMap;
         use tickvault_common::instrument_types::{

--- a/crates/core/src/instrument/instrument_loader.rs
+++ b/crates/core/src/instrument/instrument_loader.rs
@@ -317,7 +317,10 @@ async fn load_from_cache_or_emergency_download(
 
             write_freshness_marker(cache_dir);
 
-            error!(
+            // I-P0-06: the FAILURE to find cache is CRITICAL (logged above at line 290).
+            // The successful recovery is WARN — visible for investigation but does NOT
+            // re-trigger Telegram (that already fired on the cache-missing ERROR).
+            warn!(
                 derivatives = universe.derivative_contracts.len(),
                 "emergency download succeeded — instruments loaded (investigate why cache was missing)"
             );

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -821,8 +821,21 @@ impl NotificationEvent {
                 reason,
                 candles_compared,
             } => {
+                // Subtext varies by reason category — the previous hardcoded
+                // "first run / fresh DB / post-market boot" line was misleading
+                // for weekend, holiday, and pre-market skips. Match the lead-in
+                // sentence to the reason so the operator understands WHY the
+                // verification was skipped at a glance.
+                let lower = reason.to_ascii_lowercase();
+                let next_action = if lower.contains("weekend") || lower.contains("holiday") {
+                    "Will compare on the next trading day's post-market run."
+                } else if lower.contains("pre-market") {
+                    "Will compare after market open + post-market historical re-fetch."
+                } else {
+                    "Will compare on next run after live ticks during market hours."
+                };
                 format!(
-                    "<b>Historical vs Live cross-match SKIPPED</b>\nReason: {reason}\n(first run, fresh DB, or post-market boot — no live ticks yet)\nLEFT JOIN rows: {candles_compared} (diagnostic only)\nWill compare on next run after live ticks during market hours."
+                    "<b>Historical vs Live cross-match SKIPPED</b>\nReason: {reason}\nLEFT JOIN rows: {candles_compared} (diagnostic only)\n{next_action}"
                 )
             }
             Self::IpVerificationFailed { reason } => {
@@ -1499,8 +1512,37 @@ mod tests {
         let msg = event.to_message();
         assert!(msg.contains("cross-match SKIPPED"));
         assert!(msg.contains("no live data"));
-        assert!(msg.contains("first run"));
         assert!(msg.contains("Will compare on next run"));
+    }
+
+    #[test]
+    fn test_cross_match_skipped_weekend_subtext() {
+        let event = NotificationEvent::CandleCrossMatchSkipped {
+            reason: "weekend or holiday — not a trading day".to_string(),
+            candles_compared: 0,
+        };
+        let msg = event.to_message();
+        assert!(
+            msg.contains("next trading day"),
+            "weekend reason must use trading-day subtext, got: {msg}"
+        );
+        assert!(
+            !msg.contains("first run"),
+            "weekend reason must NOT show the first-run subtext"
+        );
+    }
+
+    #[test]
+    fn test_cross_match_skipped_premarket_subtext() {
+        let event = NotificationEvent::CandleCrossMatchSkipped {
+            reason: "pre-market (before 09:15 IST) — no live data yet".to_string(),
+            candles_compared: 0,
+        };
+        let msg = event.to_message();
+        assert!(
+            msg.contains("after market open"),
+            "pre-market reason must use post-open subtext, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -307,6 +307,13 @@ pub enum NotificationEvent {
         timeframes_checked: usize,
         /// Total candles compared.
         candles_compared: usize,
+        /// Human-readable IST session label, e.g. `"2026-04-20 09:15–15:30 IST"`.
+        /// Empty string when the caller doesn't have a window (legacy paths).
+        /// Surfaced on the first Telegram line so the operator immediately
+        /// sees which trading session this "OK" actually verifies — fixes
+        /// the 2026-04-20 ambiguity where an OK on 12 days of accumulated
+        /// data looked like today's session was clean.
+        today_ist_label: String,
     },
 
     /// Historical vs Live candle cross-match found mismatches.
@@ -319,6 +326,9 @@ pub enum NotificationEvent {
         missing_live: usize,
         /// Pre-formatted mismatch detail lines for Telegram.
         mismatch_details: Vec<String>,
+        /// Human-readable IST session label, e.g. `"2026-04-20 09:15–15:30 IST"`.
+        /// See `CandleCrossMatchPassed.today_ist_label`.
+        today_ist_label: String,
     },
 
     /// Historical vs Live candle cross-match skipped — no live data in
@@ -763,9 +773,15 @@ impl NotificationEvent {
             Self::CandleCrossMatchPassed {
                 timeframes_checked,
                 candles_compared,
+                today_ist_label,
             } => {
+                let header = if today_ist_label.is_empty() {
+                    String::new()
+                } else {
+                    format!("\n<b>TODAY ONLY:</b> {today_ist_label}")
+                };
                 format!(
-                    "<b>Historical vs Live cross-match OK</b>\nTimeframes: {timeframes_checked} | Candles compared: {candles_compared}\nAll OHLCV values match exactly (zero tolerance, precision-verified)"
+                    "<b>Historical vs Live cross-match OK</b>{header}\nTimeframes: {timeframes_checked} | Candles compared: {candles_compared}\nAll OHLCV values match exactly (zero tolerance, precision-verified)"
                 )
             }
             Self::CandleCrossMatchFailed {
@@ -773,9 +789,15 @@ impl NotificationEvent {
                 mismatches,
                 missing_live,
                 mismatch_details,
+                today_ist_label,
             } => {
+                let header = if today_ist_label.is_empty() {
+                    String::new()
+                } else {
+                    format!("\n<b>TODAY ONLY:</b> {today_ist_label}")
+                };
                 let mut msg = format!(
-                    "<b>Historical vs Live cross-match FAILED</b>\nCompared: {candles_compared} | Mismatches: {mismatches}"
+                    "<b>Historical vs Live cross-match FAILED</b>{header}\nCompared: {candles_compared} | Mismatches: {mismatches}"
                 );
                 if *missing_live > 0 {
                     msg.push_str(&format!("\nMissing live: {missing_live}"));
@@ -1419,6 +1441,7 @@ mod tests {
         let event = NotificationEvent::CandleCrossMatchPassed {
             timeframes_checked: 5,
             candles_compared: 187500,
+            today_ist_label: String::new(),
         };
         let msg = event.to_message();
         assert!(msg.contains("cross-match OK"));
@@ -1435,6 +1458,7 @@ mod tests {
             mismatch_details: vec![
                 "\u{2022} RELIANCE (NSE_EQ) 1m @ 2026-03-18 10:15 IST\n  Hist: O=2450.0 H=2465.0\n  Live: O=2450.0 H=2463.5\n  Diff: H(-1.5)".to_string(),
             ],
+            today_ist_label: String::new(),
         };
         let msg = event.to_message();
         assert!(msg.contains("cross-match FAILED"));
@@ -1451,6 +1475,7 @@ mod tests {
             mismatches: 12,
             missing_live: 8,
             mismatch_details: vec![],
+            today_ist_label: String::new(),
         };
         assert_eq!(event.severity(), Severity::High);
     }
@@ -1460,6 +1485,7 @@ mod tests {
         let event = NotificationEvent::CandleCrossMatchPassed {
             timeframes_checked: 5,
             candles_compared: 187500,
+            today_ist_label: String::new(),
         };
         assert_eq!(event.severity(), Severity::Low);
     }
@@ -1919,6 +1945,7 @@ mod tests {
             mismatches: 5,
             missing_live: 0,
             mismatch_details: vec![],
+            today_ist_label: String::new(),
         };
         let msg = event.to_message();
         assert!(!msg.contains("Missing live"));
@@ -1931,6 +1958,7 @@ mod tests {
             mismatches: 0,
             missing_live: 0,
             mismatch_details: vec![],
+            today_ist_label: String::new(),
         };
         let msg = event.to_message();
         // The header always contains "Mismatches: N", but the details section should be absent
@@ -2028,6 +2056,7 @@ mod tests {
             mismatches: 60,
             missing_live: 0,
             mismatch_details: details,
+            today_ist_label: String::new(),
         };
         let msg = event.to_message();
         assert!(msg.contains("mismatch 0"));

--- a/crates/core/src/websocket/depth_connection.rs
+++ b/crates/core/src/websocket/depth_connection.rs
@@ -687,7 +687,13 @@ pub async fn run_two_hundred_depth_connection(
                     });
                 }
 
-                // Escalate to ERROR after 10+ consecutive failures
+                // Log policy — reduces noise during transient Dhan-side
+                // resets (e.g. 200-level `/twohundreddepth` TCP resets per
+                // Ticket #5519522/#5543510) while preserving escalation.
+                //
+                // * attempt == 0          → WARN  (first failure is visible)
+                // * attempt == 1..=9      → DEBUG (silent during brief backoff)
+                // * attempt % 10 == 0 (≥10) → ERROR (Telegram escalation)
                 if attempt > 0 && attempt.is_multiple_of(10) {
                     error!(
                         security_id,
@@ -696,13 +702,21 @@ pub async fn run_two_hundred_depth_connection(
                         ?err,
                         "{prefix}: reconnection threshold — still retrying"
                     );
-                } else {
+                } else if attempt == 0 {
                     warn!(
                         security_id,
                         label = %label,
                         attempt,
                         ?err,
                         "{prefix}: connection failed — will reconnect"
+                    );
+                } else {
+                    debug!(
+                        security_id,
+                        label = %label,
+                        attempt,
+                        ?err,
+                        "{prefix}: connection still failing — retrying"
                     );
                 }
 

--- a/crates/trading/src/risk/tick_gap_tracker.rs
+++ b/crates/trading/src/risk/tick_gap_tracker.rs
@@ -31,6 +31,13 @@ struct SecurityFeedState {
     /// Whether a stale alert has already been emitted for the current gap.
     /// Prevents duplicate alerts until the instrument resumes ticking.
     stale_alerted: bool,
+    /// Whether an ERROR-level gap alert has already been emitted for the
+    /// current gap episode. Edge-triggered: fires once when a gap first
+    /// crosses `TICK_GAP_ERROR_THRESHOLD_SECS`, resets when the instrument
+    /// resumes ticking within the normal band (< WARN threshold). Prevents
+    /// Telegram spam for illiquid F&O contracts that simply don't trade
+    /// for minutes at a time during live hours.
+    error_gap_alerted: bool,
 }
 
 /// Tracks tick gaps per security for feed health monitoring.
@@ -93,6 +100,7 @@ impl TickGapTracker {
             tick_count: 0,
             last_wall_clock: now,
             stale_alerted: false,
+            error_gap_alerted: false,
         });
 
         state.tick_count = state.tick_count.saturating_add(1);
@@ -109,15 +117,23 @@ impl TickGapTracker {
         let gap_secs = exchange_timestamp.saturating_sub(state.last_exchange_timestamp);
 
         let result = if gap_secs >= TICK_GAP_ERROR_THRESHOLD_SECS {
-            // ERROR: possible disconnection — log immediately per-instrument.
-            error!(
-                security_id = security_id,
-                gap_secs = gap_secs,
-                last_ts = state.last_exchange_timestamp,
-                current_ts = exchange_timestamp,
-                "tick feed gap — possible disconnection"
-            );
+            // ERROR: possible disconnection — edge-triggered per instrument.
+            // Log + Telegram fires ONCE when the gap first crosses threshold.
+            // Subsequent ticks still in gap are counted but suppressed to
+            // avoid Telegram spam for illiquid options that legitimately
+            // don't trade for minutes. The flag clears in the recovery
+            // branch below (gap_secs < WARN) once ticks resume normally.
             self.total_errors = self.total_errors.saturating_add(1);
+            if !state.error_gap_alerted {
+                error!(
+                    security_id = security_id,
+                    gap_secs = gap_secs,
+                    last_ts = state.last_exchange_timestamp,
+                    current_ts = exchange_timestamp,
+                    "tick feed gap — possible disconnection"
+                );
+                state.error_gap_alerted = true;
+            }
             TickGapResult::Error { gap_secs }
         } else if gap_secs >= TICK_GAP_ALERT_THRESHOLD_SECS {
             // WARN: normal illiquidity gap — aggregate into periodic summary
@@ -126,6 +142,9 @@ impl TickGapTracker {
             self.total_warnings = self.total_warnings.saturating_add(1);
             TickGapResult::Warning { gap_secs }
         } else {
+            // Recovered — tick arrived within normal band. Clear error
+            // edge-trigger so the next ERROR-level gap fires afresh.
+            state.error_gap_alerted = false;
             TickGapResult::Ok
         };
 
@@ -401,6 +420,7 @@ impl TickGapTracker {
                     tick_count: 0,
                     last_wall_clock: Instant::now(),
                     stale_alerted: false,
+                    error_gap_alerted: false,
                 });
                 BackwardsJumpResult::FirstSeen
             }
@@ -902,6 +922,117 @@ mod tests {
             matches!(result, TickGapResult::Warning { .. }),
             "first tick after warmup must detect gap"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge-triggered ERROR gap dedup (Telegram spam suppression for illiquid
+    // F&O contracts that don't tick for minutes during live hours).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn error_gap_alerted_fires_once_then_suppresses_until_recovery() {
+        let mut tracker = TickGapTracker::new(10);
+        let base_ts = 1_700_000_000;
+
+        // Warmup
+        for i in 0..=TICK_GAP_MIN_TICKS_BEFORE_ACTIVE {
+            tracker.record_tick(1001, base_ts + i);
+        }
+
+        // First ERROR-level gap — flag was false, must fire.
+        let t1 = base_ts + TICK_GAP_MIN_TICKS_BEFORE_ACTIVE + TICK_GAP_ERROR_THRESHOLD_SECS;
+        let r1 = tracker.record_tick(1001, t1);
+        assert!(matches!(r1, TickGapResult::Error { .. }));
+        assert!(
+            tracker.states.get(&1001).unwrap().error_gap_alerted,
+            "first ERROR tick must set the edge-trigger flag"
+        );
+        assert_eq!(tracker.total_errors(), 1);
+
+        // Second ERROR-level gap on same instrument while still in gap —
+        // counter still increments but NO new Telegram-routed error! call.
+        // (We can't observe the log macro directly, but the flag gate proves
+        // the error! path was skipped.)
+        let t2 = t1 + TICK_GAP_ERROR_THRESHOLD_SECS;
+        let r2 = tracker.record_tick(1001, t2);
+        assert!(matches!(r2, TickGapResult::Error { .. }));
+        assert!(
+            tracker.states.get(&1001).unwrap().error_gap_alerted,
+            "flag must stay set while instrument is still in the gap episode"
+        );
+        assert_eq!(
+            tracker.total_errors(),
+            2,
+            "counter increments regardless of dedup (metric accuracy)"
+        );
+    }
+
+    #[test]
+    fn error_gap_flag_clears_on_recovery_tick() {
+        let mut tracker = TickGapTracker::new(10);
+        let base_ts = 1_700_000_000;
+
+        // Warmup + first ERROR gap
+        for i in 0..=TICK_GAP_MIN_TICKS_BEFORE_ACTIVE {
+            tracker.record_tick(1001, base_ts + i);
+        }
+        let t1 = base_ts + TICK_GAP_MIN_TICKS_BEFORE_ACTIVE + TICK_GAP_ERROR_THRESHOLD_SECS;
+        tracker.record_tick(1001, t1);
+        assert!(tracker.states.get(&1001).unwrap().error_gap_alerted);
+
+        // Recovery: a normal 1-second tick must CLEAR the flag so the
+        // next ERROR episode fires fresh.
+        let recovery = t1 + 1;
+        let rr = tracker.record_tick(1001, recovery);
+        assert_eq!(rr, TickGapResult::Ok);
+        assert!(
+            !tracker.states.get(&1001).unwrap().error_gap_alerted,
+            "normal tick must clear the error-gap edge-trigger flag"
+        );
+    }
+
+    #[test]
+    fn error_gap_alerted_fires_again_after_recovery() {
+        let mut tracker = TickGapTracker::new(10);
+        let base_ts = 1_700_000_000;
+
+        // Warmup + first ERROR episode
+        for i in 0..=TICK_GAP_MIN_TICKS_BEFORE_ACTIVE {
+            tracker.record_tick(1001, base_ts + i);
+        }
+        let t1 = base_ts + TICK_GAP_MIN_TICKS_BEFORE_ACTIVE + TICK_GAP_ERROR_THRESHOLD_SECS;
+        tracker.record_tick(1001, t1);
+        // Recovery
+        tracker.record_tick(1001, t1 + 1);
+        assert!(!tracker.states.get(&1001).unwrap().error_gap_alerted);
+
+        // Second ERROR episode (after recovery) — flag should re-arm.
+        let t2 = t1 + 1 + TICK_GAP_ERROR_THRESHOLD_SECS;
+        tracker.record_tick(1001, t2);
+        assert!(
+            tracker.states.get(&1001).unwrap().error_gap_alerted,
+            "second gap episode must re-set the edge-trigger flag"
+        );
+    }
+
+    #[test]
+    fn error_gap_dedup_is_per_security() {
+        let mut tracker = TickGapTracker::new(10);
+        let base_ts = 1_700_000_000;
+
+        // Warmup two securities
+        for i in 0..=TICK_GAP_MIN_TICKS_BEFORE_ACTIVE {
+            tracker.record_tick(1001, base_ts + i);
+            tracker.record_tick(1002, base_ts + i);
+        }
+
+        // Both hit an ERROR-level gap independently — both must fire once.
+        let t_err = base_ts + TICK_GAP_MIN_TICKS_BEFORE_ACTIVE + TICK_GAP_ERROR_THRESHOLD_SECS;
+        tracker.record_tick(1001, t_err);
+        tracker.record_tick(1002, t_err);
+        assert!(tracker.states.get(&1001).unwrap().error_gap_alerted);
+        assert!(tracker.states.get(&1002).unwrap().error_gap_alerted);
+        assert_eq!(tracker.total_errors(), 2);
     }
 
     #[test]

--- a/scripts/dhan-200depth-paste-and-run.py
+++ b/scripts/dhan-200depth-paste-and-run.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Dhan 200-Level Depth — Paste-and-Run (no env vars needed)
+=========================================================
+
+Minimum-friction reproducer for Dhan Ticket #5519522 / #5543510.
+Paste your CLIENT_ID, ACCESS_TOKEN, and SECURITY_ID directly below,
+save, run:
+
+    pip install dhanhq==2.2.0rc1
+    python3 scripts/dhan-200depth-paste-and-run.py
+
+Uses Dhan's OFFICIAL `dhanhq.FullDepth` class — same code path the Dhan
+Support team uses internally. If this succeeds, our Rust client is the
+odd one out. If it fails the same way (TCP reset in <5s), we have clean
+evidence to send back on the ticket.
+
+SECURITY NOTE
+-------------
+DO NOT commit a real token. The placeholder below is intentionally
+obviously-bogus so an accidental commit is caught by the secret scanner.
+If you push this file with a real token, rotate it immediately at
+web.dhan.co.
+"""
+
+# ============================================================
+# PASTE YOUR VALUES HERE — then save and run
+# ============================================================
+
+CLIENT_ID      = "1106656882"                        # your Dhan client id
+ACCESS_TOKEN   = "PASTE_YOUR_JWT_HERE_eyJ..."        # 24h JWT from web.dhan.co
+SECURITY_ID    = "63424"                             # integer as string; e.g. NIFTY 24150 CE
+SEGMENT        = 2                                   # 2 = NSE_FNO, 1 = NSE_EQ, 0 = IDX_I
+DEPTH_LEVEL    = 200                                 # 20 or 200
+
+# ============================================================
+# Nothing below this line needs editing
+# ============================================================
+
+import sys
+import time
+from datetime import datetime
+
+
+def guard_placeholders() -> None:
+    if "PASTE_YOUR" in ACCESS_TOKEN or not ACCESS_TOKEN.strip():
+        print("ERROR: edit this file and paste your ACCESS_TOKEN at the top.")
+        sys.exit(2)
+    if not CLIENT_ID.strip() or not SECURITY_ID.strip():
+        print("ERROR: CLIENT_ID and SECURITY_ID cannot be empty.")
+        sys.exit(2)
+
+
+def main() -> int:
+    guard_placeholders()
+
+    try:
+        from dhanhq import DhanContext, FullDepth  # type: ignore
+    except ImportError:
+        print("ERROR: dhanhq SDK not installed.")
+        print("       Run:  pip install dhanhq==2.2.0rc1")
+        return 2
+
+    print("=" * 70)
+    print("Dhan 200-Level Full Market Depth — Paste-and-Run")
+    print("=" * 70)
+    print(f"  Started at      : {datetime.now().isoformat()}")
+    print(f"  Client ID       : {CLIENT_ID}")
+    print(f"  Security ID     : {SECURITY_ID}")
+    print(f"  Segment         : {SEGMENT} (2=NSE_FNO, 1=NSE_EQ, 0=IDX_I)")
+    print(f"  Depth level     : {DEPTH_LEVEL}")
+    print("=" * 70)
+
+    dhan_context = DhanContext(CLIENT_ID, ACCESS_TOKEN)
+    instruments = [(SEGMENT, SECURITY_ID)]
+
+    started = time.time()
+    frames = 0
+    try:
+        response = FullDepth(dhan_context, instruments, DEPTH_LEVEL)
+        response.run_forever()
+
+        while True:
+            data = response.get_data()
+            if data is not None:
+                frames += 1
+                if frames <= 5 or frames % 50 == 0:
+                    print(f"[frame {frames:>5}] {data}")
+
+            if getattr(response, "on_close", False):
+                elapsed = time.time() - started
+                print("-" * 70)
+                print(f"RESULT : server closed after {elapsed:.1f}s")
+                print(f"         frames received = {frames}")
+                if elapsed < 10.0 and frames == 0:
+                    print("         PATTERN MATCHES Ticket #5519522 / #5543510")
+                    print("         (TCP reset within 5s, zero frames). Send")
+                    print("         this stdout back to Dhan support.")
+                else:
+                    print("         Clean stream, then disconnect.")
+                break
+    except KeyboardInterrupt:
+        print(f"\nInterrupted (Ctrl-C). Total frames: {frames}.")
+    except Exception as exc:  # noqa: BLE001
+        print(f"EXCEPTION: {type(exc).__name__}: {exc}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dhan-official-200depth.py
+++ b/scripts/dhan-official-200depth.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Dhan Official 200-Level Full Market Depth Test
+==============================================
+
+EXACT script shared by Dhan Support team after the Google Meet
+(ref: Ticket #5519522, #5543510, Apr 17 2026 Dhan Cares email:
+ "try connecting to the WebSocket for Full Market Depth, as discussed
+  over the G-Meet, since it is working fine now from our end").
+
+This uses Dhan's OFFICIAL Python SDK — `dhanhq.FullDepth` — so the
+result is a clean apples-to-apples test against Dhan's own reference
+implementation. If this script connects and streams data, the fault
+is in our Rust client. If it fails the same way as the Rust client
+(TCP reset within 3-5 seconds), the fault is on Dhan's side and we
+have verbatim proof to send back.
+
+PREREQUISITES
+-------------
+    pip install dhanhq==2.2.0rc1
+
+USAGE
+-----
+    # Credentials via env (recommended — never commit tokens):
+    export DHAN_CLIENT_ID="1106656882"
+    export DHAN_ACCESS_TOKEN="eyJ..."
+    python3 scripts/dhan-official-200depth.py
+
+    # Override SecurityId if Dhan gives a specific contract to test
+    # (default is NIFTY 21 APR 24150 CALL = 63424 from Dhan's own sample):
+    DHAN_SECURITY_ID="63424" DHAN_SEGMENT="2" \
+        python3 scripts/dhan-official-200depth.py
+
+SEGMENT CODES (from Dhan annexure-enums)
+----------------------------------------
+    0 = IDX_I        (indices)
+    1 = NSE_EQ       (NSE equity)
+    2 = NSE_FNO      (NSE F&O)          ← default, matches Dhan's sample
+    3 = NSE_CURRENCY
+    4 = BSE_EQ
+    5 = MCX_COMM
+    7 = BSE_CURRENCY (no 6)
+    8 = BSE_FNO
+
+OUTPUT
+------
+Streams depth frames to stdout until Ctrl-C OR server disconnect.
+On disconnect prints a clear message so you know immediately whether
+the connection held or was reset by Dhan's server.
+
+Share stdout back on the Dhan ticket — they asked for this exact
+reproducer.
+"""
+
+import os
+import sys
+import time
+from datetime import datetime
+
+
+def main() -> int:
+    client_id = os.environ.get("DHAN_CLIENT_ID", "").strip()
+    access_token = os.environ.get("DHAN_ACCESS_TOKEN", "").strip()
+    security_id = os.environ.get("DHAN_SECURITY_ID", "63424").strip()
+    segment = int(os.environ.get("DHAN_SEGMENT", "2").strip())
+    depth_level = int(os.environ.get("DHAN_DEPTH_LEVEL", "200").strip())
+
+    if not client_id or not access_token:
+        print("ERROR: set DHAN_CLIENT_ID and DHAN_ACCESS_TOKEN env vars.")
+        print("       (Never hardcode tokens — they rotate every 24h.)")
+        return 2
+
+    try:
+        from dhanhq import DhanContext, FullDepth  # type: ignore
+    except ImportError:
+        print("ERROR: dhanhq SDK not installed.")
+        print("       Run:  pip install dhanhq==2.2.0rc1")
+        return 2
+
+    print("=" * 70)
+    print("Dhan Official 200-Level Full Market Depth Test")
+    print("=" * 70)
+    print(f"  Started at        : {datetime.now().isoformat()}")
+    print(f"  Client ID         : {client_id}")
+    print(f"  Security ID       : {security_id}")
+    print(f"  Segment (numeric) : {segment}")
+    print(f"  Depth level       : {depth_level}")
+    print("=" * 70)
+
+    dhan_context = DhanContext(client_id, access_token)
+    instruments = [(segment, security_id)]
+
+    try:
+        response = FullDepth(dhan_context, instruments, depth_level)
+        response.run_forever()
+
+        frames = 0
+        started = time.time()
+        while True:
+            data = response.get_data()
+            if data is not None:
+                frames += 1
+                if frames <= 5 or frames % 50 == 0:
+                    print(f"[frame {frames:>5}] {data}")
+
+            if getattr(response, "on_close", False):
+                elapsed = time.time() - started
+                print("-" * 70)
+                print(f"RESULT: Server disconnection after {elapsed:.1f}s")
+                print(f"        Total frames received: {frames}")
+                if elapsed < 10.0 and frames == 0:
+                    print("        Pattern matches the TCP-reset-within-5s bug")
+                    print("        (Ticket #5519522 / #5543510). Send this log")
+                    print("        back to Dhan support.")
+                else:
+                    print("        Clean disconnect after real streaming.")
+                break
+    except KeyboardInterrupt:
+        print("\nInterrupted by operator (Ctrl-C). Exiting cleanly.")
+    except Exception as exc:  # noqa: BLE001 — diagnostic script, print all
+        print(f"EXCEPTION: {type(exc).__name__}: {exc}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Batched five fixes + two Dhan 200-depth diagnostic scripts into one PR.

### 1. ATM label vs security_id mismatch (CRITICAL)

Telegram alert showed:
```
Contract: BANKNIFTY-Apr2026-56700-PE
SecurityId: 67481
```
But `security_id=67481` in QuestDB is actually `BANKNIFTY 28 APR 54300 PUT` (strike 54300, not 56700).

**Root cause:** `sel.call_security_ids.first()` returned the **lowest** strike in the ATM ± N range (atm − 24), not the ATM itself, while the label was built with `sel.atm_strike` (center).

**Fix:** added dedicated `atm_ce_security_id` / `atm_pe_security_id` fields to `DepthStrikeSelection`, computed from the ATM index **before** range expansion. `main.rs` now uses these.

Regression tests:
- `test_atm_ce_security_id_is_exact_atm_not_range_first`
- `test_atm_ce_matches_find_atm_security_ids`
- `test_atm_security_id_correct_near_chain_edge`

### 2. CSV `display_name` for depth 20 + 200 operator surfaces

Added `atm_ce_display_name` / `atm_pe_display_name` on `DepthStrikeSelection` and `ce_display_name` / `pe_display_name` on `AtmIds`, populated from `universe.derivative_contracts[sid].display_name`. Telegram alerts + logs now show the exact Dhan web-UI string (`BANKNIFTY 28 APR 54300 PUT`) instead of the synthesized `BANKNIFTY-Apr2026-54300-PE`.

Regression tests:
- `test_fill_display_names_from_universe_uses_registry_display_name`
- `test_fill_display_names_from_universe_atmids_populates_both_sides`

### 3. Edge-triggered ERROR dedup in `tick_gap_tracker`

Illiquid F&O options legitimately don't tick for 120-800s during live hours — flooded Telegram with per-instrument ERROR lines. Added `error_gap_alerted` flag on `SecurityFeedState` (same pattern as `stale_alerted`): fires ERROR **once** per gap episode, clears on first recovery tick. Counter (`total_errors`) still increments every time for Prometheus accuracy.

### 4. Depth-200 reconnect WARN noise (Ticket #5519522 / #5543510)

Dhan's `/twohundreddepth` currently resets TCP within 3-5s. Our loop retries cleanly but logged WARN on every attempt = 10× Telegram-eligible noise/min/contract. Attempts 1-9 → `debug!`; attempt 0 stays WARN for first-failure visibility; attempts at 10, 20, 30… stay ERROR so Telegram escalation is preserved.

### 5. Emergency-download-succeeded log level

Per **I-P0-06** the FAILURE must be CRITICAL (unchanged). The RECOVERY message no longer needs to re-fire Telegram. Downgraded to `warn!` so the investigate-why-cache-was-missing hint stays visible without duplicate alerts.

### 6. Dhan 200-depth diagnostic scripts (new)

- `scripts/dhan-official-200depth.py` — wraps `dhanhq.FullDepth` SDK with env-var credentials (apples-to-apples vs Dhan's own reference).
- `scripts/dhan-200depth-paste-and-run.py` — same, but paste-token-inline UX for quick operator tests.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo check --workspace` clean
- [x] `cargo test -p tickvault-core --lib` → 2872 passed
- [x] `cargo test -p tickvault-trading --lib` → 1213 passed
- [x] `cargo test -p tickvault-app --lib` → 397 passed
- [x] Pre-push pub-fn-test guard: baseline 130 (stable)
- [x] Pre-push fmt + banned patterns + secrets + data integrity + 22-type + Dhan locked facts: all PASS
- [ ] CI full pipeline (clippy, audit, deny, loom)
- [ ] Operator smoke test at next market open

## Files touched

```
crates/app/src/main.rs
crates/core/src/instrument/depth_rebalancer.rs
crates/core/src/instrument/depth_strike_selector.rs
crates/core/src/instrument/instrument_loader.rs
crates/core/src/websocket/depth_connection.rs
crates/trading/src/risk/tick_gap_tracker.rs
scripts/dhan-200depth-paste-and-run.py      (new)
scripts/dhan-official-200depth.py           (new)
```

https://claude.ai/code/session_01NXBWR9TXVxCFn3HRyUNhsm
