### PR TITLE
fix(core): durable instrument + CSV cache writes (fsync + atomic rename) — I2+I3

### DIFF
--- a/crates/core/src/instrument/binary_cache.rs
+++ b/crates/core/src/instrument/binary_cache.rs
@@ -52,17 +52,51 @@ pub fn write_binary_cache(universe: &FnoUniverse, cache_dir: &str) -> Result<()>
     payload.extend_from_slice(&[0u8; HEADER_LEN - CACHE_MAGIC.len() - 1]); // padding
     payload.extend_from_slice(&rkyv_bytes);
 
-    // Atomic write: temp file → rename (prevents readers from seeing partial data)
+    // Atomic + DURABLE write (queue item I2, 2026-04-21):
+    //
+    //   1. Write payload to temp file + `sync_all()` — forces kernel to
+    //      persist file contents to disk BEFORE the rename is visible.
+    //      Without this, the rename can land in the directory entry
+    //      while the file data is still in page cache — a crash then
+    //      leaves a zero-length (or partial) `api-scrip-master.bin` on
+    //      disk and the next boot hits I-P0-06 emergency download.
+    //   2. Rename temp → final (atomic within same filesystem).
+    //   3. Open the parent directory and `sync_all()` — forces the
+    //      directory entry update (rename) to persist. On ext4/xfs
+    //      the rename itself is atomic but not durable until the
+    //      parent-dir inode is fsynced.
+    //
+    // Matches the "write → rename → fsync(dir)" pattern used by SQLite,
+    // PostgreSQL, and every serious durability-sensitive writer.
     let temp_path = path.with_extension("tmp");
-    std::fs::write(&temp_path, &payload)
-        .with_context(|| format!("failed to write temp rkyv cache: {}", temp_path.display()))?;
+    {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temp_path)
+            .with_context(|| format!("failed to open temp rkyv cache: {}", temp_path.display()))?;
+        file.write_all(&payload)
+            .with_context(|| format!("failed to write temp rkyv cache: {}", temp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("failed to fsync temp rkyv cache: {}", temp_path.display()))?;
+    }
     std::fs::rename(&temp_path, &path)
         .with_context(|| format!("failed to rename rkyv cache: {}", path.display()))?;
+    // fsync the parent directory so the rename is durable.
+    if let Some(parent) = path.parent() {
+        let dir = std::fs::File::open(parent).with_context(|| {
+            format!("failed to open parent dir for fsync: {}", parent.display())
+        })?;
+        dir.sync_all()
+            .with_context(|| format!("failed to fsync parent dir: {}", parent.display()))?;
+    }
 
     info!(
         bytes = payload.len(),
         path = %path.display(),
-        "rkyv binary cache written (atomic)"
+        "rkyv binary cache written (atomic + durable: data fsynced, rename fsynced)"
     );
     Ok(())
 }

--- a/crates/core/src/instrument/csv_downloader.rs
+++ b/crates/core/src/instrument/csv_downloader.rs
@@ -199,19 +199,51 @@ async fn write_cache(cache_dir: &str, cache_filename: &str, csv_text: &str) {
     }
 
     let cache_path = dir.join(cache_filename);
