### PR TITLE
feat(core,app): mid-session profile watchdog (I7)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -3613,6 +3613,22 @@ async fn main() -> Result<()> {
     info!("token renewal task started");
 
     // -----------------------------------------------------------------------
+    // Step 12a: Spawn mid-session profile watchdog (queue item I7)
+    // -----------------------------------------------------------------------
+    // Every 15 minutes during market hours, re-runs `pre_market_check`
+    // (dataPlan == "Active", activeSegment contains "Derivative", token
+    // expires > 4h). On rising-edge failure fires CRITICAL Telegram via
+    // NotificationEvent::MidSessionProfileInvalidated. Does NOT HALT —
+    // dropping the live WS feed mid-session costs more than the
+    // silent-failure risk we're monitoring.
+    let _mid_session_watchdog_handle =
+        tickvault_core::auth::mid_session_watchdog::spawn_mid_session_profile_watchdog(
+            std::sync::Arc::clone(&token_manager),
+            Some(std::sync::Arc::clone(&notifier)),
+        );
+    info!("mid-session profile watchdog spawned (15-min cadence, market-hours only)");
+
+    // -----------------------------------------------------------------------
     // Boot duration check — alert if boot exceeded BOOT_TIMEOUT_SECS
     // -----------------------------------------------------------------------
     let boot_elapsed = boot_start.elapsed();

--- a/crates/core/src/auth/mid_session_watchdog.rs
+++ b/crates/core/src/auth/mid_session_watchdog.rs
@@ -1,0 +1,241 @@
+//! Mid-session profile watchdog.
+//!
+//! # Why this exists (queue item I7, 2026-04-21)
+//!
+//! On 2026-04-21 the app booted during market hours, WebSocket reported
+//! all 5 connections "connected", but Dhan was not actually streaming
+//! data — likely a `dataPlan` / `activeSegment` / token-validity issue
+//! that appeared DURING the session. PR #309 added a pre-market profile
+//! HALT at boot, but once the app is already running the invariant goes
+//! unchecked for the rest of the day.
+//!
+//! This watchdog closes that gap. Every [`MID_SESSION_CHECK_INTERVAL_SECS`]
+//! during market hours, it calls [`TokenManager::pre_market_check`]
+//! (same validation the boot-time HALT uses). On failure during market
+//! hours it fires CRITICAL Telegram via
+//! [`NotificationEvent::PreMarketProfileCheckFailed`] — but does NOT HALT
+//! the running process. A mid-session HALT would terminate the live
+//! WebSocket feed, and reconnecting after systemd restart would take
+//! >30 seconds of lost ticks. Paging the operator is strictly better.
+//!
+//! # Design
+//!
+//! - **Background tokio task** spawned at boot, runs forever.
+//! - **Market-hours gated** (Rule 3 — `tickvault_common::market_hours`).
+//! - **Edge-triggered** (Rule 4 — `currently_failing: bool`). Rising
+//!   edge fires CRITICAL. Falling edge fires INFO (recovery), no
+//!   Telegram on recovery.
+//! - **Interval**: 15 minutes. Tight enough to catch a mid-session
+//!   `dataPlan` invalidation within one check window; loose enough to
+//!   not pound Dhan's `/v2/profile` endpoint (1 req/sec Quote rate
+//!   limit shared).
+//! - **Cold path**: one HTTP round-trip every 15 minutes. Zero impact
+//!   on the tick hot path.
+//!
+//! # Not a HALT
+//!
+//! The pre-market HALT (PR #309) is intentional — booting into a known-
+//! bad state is a no-op that costs nothing. A MID-SESSION HALT would
+//! cost live ticks. The product requirement (operator must be paged,
+//! boot must not continue into silent failure) is satisfied by the
+//! CRITICAL Telegram alert alone. Any remediation (token rotation,
+//! Dhan account fix, manual restart) is an operator decision, not an
+//! automatic one.
+//!
+//! # Tests
+//!
+//! - `evaluate_transition_first_failure` — rising edge
+//! - `evaluate_transition_recovery_after_failure` — falling edge
+//! - `evaluate_transition_steady_fail_no_duplicate_alert` — idempotent
+//! - `evaluate_transition_steady_ok_no_op` — idempotent
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tickvault_common::market_hours::is_within_market_hours_ist;
+use tracing::{error, info};
+
+use crate::auth::token_manager::TokenManager;
+use crate::notification::events::NotificationEvent;
+use crate::notification::service::NotificationService;
+
+/// Check cadence (seconds). 15 minutes = 900 s. Loose enough to stay
+/// under the 1 req/sec Quote API rate limit even under pathological
+/// burst conditions; tight enough that a mid-session `dataPlan`
+/// invalidation is detected within one cycle.
+pub const MID_SESSION_CHECK_INTERVAL_SECS: u64 = 900;
+
+/// Spawns the mid-session profile watchdog as an independent tokio task.
+///
+/// Consumers should keep the returned [`tokio::task::JoinHandle`] around
+/// and abort it on graceful shutdown. The task runs forever otherwise.
+///
+/// # Arguments
+/// * `token_manager` — shared `TokenManager` (uses `pre_market_check`).
+/// * `notifier` — `NotificationService` for CRITICAL Telegram on the
+///   rising edge. `None` disables Telegram; logs still fire.
+// TEST-EXEMPT: thin tokio::spawn wrapper around `run_watchdog_loop`. The behavioural surface (`evaluate_transition` + `apply_transition`) is fully covered by the 4 unit tests in this module; the spawn wrapper itself has no decision logic.
+pub fn spawn_mid_session_profile_watchdog(
+    token_manager: Arc<TokenManager>,
+    notifier: Option<Arc<NotificationService>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(run_watchdog_loop(token_manager, notifier))
+}
+
+/// Internal loop. Extracted so the unit tests below can drive it via
+/// `evaluate_transition` + `apply_transition` without spawning a task.
+async fn run_watchdog_loop(
+    token_manager: Arc<TokenManager>,
+    notifier: Option<Arc<NotificationService>>,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(MID_SESSION_CHECK_INTERVAL_SECS));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Consume the immediate first tick — we want to wait one full
+    // interval before the first check so this doesn't fire at boot
+    // (the pre-market HALT already covers boot-time).
+    interval.tick().await;
+    let mut state = WatchdogState::default();
+    loop {
+        interval.tick().await;
+        if !is_within_market_hours_ist() {
+            // Off-hours: skip the check entirely. Do NOT touch state —
+            // if we were alerting at 15:30 market close, the next
+            // market open (09:15 tomorrow) should fire fresh if the
+            // condition persists.
+            continue;
+        }
+        let check_result = token_manager.pre_market_check().await;
+        let is_failing = check_result.is_err();
+        let reason = match &check_result {
+            Ok(()) => None,
+            Err(err) => Some(format!("{err}")),
+        };
+        let transition = evaluate_transition(&state, is_failing);
+        apply_transition(transition, &mut state, reason, notifier.as_ref());
+    }
+}
+
+/// Internal state for the edge-triggered watchdog.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+struct WatchdogState {
+    currently_failing: bool,
+}
+
+/// Pure verdict — isolates the decision logic from IO so tests can
+/// exercise every edge without a live `TokenManager` + `Notifier`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Transition {
+    /// No-op — state unchanged (steady ok or steady fail).
+    NoOp,
+    /// Rising edge — first failure detected. Fire CRITICAL Telegram.
+    FirstFailure,
+    /// Falling edge — recovery after a failing episode. Fire INFO
+    /// (no Telegram — operator already knows from the rising edge).
+    Recovery,
+}
+
+fn evaluate_transition(state: &WatchdogState, is_failing_now: bool) -> Transition {
+    match (state.currently_failing, is_failing_now) {
+        (false, true) => Transition::FirstFailure,
+        (true, false) => Transition::Recovery,
+        _ => Transition::NoOp,
+    }
+}
+
+fn apply_transition(
+    transition: Transition,
+    state: &mut WatchdogState,
+    reason: Option<String>,
+    notifier: Option<&Arc<NotificationService>>,
+) {
+    match transition {
+        Transition::NoOp => {}
+        Transition::FirstFailure => {
+            let reason = reason.unwrap_or_else(|| "no reason provided".to_string());
+            error!(
+                reason = %reason,
+                "CRITICAL: mid-session profile check FAILED — dataPlan / activeSegment / token may be invalid"
+            );
+            metrics::counter!("tv_mid_session_profile_alert_fired_total").increment(1);
+            if let Some(n) = notifier {
+                // Dedicated event variant so Telegram message can carry
+                // mid-session-specific guidance (restart the app so the
+                // boot-time HALT gate triggers — as opposed to the
+                // pre-market `PreMarketProfileCheckFailed` which
+                // already fires that HALT automatically).
+                n.notify(NotificationEvent::MidSessionProfileInvalidated { reason });
+            }
+            state.currently_failing = true;
+        }
+        Transition::Recovery => {
+            let reason_context = reason.unwrap_or_default();
+            info!(
+                last_failure_reason = %reason_context,
+                "mid-session profile check recovered — no Telegram on falling edge (operator already paged)"
+            );
+            metrics::counter!("tv_mid_session_profile_recovery_total").increment(1);
+            state.currently_failing = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evaluate_transition_first_failure() {
+        let state = WatchdogState::default();
+        let t = evaluate_transition(&state, true);
+        assert_eq!(t, Transition::FirstFailure);
+    }
+
+    #[test]
+    fn evaluate_transition_recovery_after_failure() {
+        let state = WatchdogState {
+            currently_failing: true,
+        };
+        let t = evaluate_transition(&state, false);
+        assert_eq!(t, Transition::Recovery);
+    }
+
+    #[test]
+    fn evaluate_transition_steady_fail_no_duplicate_alert() {
+        let state = WatchdogState {
+            currently_failing: true,
+        };
+        let t = evaluate_transition(&state, true);
+        assert_eq!(t, Transition::NoOp);
+    }
+
+    #[test]
+    fn evaluate_transition_steady_ok_no_op() {
+        let state = WatchdogState::default();
+        let t = evaluate_transition(&state, false);
+        assert_eq!(t, Transition::NoOp);
+    }
+
+    /// Rising-edge followed by falling-edge in the same test — proves
+    /// the state flips correctly across a full failure episode.
+    #[test]
+    fn apply_transition_episode_round_trip() {
+        let mut state = WatchdogState::default();
+        apply_transition(
+            Transition::FirstFailure,
+            &mut state,
+            Some("test failure".to_string()),
+            None,
+        );
+        assert!(state.currently_failing);
+        apply_transition(Transition::Recovery, &mut state, None, None);
+        assert!(!state.currently_failing);
+    }
+
+    #[test]
+    fn interval_constant_is_sane() {
+        // At least 5 min (so we don't pound Dhan).
+        const _: () = assert!(MID_SESSION_CHECK_INTERVAL_SECS >= 300);
+        // At most 30 min (so mid-session invalidation is caught fast).
+        const _: () = assert!(MID_SESSION_CHECK_INTERVAL_SECS <= 1800);
+    }
+}

--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -31,6 +31,7 @@
 //! let auth_header = token.access_token().expose_secret();
 //! ```
 
+pub mod mid_session_watchdog;
 pub mod secret_manager;
 pub mod token_cache;
 pub mod token_manager;

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -99,6 +99,14 @@ pub enum NotificationEvent {
         within_market_hours: bool,
     },
 
+    /// Mid-session profile check failed during market hours (queue item
+    /// I7, 2026-04-21). Fires CRITICAL on the rising edge only — if
+    /// the profile recovers on a subsequent check, an INFO log is
+    /// emitted (no Telegram). The app does NOT HALT mid-session — a
+    /// mid-session HALT would drop the live WS feed, which costs more
+    /// than the silent-failure risk. Operator remediation is manual.
+    MidSessionProfileInvalidated { reason: String },
+
     /// JWT token renewed successfully by background task.
     TokenRenewed,
 
@@ -524,6 +532,16 @@ impl NotificationEvent {
                     "{header}\n{reason}\n\
                      Run:\n  curl -H \"access-token: $TOKEN\" https://api.dhan.co/v2/profile\n\
                      Check: dataPlan == \"Active\", activeSegment contains \"Derivative\", tokenValidity > 4h."
+                )
+            }
+            Self::MidSessionProfileInvalidated { reason } => {
+                format!(
+                    "<b>CRITICAL: Mid-session profile INVALIDATED</b>\n{reason}\n\
+                     Live WS still running — operator action required.\n\
+                     Run:\n  curl -H \"access-token: $TOKEN\" https://api.dhan.co/v2/profile\n\
+                     Check: dataPlan == \"Active\", activeSegment contains \"Derivative\", tokenValidity > 4h.\n\
+                     If the profile is confirmed bad, restart the app so the boot-time HALT gate triggers \
+                     (the no-tick watchdog will then page again if ticks stop)."
                 )
             }
             Self::TokenRenewed => "<b>Token renewed</b>".to_string(),
@@ -1035,6 +1053,7 @@ impl NotificationEvent {
             Self::BootDeadlineMissed { .. } => Severity::Critical,
             Self::AuthenticationFailed { .. } => Severity::Critical,
             Self::PreMarketProfileCheckFailed { .. } => Severity::Critical,
+            Self::MidSessionProfileInvalidated { .. } => Severity::Critical,
             Self::TokenRenewalFailed { .. } => Severity::Critical,
             Self::InstrumentBuildFailed { .. } => Severity::High,
             Self::WebSocketDisconnected { .. } => Severity::High,

--- a/crates/core/tests/mid_session_profile_watchdog_guard.rs
+++ b/crates/core/tests/mid_session_profile_watchdog_guard.rs
@@ -1,0 +1,135 @@
+//! Ratchet tests: mid-session profile watchdog wiring (queue item I7).
+//!
+//! Production evidence (2026-04-21): the app booted during market hours,
+//! all 5 WS connections reported "connected", but Dhan was not streaming
+//! data. The pre-market profile HALT (PR #309) catches this at boot. I7
+//! adds the same check as a 15-minute background sweep during market
+//! hours — catching a mid-session `dataPlan` / `activeSegment` / token
+//! invalidation.
+//!
+//! These tests scan the source so the wiring cannot regress silently.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p.push(rel);
+    p
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_path(rel);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// (1) Module exists and exposes the canonical entry point
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mid_session_watchdog_module_exists() {
+    let src = read("crates/core/src/auth/mid_session_watchdog.rs");
+    assert!(
+        src.contains("pub fn spawn_mid_session_profile_watchdog"),
+        "mid_session_watchdog module must expose spawn_mid_session_profile_watchdog — \
+         the only wiring contract that main.rs depends on."
+    );
+    assert!(
+        src.contains("MID_SESSION_CHECK_INTERVAL_SECS"),
+        "module must expose a tunable interval constant."
+    );
+    assert!(
+        src.contains("is_within_market_hours_ist()"),
+        "loop must be market-hours gated (Rule 3)."
+    );
+    assert!(
+        src.contains("currently_failing"),
+        "watchdog must be edge-triggered (Rule 4) — track currently_failing \
+         state to suppress duplicate CRITICAL alerts on sustained failure."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) main.rs spawns the watchdog after auth is initialized
+// ---------------------------------------------------------------------------
+
+#[test]
+fn main_rs_spawns_mid_session_watchdog() {
+    let src = read("crates/app/src/main.rs");
+    assert!(
+        src.contains("spawn_mid_session_profile_watchdog"),
+        "main.rs must spawn the mid-session profile watchdog — without it, \
+         a mid-session dataPlan/segment/token invalidation goes undetected \
+         until the next boot, exactly the 2026-04-21 failure mode."
+    );
+    assert!(
+        src.contains("mid-session profile watchdog spawned"),
+        "main.rs must log a confirmation line so deployment logs show the \
+         watchdog is running."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) Event variant declared with Critical severity + clear message
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mid_session_profile_event_declared_critical() {
+    let src = read("crates/core/src/notification/events.rs");
+    assert!(
+        src.contains("MidSessionProfileInvalidated"),
+        "events.rs must declare MidSessionProfileInvalidated variant."
+    );
+    assert!(
+        src.contains("Self::MidSessionProfileInvalidated { .. } => Severity::Critical"),
+        "MidSessionProfileInvalidated must be Critical severity — operator \
+         MUST be paged immediately. Downgrading risks silent mid-session \
+         data loss."
+    );
+}
+
+#[test]
+fn mid_session_profile_event_message_carries_diagnostics() {
+    let src = read("crates/core/src/notification/events.rs");
+    // Telegram text must tell the operator EXACTLY what to do next.
+    assert!(
+        src.contains("CRITICAL: Mid-session profile INVALIDATED"),
+        "event message header must clearly identify this as a mid-session \
+         failure (distinct from boot-time HALT)."
+    );
+    assert!(
+        src.contains("dataPlan == \\\"Active\\\""),
+        "message must tell the operator to verify dataPlan."
+    );
+    assert!(
+        src.contains("Derivative"),
+        "message must call out the Derivative segment check."
+    );
+    assert!(
+        src.contains("Live WS still running"),
+        "message must clarify that the app did NOT HALT mid-session — \
+         operator must understand that the fix is manual."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (4) Interval bounds are sane
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mid_session_interval_bounds_are_sane() {
+    use tickvault_core::auth::mid_session_watchdog::MID_SESSION_CHECK_INTERVAL_SECS;
+    assert!(
+        MID_SESSION_CHECK_INTERVAL_SECS >= 300,
+        "interval must be >= 5 min to avoid pounding Dhan's /v2/profile \
+         (shared with the 1 req/sec Quote rate limit). Current: {MID_SESSION_CHECK_INTERVAL_SECS}s."
+    );
+    assert!(
+        MID_SESSION_CHECK_INTERVAL_SECS <= 1800,
+        "interval must be <= 30 min so a mid-session invalidation is \
+         caught within one cycle. Current: {MID_SESSION_CHECK_INTERVAL_SECS}s."
+    );
+}


### PR DESCRIPTION
## Why (queue item I7)

On 2026-04-21 the app booted during market hours, all 5 WS connections reported "connected", but Dhan was not streaming data. PR #309 added a **boot-time** pre-market profile HALT. Once the app is already running, there was NO mid-session check — a mid-session `dataPlan` / `activeSegment` / token invalidation would go silent until the next boot.

This PR closes that gap.

## What changed

- New background tokio task spawned after auth init: every **15 min during market hours**, re-runs `TokenManager::pre_market_check` (same validation as the boot-time HALT).
- On **rising-edge failure**: fires CRITICAL Telegram via new `MidSessionProfileInvalidated` event. Does **NOT HALT** — a mid-session HALT would drop the live WS feed, which costs more than the silent-failure risk.
- On **falling-edge recovery**: INFO log, no Telegram.
- Market-hours gated (Rule 3) + edge-triggered (Rule 4).

## Files

- `crates/core/src/auth/mid_session_watchdog.rs` — new module (214 LoC, 6 unit tests)
- `crates/core/src/auth/mod.rs` — expose submodule
- `crates/core/src/notification/events.rs` — new Critical `MidSessionProfileInvalidated` variant
- `crates/app/src/main.rs` — spawn watchdog after `spawn_renewal_task`
- `crates/core/tests/mid_session_profile_watchdog_guard.rs` — 5 ratchet tests

## Tests (11, all passing)

```
cargo test -p tickvault-core --lib auth::mid_session_watchdog  → 6/6 ✅
cargo test -p tickvault-core --test mid_session_profile_watchdog_guard  → 5/5 ✅
cargo test -p tickvault-core --lib notification  → 200/200 ✅
cargo check --workspace  → clean
cargo fmt --check  → clean
```

## Pairs with other PRs

- **PR #309** (pre-market HALT) — boot gate
- **PR #308** (merged, no-tick watchdog) — symptom catcher
- **This PR** — 15-min mid-session page

Together: every dataPlan/segment/token invalidation is caught within 15 min max, regardless of when it happens during the trading session.

## Honest scope

Watchdog pages but does NOT auto-fix. Token rotation / account fix / restart is manual operator action (by design — auto-remediation would terminate the live feed).

https://claude.ai/code/session_01Cs3Z9DzSVjGj11c3iFtnxq