### PR TITLE
test(core): fix 2 pre-existing notification test off-by-one failures (I9)

### DIFF
--- a/crates/core/tests/plan_p4_p5_alert_proof.rs
+++ b/crates/core/tests/plan_p4_p5_alert_proof.rs
@@ -153,17 +153,24 @@ fn test_depth_200_disconnected_includes_security_id_and_reason() {
 /// Every WebSocket type's connected/disconnected notification must carry
 /// enough context for the operator to identify the exact connection from
 /// the Telegram alert alone.
+///
+/// `WebSocketDisconnected::to_message()` displays the connection as
+/// 1-indexed (`{index + 1}/{MAX}`) to match how operators + Dhan talk
+/// about connection slots. So for `connection_index = 3` we expect
+/// `"4"` (3+1) in the formatted message, NOT `"3"`.
 #[test]
 fn test_all_4_ws_notification_events_include_identifiers() {
-    // Live Market Feed — connection_index.
+    // Live Market Feed — connection_index. Display is 1-indexed:
+    // `connection_index = 3` renders as `WebSocket 4/5 disconnected`.
     let live_disc = NotificationEvent::WebSocketDisconnected {
         connection_index: 3,
         reason: "transport error".to_string(),
     };
     let msg = live_disc.to_message();
     assert!(
-        msg.contains("3") || msg.contains("#3"),
-        "Live feed disconnect must include connection_index, got: {msg}"
+        msg.contains("4/") && msg.contains("disconnected"),
+        "Live feed disconnect must include 1-indexed connection (expected \
+         'WebSocket 4/N'), got: {msg}"
     );
 
     // Depth 20 — underlying.
@@ -220,6 +227,9 @@ fn test_questdb_reconnected_event_includes_drained_count() {
 
 // ─── WebSocket reconnection exhausted includes attempts ───
 
+/// Connection display is 1-indexed in the Telegram message (slot N+1 / MAX)
+/// because operators / Dhan refer to connection slots as `1..=5`, not
+/// `0..=4`. `connection_index = 2` → rendered as `WebSocket 3/5`.
 #[test]
 fn test_ws_reconnection_exhausted_includes_connection_and_attempts() {
     let event = NotificationEvent::WebSocketReconnectionExhausted {
@@ -229,8 +239,8 @@ fn test_ws_reconnection_exhausted_includes_connection_and_attempts() {
     let msg = event.to_message();
 
     assert!(
-        msg.contains("2") || msg.contains("#2"),
-        "Must include connection index, got: {msg}"
+        msg.contains("3/") && msg.contains("RECONNECTION EXHAUSTED"),
+        "Must include 1-indexed connection slot (expected 'WebSocket 3/N'), got: {msg}"
     );
     assert!(msg.contains("10"), "Must include attempt count, got: {msg}");
 }


### PR DESCRIPTION
## Why

Queue item **I9** from `.claude/queues/production-fixes-2026-04-21.md`.

Two tests in `crates/core/tests/plan_p4_p5_alert_proof.rs` have been failing on `main` for some time after the WS notification display format was updated to show connection slots as **1-indexed** (`{index + 1}/{MAX}`). The tests still asserted the raw zero-indexed value, which never appears in the rendered message.

## Failing tests before this PR

| Test | Construction | Rendered output | Assertion | Verdict |
|---|---|---|---|---|
| `test_all_4_ws_notification_events_include_identifiers` | `connection_index: 3` | `WebSocket 4/5 disconnected` | `msg.contains("3")` | ❌ "3" not present |
| `test_ws_reconnection_exhausted_includes_connection_and_attempts` | `connection_index: 2` | `WebSocket 3/5 RECONNECTION EXHAUSTED` | `msg.contains("2")` | ❌ "2" not present |

## Fix

The display format is intentional — operators and Dhan refer to connection slots as `1..=5`, not `0..=4`. This PR updates the **test assertions** to match the actual (correct) display format:

- Assert `msg.contains("4/")` for connection_index=3
- Assert `msg.contains("3/")` for connection_index=2
- Plus a second substring anchor (`"disconnected"` / `"RECONNECTION EXHAUSTED"`) so the match can't accidentally pass on a random `"4"` elsewhere in the string.
- Doc comments on both tests documenting the 1-indexed convention so future editors don't re-trip.

## Tests

```
cargo test -p tickvault-core --test plan_p4_p5_alert_proof — 8/8 passed ✅
```

All 8 tests in that file pass now (was 6 pass / 2 fail on `main`).

## Honest scope

This is **NOT** a production behaviour change. The notification display format is unchanged. Only 2 test assertions were corrected to reflect the existing + intentional 1-indexed display convention.

https://claude.ai/code/session_01Cs3Z9DzSVjGj11c3iFtnxq