-    if let Err(error) = fs::write(&cache_path, csv_text).await {
-        warn!(
-            path = %cache_path.display(),
-            %error,
-            "failed to write CSV cache file"
-        );
-    } else {
-        info!(
+    // Durable write (queue item I2, 2026-04-21): write → fsync file →
+    // atomic rename → fsync parent dir. Without this, a crash between
+    // `fs::write` and kernel page-cache flush leaves a zero-length CSV
+    // on disk; next boot hits I-P0-06 emergency download.
+    match write_csv_durable(&cache_path, dir, csv_text).await {
+        Ok(()) => info!(
             path = %cache_path.display(),
             bytes = csv_text.len(),
-            "instrument CSV cached successfully"
-        );
+            "instrument CSV cached successfully (durable: data + dir fsynced)"
+        ),
+        Err(error) => warn!(
+            path = %cache_path.display(),
+            %error,
+            "failed to write CSV cache file durably"
+        ),
     }
+}
+
+/// Durable-write helper (queue item I2). Writes `csv_text` to a temp file,
+/// fsyncs the file, renames over the final path (atomic within the same
+/// filesystem), then fsyncs the parent directory so the rename is durable
+/// across a crash. Matches the "write → rename → fsync(dir)" pattern used
+/// by SQLite and every other durability-sensitive writer.
+async fn write_csv_durable(
+    cache_path: &Path,
+    parent_dir: &Path,
+    csv_text: &str,
+) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+    let tmp_path = cache_path.with_extension("csv.tmp");
+    {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)
+            .await?;
+        file.write_all(csv_text.as_bytes()).await?;
+        file.sync_all().await?;
+    }
+    fs::rename(&tmp_path, cache_path).await?;
+    // Fsync the parent directory so the rename entry is persisted.
+    let dir = fs::File::open(parent_dir).await?;
+    dir.sync_all().await?;
+    Ok(())
 }
 
 /// Load instrument CSV from local cache only (no HTTP download).

