### PR TITLE
feat(app,core): pre-market profile check HALTs boot + CRITICAL Telegram

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1614,24 +1614,61 @@ async fn main() -> Result<()> {
     };
 
     // -----------------------------------------------------------------------
-    // Step 6c: Pre-market readiness check (08:00/08:05 IST on trading days)
+    // Step 6c: Pre-market readiness check (Parthiban directive 2026-04-21)
     // -----------------------------------------------------------------------
-    // On AWS the app starts at 08:00 IST. Verify essential conditions before
-    // market open so failures are caught with 75 minutes to spare.
-    // Checks: data plan active, derivative segment enabled, token >4h remaining.
+    // Three-zone behaviour:
+    //   - 08:00–09:14 IST (pre-market): run + CRITICAL Telegram on failure,
+    //     but boot CONTINUES so operator has 75min to rotate the token /
+    //     reactivate dataPlan before 09:15.
+    //   - 09:15–15:30 IST (market hours): run + CRITICAL Telegram on failure
+    //     AND HALT the boot — we refuse to start trading against a bad
+    //     profile (expired dataPlan, revoked Derivative segment, or
+    //     4h-expiring token would all cause silent data loss).
+    //   - Off-hours / non-trading: skip (nothing to check against).
+    //
+    // Checks: dataPlan == "Active", activeSegment contains "Derivative",
+    // token expires > 4 hours from now.
     if is_trading {
         let now_ist =
             chrono::Utc::now() + chrono::Duration::hours(5) + chrono::Duration::minutes(30);
         let hour = now_ist.hour();
-        // Run pre-market check if booting between 08:00-09:14 IST (before market open).
-        if hour == 8 || (hour == 9 && now_ist.minute() < 15) {
-            info!("running pre-market readiness check (08:00–09:14 IST)");
+        let minute = now_ist.minute();
+        let in_pre_market = hour == 8 || (hour == 9 && minute < 15);
+        let in_market_hours =
+            (hour == 9 && minute >= 15) || (10..=14).contains(&hour) || (hour == 15 && minute < 30);
+        if in_pre_market || in_market_hours {
+            info!(
+                in_pre_market,
+                in_market_hours, "running pre-market readiness check"
+            );
             match token_manager.pre_market_check().await {
                 Ok(()) => info!("pre-market readiness check passed"),
                 Err(err) => {
-                    // WARN, not ERROR — system continues but operator should investigate.
-                    // During market hours this would be CRITICAL; at 08:00 there's time to fix.
-                    warn!(error = %err, "pre-market readiness check FAILED — investigate before 09:15");
+                    let reason = format!("{err}");
+                    // Critical Telegram event — always fires (pre-market or market-hours).
+                    notifier.notify(NotificationEvent::PreMarketProfileCheckFailed {
+                        reason: reason.clone(),
+                        within_market_hours: in_market_hours,
+                    });
+                    if in_market_hours {
+                        // HALT — we refuse to boot into a live trading session
+                        // with a bad profile. systemd will restart on the next
+                        // attempt but the underlying cause (dataPlan / segment
+                        // / token) must be fixed first.
+                        error!(
+                            error = %err,
+                            "HALTING BOOT — pre-market profile check failed during market hours"
+                        );
+                        anyhow::bail!(
+                            "pre-market profile check FAILED during market hours — HALT: {reason}"
+                        );
+                    }
+                    // Pre-market window — log ERROR (triggers Telegram) but
+                    // allow boot to continue; operator has until 09:15 IST.
+                    error!(
+                        error = %err,
+                        "pre-market profile check FAILED — investigate before 09:15 IST"
+                    );
                 }
             }
         }

--- a/crates/app/tests/premarket_profile_halt_guard.rs
+++ b/crates/app/tests/premarket_profile_halt_guard.rs
@@ -1,0 +1,144 @@
+//! Ratchet test: pre-market profile check HALTS the boot during market
+//! hours and fires CRITICAL Telegram regardless of when the failure is
+//! detected.
+//!
+//! # Why this exists (Parthiban directive 2026-04-21)
+//!
+//! On 2026-04-21 the app booted, WebSocket reported "connected" on all
+//! 5 connections, but Dhan was not streaming data during market hours.
+//! The operator discovered hours later via Grafana. Root cause was
+//! almost certainly a dataPlan / activeSegment / token-validity issue
+//! on the Dhan side — but the app had no HALT gate, so it kept running
+//! with a broken configuration.
+//!
+//! This PR wires the existing `pre_market_check` into a proper HALT +
+//! Telegram escalation:
+//!
+//! | Time window | Failure action |
+//! |---|---|
+//! | Off-hours / non-trading | skip check |
+//! | 08:00–09:14 IST | CRITICAL Telegram, boot continues |
+//! | 09:15–15:30 IST | CRITICAL Telegram + HALT boot |
+//!
+//! These ratchets scan the source so the behaviour cannot regress
+//! silently. Complementary to `crates/core/src/auth/token_manager.rs`
+//! unit tests that validate the check's decision logic.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p.push(rel);
+    p
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_path(rel);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn events_rs_declares_pre_market_profile_check_failed() {
+    let src = read("crates/core/src/notification/events.rs");
+    assert!(
+        src.contains("PreMarketProfileCheckFailed"),
+        "events.rs must declare PreMarketProfileCheckFailed variant \
+         — without it, the halt event has no Telegram message."
+    );
+    assert!(
+        src.contains("within_market_hours: bool"),
+        "PreMarketProfileCheckFailed must carry within_market_hours \
+         so the Telegram message can distinguish 'HALT fired' from \
+         'operator has 75min'."
+    );
+}
+
+#[test]
+fn pre_market_profile_check_failed_is_critical_severity() {
+    let src = read("crates/core/src/notification/events.rs");
+    assert!(
+        src.contains("Self::PreMarketProfileCheckFailed { .. } => Severity::Critical"),
+        "PreMarketProfileCheckFailed MUST be Critical severity — the \
+         operator MUST be paged immediately. Downgrading this to High \
+         or Medium means the page might be delayed or lost in SNS quiet \
+         hours policies."
+    );
+}
+
+#[test]
+fn pre_market_profile_check_failed_to_message_mentions_diagnostics() {
+    let src = read("crates/core/src/notification/events.rs");
+    // The message must guide the operator to the exact curl commands
+    // they need to run. Without this, the operator has to remember the
+    // Dhan API layout under pressure.
+    assert!(
+        src.contains("dataPlan == \\\"Active\\\""),
+        "PreMarketProfileCheckFailed message must tell the operator to \
+         check dataPlan — else the operator has to re-read the Dhan \
+         docs under pressure."
+    );
+    assert!(
+        src.contains("Derivative"),
+        "PreMarketProfileCheckFailed message must call out the \
+         Derivative segment check."
+    );
+    assert!(
+        src.contains("BOOT HALTED"),
+        "PreMarketProfileCheckFailed message must distinguish the \
+         HALT branch from the pre-market warn-only branch."
+    );
+}
+
+#[test]
+fn main_rs_halts_on_profile_failure_during_market_hours() {
+    let src = read("crates/app/src/main.rs");
+    assert!(
+        src.contains("HALTING BOOT — pre-market profile check failed during market hours"),
+        "main.rs must HALT when pre_market_check fails during market \
+         hours (09:15-15:30 IST). Regression = app boots with bad \
+         profile → silent data loss during trading."
+    );
+    assert!(
+        src.contains("anyhow::bail!"),
+        "main.rs halt branch must use anyhow::bail! to exit the boot \
+         sequence — using plain `return` skips the top-level error \
+         handler that systemd relies on to trigger restart."
+    );
+}
+
+#[test]
+fn main_rs_fires_critical_telegram_on_profile_failure() {
+    let src = read("crates/app/src/main.rs");
+    assert!(
+        src.contains("NotificationEvent::PreMarketProfileCheckFailed"),
+        "main.rs must call notifier.notify(PreMarketProfileCheckFailed \
+         {{ ... }}) on every pre_market_check failure — else the \
+         operator receives no Telegram and learns via Grafana (the \
+         2026-04-21 failure mode)."
+    );
+}
+
+#[test]
+fn main_rs_covers_both_pre_market_and_market_hours_windows() {
+    let src = read("crates/app/src/main.rs");
+    assert!(
+        src.contains("in_pre_market"),
+        "main.rs pre-market check must define an in_pre_market window \
+         variable so the CRITICAL alert can fire BEFORE 09:15 (giving \
+         the operator 75 minutes to rotate a bad token)."
+    );
+    assert!(
+        src.contains("in_market_hours"),
+        "main.rs pre-market check must define an in_market_hours \
+         window so the HALT branch activates inside 09:15-15:30 IST."
+    );
+    assert!(
+        src.contains("within_market_hours: in_market_hours"),
+        "main.rs must pass the in_market_hours flag into the \
+         PreMarketProfileCheckFailed event so the Telegram message \
+         distinguishes HALT from WARN."
+    );
+}

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -82,6 +82,23 @@ pub enum NotificationEvent {
     /// Dhan authentication failed at boot — system started in offline mode.
     AuthenticationFailed { reason: String },
 
+    /// Pre-market profile check FAILED — dataPlan, activeSegment, or token
+    /// expiry is not acceptable for today's trading session. Fires CRITICAL
+    /// Telegram on every failure. If the check runs during market hours
+    /// AND fails, the boot sequence HALTS (Parthiban directive 2026-04-21).
+    ///
+    /// Common causes:
+    /// - `dataPlan != "Active"` — subscription expired over weekend
+    /// - `activeSegment` lacks `"Derivative"` — F&O access revoked
+    /// - Token has < 4h until expiry — rotate before market open
+    ///
+    /// `within_market_hours = true` means HALT fired; `false` means operator
+    /// has until market open to investigate.
+    PreMarketProfileCheckFailed {
+        reason: String,
+        within_market_hours: bool,
+    },
+
     /// JWT token renewed successfully by background task.
     TokenRenewed,
 
@@ -461,6 +478,21 @@ impl NotificationEvent {
                 format!(
                     "<b>Auth FAILED</b> — offline mode\n{}",
                     redact_url_params(reason)
+                )
+            }
+            Self::PreMarketProfileCheckFailed {
+                reason,
+                within_market_hours,
+            } => {
+                let header = if *within_market_hours {
+                    "<b>CRITICAL: Pre-market profile check FAILED — BOOT HALTED</b>"
+                } else {
+                    "<b>CRITICAL: Pre-market profile check FAILED — investigate before 09:15 IST</b>"
+                };
+                format!(
+                    "{header}\n{reason}\n\
+                     Run:\n  curl -H \"access-token: $TOKEN\" https://api.dhan.co/v2/profile\n\
+                     Check: dataPlan == \"Active\", activeSegment contains \"Derivative\", tokenValidity > 4h."
                 )
             }
             Self::TokenRenewed => "<b>Token renewed</b>".to_string(),
@@ -942,6 +974,7 @@ impl NotificationEvent {
             Self::IpVerificationFailed { .. } => Severity::Critical,
             Self::BootDeadlineMissed { .. } => Severity::Critical,
             Self::AuthenticationFailed { .. } => Severity::Critical,
+            Self::PreMarketProfileCheckFailed { .. } => Severity::Critical,
             Self::TokenRenewalFailed { .. } => Severity::Critical,
             Self::InstrumentBuildFailed { .. } => Severity::High,
             Self::WebSocketDisconnected { .. } => Severity::High,


### PR DESCRIPTION
## Why

On 2026-04-21 the app booted during market hours, WebSocket reported "connected" on all 5 connections, but Dhan was not streaming data. Root cause was almost certainly a `dataPlan` / `activeSegment` / token-validity issue on Dhan's side — but our app had **no HALT gate**. It ran for hours with a broken profile, accumulating zero ticks while the operator only noticed via Grafana.

The `pre_market_check` function already exists in `token_manager` (validates `dataPlan == "Active"`, `activeSegment` contains `"Derivative"`, token expires > 4 h). Before this PR, `main.rs` only called it in the 08:00–09:14 IST window and logged failures at WARN (no Telegram, no HALT). During market hours it was never called.

## What changed

### New three-zone behaviour

| Time window | Failure action |
|---|---|
| Off-hours / non-trading | skip |
| 08:00–09:14 IST | CRITICAL Telegram, boot continues (75 min to fix) |
| 09:15–15:30 IST | CRITICAL Telegram + `anyhow::bail!` HALT |

HALT means the boot exits. systemd restarts the service, and until the dataPlan / segment / token is fixed, every restart HALTs with the same Telegram — so the operator **cannot miss it**.

### New `NotificationEvent` variant

```rust
PreMarketProfileCheckFailed {
    reason: String,
    within_market_hours: bool,
}
```

- Severity: **Critical**
- Message distinguishes `BOOT HALTED` (in-market-hours branch) from `investigate before 09:15 IST` (pre-market branch)
- Diagnostic payload embeds the exact curl commands for `/v2/profile`

### Files touched

- `crates/core/src/notification/events.rs` — new variant, `to_message`, severity wiring
- `crates/app/src/main.rs` — expanded window, wired Telegram + HALT
- `crates/app/tests/premarket_profile_halt_guard.rs` — **new** (6 ratchet tests)

## Tests (6 ratchets, all passing)

1. `events_rs_declares_pre_market_profile_check_failed`
2. `pre_market_profile_check_failed_is_critical_severity`
3. `pre_market_profile_check_failed_to_message_mentions_diagnostics`
4. `main_rs_halts_on_profile_failure_during_market_hours`
5. `main_rs_fires_critical_telegram_on_profile_failure`
6. `main_rs_covers_both_pre_market_and_market_hours_windows`

```
cargo test -p tickvault-app --test premarket_profile_halt_guard — 6/6 ✅
cargo test -p tickvault-core --lib notification — 200/200 ✅
cargo test -p tickvault-app --lib — 399/399 ✅
cargo fmt --check — clean
cargo check --workspace — clean
```

## Honest guarantees

- ✅ Any boot during market hours with a bad profile HALTS — no silent trading
- ✅ Every failure fires CRITICAL Telegram — operator paged in seconds, not hours
- ✅ Off-hours failures don't fire (operator would ignore noise)
- ✅ Diagnostic Telegram message spells out the three checks

## What this does NOT do

- Does not rotate tokens (background renewal already handles that) — this gate only ensures we don't BOOT past a known-bad token
- Does not detect **mid-session** profile invalidation (e.g. dataPlan expires at 11:00 IST). The no-tick watchdog in PR #308 partially covers that symptom

## Relationship to PR #308

Complementary. PR #308 fixes the WebSocket resilience layer + adds the no-tick watchdog (catches symptom of silent data loss). This PR adds the upstream gate (prevents booting into silent data loss in the first place).

## Test plan

- [x] Unit + ratchet tests pass
- [ ] Boot with a deliberately invalid token inside market hours → expect HALT + Telegram
- [ ] Boot at 08:00 IST with bad dataPlan → expect Telegram + boot continues
- [ ] Boot post-market (weekend) → expect skip (no Telegram, no HALT)

https://claude.ai/code/session_01Cs3Z9DzSVjGj11c3iFtnxq