--- a/crates/core/tests/instrument_cache_durability_guard.rs
+++ b/crates/core/tests/instrument_cache_durability_guard.rs
@@ -1,0 +1,119 @@
+//! Ratchet: instrument + CSV cache writes MUST fsync + atomically rename.
+//!
+//! # Why (queue items I2 + I3, 2026-04-21)
+//!
+//! Live production log at 13:06:02 IST today:
+//! ```
+//! level=ERROR "CRITICAL: no instrument cache available during market hours
+//!   — triggering emergency download"
+//! ```
+//! Followed by a successful download of 106,214 derivatives. The previous
+//! run MUST have written a cache file, but the cache was gone on restart.
+//!
+//! Root cause: `std::fs::write` + `std::fs::rename` persist via OS page
+//! cache only. A crash / power cycle / container SIGKILL before the
+//! kernel flushes the page cache → zero-length or missing cache file
+//! → I-P0-06 emergency download fires on next boot (cost: 6-10 s of
+//! boot + one network round-trip that competes with the market-open
+//! 09:15 IST deadline).
+//!
+//! Fix (this PR): both `binary_cache::write_binary_cache` and
+//! `csv_downloader::write_cache` now (a) write to a temp file,
+//! (b) `sync_all()` the file, (c) atomically rename over the final
+//! path, (d) `sync_all()` the parent directory. Matches the
+//! "write → rename → fsync(dir)" pattern used by SQLite, PostgreSQL,
+//! and every serious durability-sensitive writer.
+//!
+//! These ratchets scan the source so the durability pattern can't
+//! silently regress back to plain `fs::write`.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn read(rel: &str) -> String {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p.push(rel);
+    fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+// ---------------------------------------------------------------------------
+// I2: rkyv binary cache
+// ---------------------------------------------------------------------------
+
+#[test]
+fn binary_cache_write_fsyncs_temp_file_before_rename() {
+    let src = read("crates/core/src/instrument/binary_cache.rs");
+    assert!(
+        src.contains("file.sync_all()"),
+        "binary_cache.rs::write_binary_cache MUST call `sync_all()` on the \
+         temp file BEFORE the rename. Without this, a crash between write \
+         and kernel flush leaves a zero-length cache file and the next \
+         boot hits I-P0-06 emergency download."
+    );
+}
+
+#[test]
+fn binary_cache_write_fsyncs_parent_directory_after_rename() {
+    let src = read("crates/core/src/instrument/binary_cache.rs");
+    assert!(
+        src.contains("dir.sync_all()"),
+        "binary_cache.rs::write_binary_cache MUST fsync the parent \
+         directory AFTER the rename so the directory-entry update is \
+         persisted. Without this, a crash after rename but before dir-inode \
+         flush leaves the old cache pointer visible and the new data \
+         invisible on reboot."
+    );
+}
+
+#[test]
+fn binary_cache_write_uses_atomic_rename() {
+    let src = read("crates/core/src/instrument/binary_cache.rs");
+    assert!(
+        src.contains("std::fs::rename(&temp_path, &path)"),
+        "binary_cache.rs MUST use atomic rename (temp → final) so readers \
+         never observe a half-written file."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// I3: CSV cache (async path)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn csv_cache_write_goes_through_durable_helper() {
+    let src = read("crates/core/src/instrument/csv_downloader.rs");
+    assert!(
+        src.contains("async fn write_csv_durable"),
+        "csv_downloader.rs MUST expose a `write_csv_durable` helper — \
+         refactored in 2026-04-21 fix for I3 so the write path is \
+         testable + has one fsync implementation to review."
+    );
+    assert!(
+        src.contains("file.sync_all().await"),
+        "csv_downloader.rs::write_csv_durable MUST fsync the temp file."
+    );
+    assert!(
+        src.contains("dir.sync_all().await"),
+        "csv_downloader.rs::write_csv_durable MUST fsync the parent directory."
+    );
+    assert!(
+        src.contains("fs::rename(&tmp_path, cache_path)"),
+        "csv_downloader.rs MUST use atomic rename (temp → final)."
+    );
+}
+
+#[test]
+fn csv_cache_no_longer_calls_plain_fs_write() {
+    let src = read("crates/core/src/instrument/csv_downloader.rs");
+    // The old `fs::write(&cache_path, csv_text)` line must be gone.
+    // `fs::write(` is still allowed elsewhere (e.g., freshness marker)
+    // but NOT on `cache_path` directly.
+    assert!(
+        !src.contains("fs::write(&cache_path, csv_text)"),
+        "csv_downloader.rs MUST NOT call `fs::write(&cache_path, csv_text)` \
+         directly — must go through `write_csv_durable` so the fsync path \
+         is exercised."
+    );
+}


### PR DESCRIPTION
## Why (queue items I2 + I3)

Live production log at 13:06:02 IST today:

```
level=ERROR "CRITICAL: no instrument cache available during market hours
  — triggering emergency download"
```

Followed by a successful download of 106,214 derivatives. **The previous run wrote a cache, but the cache was gone on restart.** Same class of bug also affects the constituency cache (I3).

## Root cause

Both `binary_cache::write_binary_cache` and `csv_downloader::write_cache` used `std::fs::write` / `fs::write` which persist to **OS page cache only**. A crash / container SIGKILL / power cycle between the write and kernel flush leaves a zero-length or missing cache file → I-P0-06 emergency download fires on next boot, costing 6-10 s + a network round-trip that competes with the 09:15 IST market-open deadline.

## Fix

Both writers now follow the **write → fsync file → atomic rename → fsync parent dir** pattern used by SQLite, PostgreSQL, and every durability-sensitive writer:

1. Write payload to `.tmp` file (create + truncate + write)
2. `file.sync_all()` — kernel persists file contents to disk
3. `fs::rename(tmp, final)` — atomic within same filesystem
4. Open parent dir as File, `dir.sync_all()` — persists rename entry

## Files

- `binary_cache.rs::write_binary_cache` — inline rewrite with `OpenOptions` + `sync_all()` + dir fsync
- `csv_downloader.rs::write_cache` — extracted to `write_csv_durable` helper so the fsync path has one implementation
- `instrument_cache_durability_guard.rs` — **new** 5 ratchet tests

## Tests

```
cargo test -p tickvault-core --lib instrument::binary_cache    → 23/23 ✅
cargo test -p tickvault-core --lib instrument::csv_downloader  → 34/34 ✅
cargo test -p tickvault-core --test instrument_cache_durability_guard → 5/5 ✅
```

## Honest scope

- **Same-filesystem guarantee**: atomic rename only works when temp and final paths are on the same filesystem. Both writers put the temp in the same dir as the final, so this holds.
- **Directory fsync on macOS**: APFS treats dir fsync as full sync, slightly stronger than Linux. Both satisfy the durability guarantee.
- **Windows not supported**: out of scope; tickvault targets Linux + macOS only.
- Does not fix a genuinely corrupted cache file — if rkyv deserialization fails post-crash, boot still falls through to CSV → download.

https://claude.ai/code/session_01Cs3Z9DzSVjGj11c3iFtnxq