### PR TITLE
fix(core): exhaustive cross-match — 09:15→15:30 IST, IDX_I + NSE_EQ, Pass-B, chunked Telegram

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,329 +1,65 @@
-# Implementation Plan: Zero-Touch Error Observability & Auto-Triage
+# Implementation Plan: Exhaustive cross-match (09:15→15:30 IST, IDX_I + NSE_EQ)
 
 **Status:** APPROVED
-**Date:** 2026-04-18
-**Approved by:** Parthiban ("go ahead with all the approach ... 100 percent automation dude")
+**Date:** 2026-04-21
+**Approved by:** Parthiban
+**Branch:** `claude/cross-match-exhaustive-coverage`
 
-**Decisions confirmed:**
-- A: all phases, phased rollout (one PR per phase, Phase 0 first)
-- B: yes, trim QuestDB 4GB → 3.5GB to fit Loki + Alloy
-- C: Claude ALWAYS pings Parthiban first for novel errors; auto-PR only when classifier confidence ≥ 0.95 AND runbook rule explicitly opts in
-- D: AWS SNS vars deferred (no AWS instance bought yet); Phase 4 becomes mechanical-only, activated when instance provisioned
+## Background
 
-## Honesty clause on "100%"
+Live production bug (2026-04-21 15:47 IST): cross-match reported OK with
+116,162 candles compared, zero mismatches, despite the app restarting
+mid-day leaving huge gaps in live `candles_*` materialized views.
 
-The operator requested 100% guarantees on coverage, testing, bug-fixing, monitoring, logging, alerting, security, uniqueness, dedup, O(1), zero-tick-loss, zero-WS-disconnect, zero-QuestDB-fail.
+Three root causes in `crates/core/src/historical/cross_verify.rs`:
 
-**PROVABLE 100%s (each = a mechanical CI gate or compile-time constraint):**
-- Line + branch coverage 100% via `cargo llvm-cov --fail-under 100`
-- Mutation score 100% (zero survivors) via `cargo-mutants`
-- Fuzz coverage — 24h clean run in nightly CI via `cargo-fuzz`
-- Banned-pattern scan 100% via `.claude/hooks/banned-pattern-scanner.sh`
-- Every pub fn has test via `pub-fn-test-guard`
-- Every error path has `error!` via new meta-guard
-- Every Result has `?` or explicit `match` via `#![deny(unused_must_use)]`
-- Every shared collection keyed by `security_id` uses `(id, segment)` via hook category 5
-- Every DEDUP key has segment via `dedup_segment_meta_guard`
-- Every dashboard has status filter + segment via `grafana_dashboard_snapshot_filter_guard`
-- O(1) hot path — zero alloc DHAT test + banned `.clone()/Vec::new()/format!/.collect()/dyn` hook
-- Wire-to-done latency ≤ 10µs — Criterion benchmark budget gate
-- Zero tick loss DURING normal operation — `tv_ticks_lost_total` assert-0 in market-hours integration test
+1. `determine_cross_match_passed` ignores `missing_live` / `missing_historical`.
+2. Detail query has `LIMIT MAX_VIOLATION_DETAILS` → `total_mismatches = details.len()` caps silently.
+3. `missing_historical` is declared but never populated — no Pass-B query exists.
 
-**NON-PROVABLE (physics/external), replaced by MEASURABLE SLAs:**
-- "WebSocket never disconnects" → "Reconnect ≤ 500ms, zero-loss via WAL replay, chaos test enforces"
-- "QuestDB never fails" → "Backpressure → disk spill → auto-resume within 30s, chaos test enforces"
-- "No future bug" → "Zero known bugs at HEAD + every pattern we've seen is a CI block"
-- "Every scenario covered" → "Every enumerated scenario tested + fuzz finds unknowns + mutation verifies non-vacuity"
+## Plan Items
 
-## Goal
+- [ ] A. Window end exclusive (`ts <=` → `ts <`)
+  - Files: `crates/core/src/historical/cross_verify.rs`
+  - Tests: `test_window_end_is_exclusive`
 
-Parthiban never monitors manually — Claude Code (or a cron-driven agent) owns the full error lifecycle: capture → classify → dedup → triage → fix-or-escalate. Works identically on Mac (dev) and AWS c7i.xlarge Mumbai (prod), within the ₹5,000/mo budget.
+- [ ] B. Scope filter to IDX_I + NSE_EQ only (reject F&O)
+  - Files: `crates/core/src/historical/cross_verify.rs`
+  - Tests: `test_scope_filter_contains_idx_i_and_nse_eq`
 
-## Research Summary (from 4 parallel audits)
+- [ ] C. Pass-B query populating `missing_historical`
+  - Files: `crates/core/src/historical/cross_verify.rs`
+  - Tests: `test_missing_historical_pass_is_wired`
 
-**Already wired (keep):**
-- Prometheus + Alertmanager + 65 alert rules → Telegram webhook via Rust `NotificationService` with edge-triggered dedup (10s–1h).
-- `NotificationService` carries structured events (`security_id`, `symbol`, `reason`, severity). Critical/High also go AWS SNS SMS.
-- Grafana: 6 dashboards against Prometheus + QuestDB PG wire.
-- AWS Terraform: 5 CloudWatch alarms, SNS topic, 14-day CloudWatch log group, EventBridge EC2 start/stop.
-- `.claude/`: 33 hooks, 31 rules, `notification-log.sh` already audits every Telegram message.
-- Systemd: `tickvault.service` with `WatchdogSec=60`, `Restart=always`.
+- [ ] D. Remove detail-query LIMIT (fetch every violation)
+  - Files: `crates/core/src/historical/cross_verify.rs`
+  - Tests: `test_detail_query_has_no_limit`
 
-**Gaps blocking full automation:**
-- 39 flush/broadcast/persist failures logged at `warn!` — NEVER reach Telegram (Rule 5 violated).
-- Loki + Alloy removed for memory budget → no LogQL alerting ("3 ERRORs in 5min" impossible today).
-- App container logs not in CloudWatch (only systemd journalctl captured).
-- No app-emitted CloudWatch custom metrics (Prometheus-only).
-- SNS has no Terraform-managed subscription (manual `aws sns subscribe` post-deploy).
-- Error codes (I-P*, OMS-*, WS-*, STORAGE-*, DH-9xx) are string literals in rustdoc — not a typed enum Claude can enumerate.
-- No log-ingestion MCP, no dedup-by-signature, no auto-triage YAML rules, no "Claude watches logs" daemon.
-- Traefik dashboard public + insecure on AWS EC2 IP.
+- [ ] E. `determine_cross_match_passed` blocks on ANY hole
+  - Files: `crates/core/src/historical/cross_verify.rs`
+  - Tests: `test_passed_false_when_missing_live_nonzero`,
+            `test_passed_false_when_missing_historical_nonzero`
 
-## Architecture (after plan)
+- [ ] F. Rich Telegram format (emoji + monospace tables)
+  - Files: `crates/core/src/notification/events.rs`
+  - Tests: `test_cross_match_ok_uses_monospace_pre`,
+            `test_cross_match_failed_groups_by_category`
 
-```
-Rust app  ──┬── metrics::*     → Prometheus :9091 ──┐
-            ├── error!/warn!   → tracing subscriber ┤
-            │                    ├→ JSONL stdout  ──┼→ docker awslogs → CloudWatch Logs
-            │                    └→ errors.jsonl  ──┤       (AWS only)
-            └── notify(event)  → Alertmanager WH ──┤
-                                                    │
-Prometheus ──(65 rules)── Alertmanager ────────────┤
-CloudWatch ──(5 alarms) ── SNS topic ──────────────┤
-                                                    │
-                     ┌──────────────────────────────┘
-                     ↓
-              NotificationService (dedup by signature hash, edge-trigger)
-                     │
-       ┌─────────────┼──────────────┐
-       ↓             ↓              ↓
-   Telegram     SNS SMS         errors.summary.md
-                              (auto-generated every 60s
-                               — human AND Claude-readable)
-                                     │
-                                     ↓
-                       .claude/hooks/error-triage.sh
-                                     │
-                         ┌───────────┴────────────┐
-                         ↓                        ↓
-                    Known signature          Novel signature
-                    (YAML runbook)           (escalate, open
-                    auto-execute or          GitHub Issue, ping
-                    link runbook             Claude agent)
-```
+- [ ] G. Telegram chunking for >4000-char messages
+  - Files: `crates/core/src/notification/service.rs`
+  - Tests: `test_chunk_preserves_order`, `test_chunk_splits_on_newline`,
+            `test_chunk_below_threshold_sends_single_message`
 
-## Plan Items (10 phases, each independently approvable)
-
-### Phase 0 — Stop the bleeding (BLOCKING for everything else)
-
-- [x] 0.1 Upgrade 39 `warn!` → `error!` on flush/broadcast/persist failures per audit-findings Rule 5
-  - Files: `crates/storage/src/tick_persistence.rs` (8 sites), `crates/storage/src/candle_persistence.rs` (9 sites), `crates/app/src/main.rs` (5 sites), `crates/core/src/pipeline/tick_processor.rs` (2 sites), `crates/app/src/greeks_pipeline.rs` (1 site), `crates/core/src/historical/candle_fetcher.rs` (1 site)
-  - Tests: add `test_flush_failure_emits_error_level` source-scan guard in `crates/storage/tests/error_level_meta_guard.rs`
-
-- [x] 0.2 Compile-enforce error capture
-  - Files: every `crates/*/src/lib.rs`
-  - Adds: `#![cfg_attr(not(test), deny(unused_must_use))]`, `#![cfg_attr(not(test), warn(clippy::let_underscore_must_use))]`, `#![cfg_attr(not(test), warn(clippy::unused_async))]`
-  - Tests: existing clippy gate catches regressions
-
-### Phase 1 — Structured error catalogue
-
-- [x] 1.1 Central `ErrorCode` enum in `crates/common/src/error.rs`
-  - Variants: every I-P*, OMS-GAP-*, WS-GAP-*, STORAGE-GAP-*, RISK-GAP-*, AUTH-GAP-*, DH-9xx, 8xx codes
-  - Methods: `.code_str()`, `.severity()`, `.runbook_url()`, `.is_actionable()`, `.suggested_fix()`
-  - Tests: `test_every_code_has_rule_doc`, `test_every_rule_doc_has_code`
-
-- [~] 1.2 Every `error!` / `warn!` on known paths must carry `code = ErrorCode::X.code_str()` as a structured field
-  - Files: `crates/*/src/**/*.rs` (mechanical migration, one ErrorCode per existing code)
-  - Tests: `crates/common/tests/error_code_field_guard.rs` scans source + fails if an error site in a tagged module lacks `code =`
-
-### Phase 2 — JSONL error stream + rotation
-
-- [x] 2.1 Tracing subscriber emits a separate `data/logs/errors.jsonl` filtered to ERROR-level only, one JSON object per line, `{ts_ist, code, severity, signature_hash, module, message, fields}`
-  - File: `crates/app/src/observability.rs`
-  - Uses `tracing-appender` file rotation (hourly, 48h retention)
-  - `signature_hash` = first 16 hex chars of sha256(code + module + truncated_message)
-
-- [x] 2.2 Makefile target `make tail-errors` — `jq`-formatted live view
-  - File: `Makefile`
-
-### Phase 3 — Loki/Alloy re-add under memory budget
-
-- [x] 3.1 Re-add slim Loki + Alloy to `docker-compose.yml` with tight memory limits that fit the 8GB c7i.xlarge budget after QuestDB trim from 4GB to 3.5GB
-  - Files: `deploy/docker/docker-compose.yml`, `deploy/docker/loki/loki-config.yml`, `deploy/docker/alloy/alloy-config.alloy`
-  - Mem: Loki 384MB, Alloy 256MB (total new: 640MB; offset by QuestDB 512MB trim → net -128MB, still within budget)
-  - Alloy scrapes: `data/logs/errors.jsonl` + `docker logs` for `tv-*` containers
-
-- [x] 3.2 Loki-ruler log-pattern alerts
-  - File: `deploy/docker/loki/rules.yml`
-  - Rules: `ErrorBurst` (>5 errors in 5min with same signature_hash), `NovelErrorSignature` (signature_hash never seen before in rolling 24h), `FlushErrorStorm`, `AuthFailureBurst`
-  - Route: Alertmanager → existing `NotificationService` webhook
-
-- [ ] 3.3 Re-add the "Errors" dashboard to Grafana
-  - File: `deploy/docker/grafana/dashboards/errors.json`
-  - Panels: live error tail (LogQL), top-10 signatures 1h, error rate time series, novel signatures callout, code → severity heatmap
-  - Single-page dashboard operator can glance at
-
-### Phase 4 — AWS observability parity
-
-- [ ] 4.1 Terraform: SNS subscriptions (email + Telegram HTTPS webhook) auto-created from `var.operator_email` and `var.telegram_webhook_url`
-  - File: `deploy/aws/terraform/sns.tf`
-  - Tests: `terraform plan` + `terraform validate` in CI
-
-- [ ] 4.2 Docker containers use `awslogs` driver in the AWS-specific compose override
-  - Files: `deploy/docker/docker-compose.aws.override.yml`, user-data.sh.tftpl
-  - Log group: `/tickvault/prod/containers/<service>`; retention 14d
-
-- [ ] 4.3 App emits CloudWatch custom metrics via a shim when `AWS_REGION` env set
-  - File: `crates/app/src/observability.rs`
-  - Uses `aws-sdk-cloudwatch` crate (already pinned — confirm with `dependency-checker`); 60s batch PutMetricData; only the 10 business-critical metrics to stay under free tier
-
-- [ ] 4.4 Secure Traefik dashboard
-  - File: `deploy/docker/traefik/traefik.yml` (remove `insecure=true`); `dynamic/services.yml` (add HTTP BasicAuth middleware, credentials from SSM)
-
-### Phase 5 — errors.summary.md (Claude-readable single-file view)
-
-- [x] 5.1 Background task inside the Rust app emits `data/logs/errors.summary.md` every 60s — markdown tables:
-  - "Active errors (last 15min)" — signature | count | severity | code | runbook | first_seen_ist
-  - "Novel today" — signatures first seen in last 24h
-  - "Infrastructure up/down" — each alert from Prometheus + CloudWatch
-  - "System KPIs" — tick rate, WS connections, memory, disk
-  - File: `crates/core/src/notification/summary_writer.rs` (new)
-  - Tests: `test_summary_file_regenerates`, `test_summary_edge_triggered_novel`
-
-- [x] 5.2 `make status` reads this file + prints dashboard
-  - File: `Makefile`, `scripts/status-dashboard.sh`
-
-### Phase 6 — Auto-triage rules engine
-
-- [x] 6.1 YAML rules file `.claude/triage/error-rules.yaml`
-  - Schema: `{ code, signature_pattern, action: "auto_fix" | "auto_restart" | "escalate" | "silence", runbook_url, confidence_threshold, cooldown_secs }`
-  - Seed rules for known recurring errors (I-P1-11 collision → silence; CandleVerificationFailed → escalate with jq'd context; Depth spot stale → auto-restart rebalancer once; Token expired → auto-refresh already handled → silence)
-
-- [x] 6.2 Triage hook `.claude/hooks/error-triage.sh`
-  - Trigger: cron (every 60s via a userland launchd/systemd-user timer) OR `Stop` / `SessionStart` hooks so it fires during Claude sessions
-  - Reads `errors.summary.md` + `error-rules.yaml` → applies rules → posts actions to Telegram and/or invokes `scripts/auto-fix-<action>.sh`
-  - Edge-triggered via `.claude/state/triage-seen.jsonl` (signature_hash + last_action_ts)
-  - Rate limit: max 10 triages/hour/signature
-
-- [~] 6.3 Novel-signature escalation
-  - When an error has `signature_hash` not in `triage-seen.jsonl`, `error-triage.sh` opens a draft GitHub Issue via existing `mcp__github__issue_write` (from the user's session) — issue body includes: code, severity, runbook, first 50 matching log lines, context links (Grafana, CloudWatch)
-
-### Phase 7 — Claude-watches-logs daemon
-
-- [x] 7.1 `/loop` skill runbook
-  - File: `.claude/triage/claude-loop-prompt.md`
-  - Prompt: "Read data/logs/errors.summary.md. For each row flagged 'ACTION_REQUIRED': investigate root cause, propose fix if tractable, open draft PR; otherwise ping operator with context."
-  - Invoked via: `/loop 5m .claude/triage/claude-loop-prompt.md`
-
-- [x] 7.2 MCP server for log access
-  - File: `scripts/mcp-servers/tickvault-logs/server.py` (new)
-  - Exposes: `tail_errors(signature, limit)`, `query_loki(logql)`, `query_cloudwatch(expression)`, `list_novel_signatures(since)`
-  - Registered in `.mcp.json`
-  - Permission-gated via `.claude/settings.json` allow list
-
-### Phase 8 — Self-healing triggers
-
-- [x] 8.1 Common auto-fix scripts
-  - `scripts/auto-fix-restart-depth.sh` — calls existing depth rebalancer reset endpoint
-  - `scripts/auto-fix-clear-spill.sh` — drains disk spill buffer after QuestDB recovery
-  - `scripts/auto-fix-refresh-instruments.sh` — triggers `POST /api/instruments/rebuild`
-  - Each script: idempotent, logs to `data/logs/auto-fix.log`, includes dry-run flag
-
-- [x] 8.2 CloudWatch webhook → Claude Code session (AWS only)
-  - Lambda function: receives SNS → invokes `tmux send-keys 'claude --resume <session_id> "triage $ALARM"'` on the EC2 via SSM RunCommand
-  - File: `deploy/aws/terraform/claude-triage-lambda.tf` + `deploy/aws/lambda/claude-triage.py`
-
-### Phase 10 — Zero-tick-loss hardening (explicit SLA)
-
-- [~] 10.1 Three-tier buffer proof
-  - `crates/core/src/pipeline/tick_processor.rs` — SPSC 65K ring → disk spill (rkyv) → WAL replay on reconnect
-  - Metric: `tv_ticks_lost_total` — must remain 0 during market hours; increments only on explicit drop decision with root cause label
-  - Test: `crates/storage/tests/zero_tick_loss_invariant.rs` — integration test kills + resumes QuestDB, drops + resumes WS, asserts final stored count = emitted count
-
-- [ ] 10.2 Sequence-hole detector
-  - For each (security_id, segment), maintain last-exchange-timestamp; gap > 2s during market hours fires `TickGapDetected` with exact missed window
-  - Already partially in `crates/trading/src/risk/tick_gap.rs` — extend + wire test
-
-- [ ] 10.3 End-to-end "no lost tick" chaos test (nightly CI only)
-  - `crates/storage/tests/chaos_zero_loss.rs`
-  - Simulates: WS random disconnect (1% per minute), QuestDB SIGSTOP for 30s, disk near-full, Valkey down
-  - Asserts: emitted = persisted after cool-down; never panic
-
-### Phase 11 — WebSocket + QuestDB resilience SLAs (chaos)
-
-- [x] 11.1-guard WS liveness SLA
-  - Reconnect latency histogram `tv_ws_reconnect_duration_ms` — p99 < 500ms
-  - Prometheus alert: `WsReconnectSlowP99` fires at > 1s for 2m
-  - Chaos test: kill WS every 5 min × 10 iterations, assert p99 SLA
-
-- [x] 11.2-guard QuestDB backpressure SLA
-  - `tv_questdb_backpressure_duration_ms`; app stays up, spills to disk
-  - Alert: `QuestDbBackpressureCritical` > 10s
-  - Chaos test: SIGSTOP QuestDB for 30s, unSTOP, assert: 0 panics + all buffered data flushed within 30s + `tv_ticks_lost_total` still 0
-
-- [x] 11.3-guard Valkey cache fallback
-  - On Valkey down, non-critical features degrade gracefully; trading continues; alert fires
-  - Chaos test: `docker kill tv-valkey`, assert app stays healthy, auto-reconnect on restart
-
-### Phase 12 — Coverage / Mutation / Fuzz ratchet (100% or fail)
-
-- [x] 12.1 Line + branch coverage 100%
-  - CI gate: `cargo llvm-cov --workspace --fail-under-lines 100 --fail-under-regions 100`
-  - File: `quality/crate-coverage-thresholds.toml` — set all crates to 100
-  - Any exemption requires a `// COVERAGE-EXEMPT: <reason>` comment + operator sign-off
-
-- [x] 12.2 Mutation score 100% (zero survivors)
-  - CI gate: `cargo mutants --workspace --error-exit-code 1 -- --release`
-  - Schedule: nightly, PR blocks if new survivor introduced
-  - File: `.github/workflows/mutation.yml` (extend)
-
-- [~] 12.3 Fuzz 24h clean
-  - CI gate: nightly runs `cargo fuzz run tick_parser` + `cargo fuzz run config_parser` for 8h each
-  - Zero crash + zero hang = pass
-  - File: `.github/workflows/fuzz.yml` (extend duration)
-
-- [ ] 12.4 `#![deny(warnings)]` workspace-wide (prod builds)
-  - All `crates/*/src/lib.rs` get `#![cfg_attr(not(test), deny(warnings))]`
-  - Any dep warning blocks the build
-
-- [x] 12.5 O(1) hot-path ratchet
-  - DHAT test budget: zero heap alloc per tick in `crates/core/tests/dhat_tick_processor.rs`
-  - Benchmark budget: `tick_pipeline_routing < 100ns`, `papaya_lookup < 50ns`, `full_tick_processing < 10µs` in `quality/benchmark-budgets.toml`
-  - CI gate: 5% regression on any budget = block
-
-- [x] 12.6 Real-time self-check on every boot
-  - `crates/app/src/main.rs` runs a 30-second smoke test at boot during market hours: synthesizes N synthetic ticks through the non-prod test pipeline, asserts they arrive in QuestDB, asserts O(1) latency samples within budget
-  - On failure → HALT + CRITICAL Telegram
-
-### Phase 9 — Dashboards + validation
-
-- [x] 9.1 Single-page "Operator Health" Grafana dashboard
-  - File: `deploy/docker/grafana/dashboards/operator-health.json`
-  - One panel for every "Is it working?" question: trading live? WS UP? depth streaming? errors rising? P&L within limits? auto-triage running? CloudWatch alarms green?
-
-- [x] 9.2 End-to-end validation script
-  - File: `scripts/validate-automation.sh`
-  - Simulates each known error code, asserts Telegram alert fires within SLA, asserts auto-fix runs (dry-run), asserts summary file regenerates
+- [ ] H. Ratchet guard test file
+  - Files: `crates/core/tests/cross_match_exhaustive_guard.rs` (new)
+  - Tests: source-scans for Pass-B, scope filter, exclusive window, no LIMIT
 
 ## Scenarios
 
 | # | Scenario | Expected |
 |---|----------|----------|
-| 1 | Flush failure during live feed | `error!` → Telegram alert in ≤15s, counter increments, auto-clear on next successful flush |
-| 2 | Known recurring I-P1-11 collision | Logged, counted in Prometheus gauge, **no Telegram** (silenced by triage rule) |
-| 3 | Novel error signature never seen before | Telegram alert + GitHub draft Issue + `errors.summary.md` flags "novel" |
-| 4 | Depth spot stale post-market | Silenced (market-hours gate — Rule 3) |
-| 5 | CloudWatch alarm EC2 high CPU | SNS → Telegram (if subscribed) + email + optional Lambda → Claude triage |
-| 6 | Dhan token 24h expiry | Auto-refresh happens → success INFO log → no escalation |
-| 7 | Loki down | Prometheus `TargetDown` fires → operator alerted; app keeps running (errors still go Telegram via direct path) |
-| 8 | Operator wakes up at 08:00 IST | Opens Telegram, sees zero-or-few alerts; opens Grafana "Operator Health" — one page, all panels green or red with links to summary |
-
-## Tradeoffs & decisions to confirm with Parthiban
-
-1. **Loki re-add:** costs ~640MB RAM, saves 4GB QuestDB pressure via 512MB trim. Alternative: skip Loki entirely, push errors via direct Alertmanager webhook. **Default: re-add** (LogQL is worth it).
-2. **CloudWatch custom metrics:** 10 metrics × 60s batching = ~432k PutMetricData/month → still free tier. Alternative: Prometheus-only and rely on EC2 staying up. **Default: emit the 10** (belt-and-suspenders).
-3. **Claude-watches-logs via `/loop` vs cron:** `/loop` only runs when Claude Code is open; cron runs 24/7 but can't do the "novel error → open PR" flow. **Default: both** — cron posts summary + Telegram; `/loop` handles triage when Claude session is active.
-4. **GitHub Issue auto-open for novel errors:** risks noise if classifier is wrong. **Default: ON with 1-issue-per-signature-per-24h rate limit.**
-5. **Scope:** all 10 phases in one shot vs phased rollout over several PRs. **Default: phased — one PR per phase, starting with Phase 0 (critical bug fixes) immediately.**
-
-## Estimated effort
-
-- Phase 0: ~45min (mechanical edit of 39 sites + guard test)
-- Phase 1: ~3h (enum + migration across ~150 error sites)
-- Phase 2: ~1h (subscriber config + rotation)
-- Phase 3: ~2h (Docker wiring + Loki rules + dashboard)
-- Phase 4: ~3h (Terraform + awslogs + CloudWatch shim)
-- Phase 5: ~2h (summary writer + status cmd)
-- Phase 6: ~3h (YAML schema + triage hook + tests)
-- Phase 7: ~2h (MCP server + loop prompt)
-- Phase 8: ~3h (auto-fix scripts + Lambda)
-- Phase 9: ~2h (dashboard + e2e validation)
-
-**Total: ~22h of focused work across ~10 PRs.** Phase 0 is ready to execute in the same session as approval.
-
-## Open questions
-
-- (A) Approve the whole plan, phase-by-phase, or only Phase 0 now?
-- (B) Budget for Loki re-add (Q: trim QuestDB from 4GB → 3.5GB acceptable?)
-- (C) Should Claude auto-open PRs for novel errors, or always escalate to Parthiban first?
-- (D) `operator_email` and `telegram_webhook_url` for Terraform SNS subscriptions — provide now or leave as pending vars?
+| 1 | App restarts mid-day, big gap in live | FAILED with per-row listing |
+| 2 | Full-day clean, no drift | OK single message |
+| 3 | Pre-market / no live data | SKIPPED |
+| 4 | 1-candle OHLCV drift | FAILED with exact field + hist→live values |
+| 5 | 500+ missing minutes | Header + multiple body Telegram msgs, full list, no truncation |

--- a/.claude/plans/archive/2026-04-18-zero-touch-observability.md
+++ b/.claude/plans/archive/2026-04-18-zero-touch-observability.md
@@ -1,0 +1,329 @@
+# Implementation Plan: Zero-Touch Error Observability & Auto-Triage
+
+**Status:** APPROVED
+**Date:** 2026-04-18
+**Approved by:** Parthiban ("go ahead with all the approach ... 100 percent automation dude")
+
+**Decisions confirmed:**
+- A: all phases, phased rollout (one PR per phase, Phase 0 first)
+- B: yes, trim QuestDB 4GB → 3.5GB to fit Loki + Alloy
+- C: Claude ALWAYS pings Parthiban first for novel errors; auto-PR only when classifier confidence ≥ 0.95 AND runbook rule explicitly opts in
+- D: AWS SNS vars deferred (no AWS instance bought yet); Phase 4 becomes mechanical-only, activated when instance provisioned
+
+## Honesty clause on "100%"
+
+The operator requested 100% guarantees on coverage, testing, bug-fixing, monitoring, logging, alerting, security, uniqueness, dedup, O(1), zero-tick-loss, zero-WS-disconnect, zero-QuestDB-fail.
+
+**PROVABLE 100%s (each = a mechanical CI gate or compile-time constraint):**
+- Line + branch coverage 100% via `cargo llvm-cov --fail-under 100`
+- Mutation score 100% (zero survivors) via `cargo-mutants`
+- Fuzz coverage — 24h clean run in nightly CI via `cargo-fuzz`
+- Banned-pattern scan 100% via `.claude/hooks/banned-pattern-scanner.sh`
+- Every pub fn has test via `pub-fn-test-guard`
+- Every error path has `error!` via new meta-guard
+- Every Result has `?` or explicit `match` via `#![deny(unused_must_use)]`
+- Every shared collection keyed by `security_id` uses `(id, segment)` via hook category 5
+- Every DEDUP key has segment via `dedup_segment_meta_guard`
+- Every dashboard has status filter + segment via `grafana_dashboard_snapshot_filter_guard`
+- O(1) hot path — zero alloc DHAT test + banned `.clone()/Vec::new()/format!/.collect()/dyn` hook
+- Wire-to-done latency ≤ 10µs — Criterion benchmark budget gate
+- Zero tick loss DURING normal operation — `tv_ticks_lost_total` assert-0 in market-hours integration test
+
+**NON-PROVABLE (physics/external), replaced by MEASURABLE SLAs:**
+- "WebSocket never disconnects" → "Reconnect ≤ 500ms, zero-loss via WAL replay, chaos test enforces"
+- "QuestDB never fails" → "Backpressure → disk spill → auto-resume within 30s, chaos test enforces"
+- "No future bug" → "Zero known bugs at HEAD + every pattern we've seen is a CI block"
+- "Every scenario covered" → "Every enumerated scenario tested + fuzz finds unknowns + mutation verifies non-vacuity"
+
+## Goal
+
+Parthiban never monitors manually — Claude Code (or a cron-driven agent) owns the full error lifecycle: capture → classify → dedup → triage → fix-or-escalate. Works identically on Mac (dev) and AWS c7i.xlarge Mumbai (prod), within the ₹5,000/mo budget.
+
+## Research Summary (from 4 parallel audits)
+
+**Already wired (keep):**
+- Prometheus + Alertmanager + 65 alert rules → Telegram webhook via Rust `NotificationService` with edge-triggered dedup (10s–1h).
+- `NotificationService` carries structured events (`security_id`, `symbol`, `reason`, severity). Critical/High also go AWS SNS SMS.
+- Grafana: 6 dashboards against Prometheus + QuestDB PG wire.
+- AWS Terraform: 5 CloudWatch alarms, SNS topic, 14-day CloudWatch log group, EventBridge EC2 start/stop.
+- `.claude/`: 33 hooks, 31 rules, `notification-log.sh` already audits every Telegram message.
+- Systemd: `tickvault.service` with `WatchdogSec=60`, `Restart=always`.
+
+**Gaps blocking full automation:**
+- 39 flush/broadcast/persist failures logged at `warn!` — NEVER reach Telegram (Rule 5 violated).
+- Loki + Alloy removed for memory budget → no LogQL alerting ("3 ERRORs in 5min" impossible today).
+- App container logs not in CloudWatch (only systemd journalctl captured).
+- No app-emitted CloudWatch custom metrics (Prometheus-only).
+- SNS has no Terraform-managed subscription (manual `aws sns subscribe` post-deploy).
+- Error codes (I-P*, OMS-*, WS-*, STORAGE-*, DH-9xx) are string literals in rustdoc — not a typed enum Claude can enumerate.
+- No log-ingestion MCP, no dedup-by-signature, no auto-triage YAML rules, no "Claude watches logs" daemon.
+- Traefik dashboard public + insecure on AWS EC2 IP.
+
+## Architecture (after plan)
+
+```
+Rust app  ──┬── metrics::*     → Prometheus :9091 ──┐
+            ├── error!/warn!   → tracing subscriber ┤
+            │                    ├→ JSONL stdout  ──┼→ docker awslogs → CloudWatch Logs
+            │                    └→ errors.jsonl  ──┤       (AWS only)
+            └── notify(event)  → Alertmanager WH ──┤
+                                                    │
+Prometheus ──(65 rules)── Alertmanager ────────────┤
+CloudWatch ──(5 alarms) ── SNS topic ──────────────┤
+                                                    │
+                     ┌──────────────────────────────┘
+                     ↓
+              NotificationService (dedup by signature hash, edge-trigger)
+                     │
+       ┌─────────────┼──────────────┐
+       ↓             ↓              ↓
+   Telegram     SNS SMS         errors.summary.md
+                              (auto-generated every 60s
+                               — human AND Claude-readable)
+                                     │
+                                     ↓
+                       .claude/hooks/error-triage.sh
+                                     │
+                         ┌───────────┴────────────┐
+                         ↓                        ↓
+                    Known signature          Novel signature
+                    (YAML runbook)           (escalate, open
+                    auto-execute or          GitHub Issue, ping
+                    link runbook             Claude agent)
+```
+
+## Plan Items (10 phases, each independently approvable)
+
+### Phase 0 — Stop the bleeding (BLOCKING for everything else)
+
+- [x] 0.1 Upgrade 39 `warn!` → `error!` on flush/broadcast/persist failures per audit-findings Rule 5
+  - Files: `crates/storage/src/tick_persistence.rs` (8 sites), `crates/storage/src/candle_persistence.rs` (9 sites), `crates/app/src/main.rs` (5 sites), `crates/core/src/pipeline/tick_processor.rs` (2 sites), `crates/app/src/greeks_pipeline.rs` (1 site), `crates/core/src/historical/candle_fetcher.rs` (1 site)
+  - Tests: add `test_flush_failure_emits_error_level` source-scan guard in `crates/storage/tests/error_level_meta_guard.rs`
+
+- [x] 0.2 Compile-enforce error capture
+  - Files: every `crates/*/src/lib.rs`
+  - Adds: `#![cfg_attr(not(test), deny(unused_must_use))]`, `#![cfg_attr(not(test), warn(clippy::let_underscore_must_use))]`, `#![cfg_attr(not(test), warn(clippy::unused_async))]`
+  - Tests: existing clippy gate catches regressions
+
+### Phase 1 — Structured error catalogue
+
+- [x] 1.1 Central `ErrorCode` enum in `crates/common/src/error.rs`
+  - Variants: every I-P*, OMS-GAP-*, WS-GAP-*, STORAGE-GAP-*, RISK-GAP-*, AUTH-GAP-*, DH-9xx, 8xx codes
+  - Methods: `.code_str()`, `.severity()`, `.runbook_url()`, `.is_actionable()`, `.suggested_fix()`
+  - Tests: `test_every_code_has_rule_doc`, `test_every_rule_doc_has_code`
+
+- [~] 1.2 Every `error!` / `warn!` on known paths must carry `code = ErrorCode::X.code_str()` as a structured field
+  - Files: `crates/*/src/**/*.rs` (mechanical migration, one ErrorCode per existing code)
+  - Tests: `crates/common/tests/error_code_field_guard.rs` scans source + fails if an error site in a tagged module lacks `code =`
+
+### Phase 2 — JSONL error stream + rotation
+
+- [x] 2.1 Tracing subscriber emits a separate `data/logs/errors.jsonl` filtered to ERROR-level only, one JSON object per line, `{ts_ist, code, severity, signature_hash, module, message, fields}`
+  - File: `crates/app/src/observability.rs`
+  - Uses `tracing-appender` file rotation (hourly, 48h retention)
+  - `signature_hash` = first 16 hex chars of sha256(code + module + truncated_message)
+
+- [x] 2.2 Makefile target `make tail-errors` — `jq`-formatted live view
+  - File: `Makefile`
+
+### Phase 3 — Loki/Alloy re-add under memory budget
+
+- [x] 3.1 Re-add slim Loki + Alloy to `docker-compose.yml` with tight memory limits that fit the 8GB c7i.xlarge budget after QuestDB trim from 4GB to 3.5GB
+  - Files: `deploy/docker/docker-compose.yml`, `deploy/docker/loki/loki-config.yml`, `deploy/docker/alloy/alloy-config.alloy`
+  - Mem: Loki 384MB, Alloy 256MB (total new: 640MB; offset by QuestDB 512MB trim → net -128MB, still within budget)
+  - Alloy scrapes: `data/logs/errors.jsonl` + `docker logs` for `tv-*` containers
+
+- [x] 3.2 Loki-ruler log-pattern alerts
+  - File: `deploy/docker/loki/rules.yml`
+  - Rules: `ErrorBurst` (>5 errors in 5min with same signature_hash), `NovelErrorSignature` (signature_hash never seen before in rolling 24h), `FlushErrorStorm`, `AuthFailureBurst`
+  - Route: Alertmanager → existing `NotificationService` webhook
+
+- [ ] 3.3 Re-add the "Errors" dashboard to Grafana
+  - File: `deploy/docker/grafana/dashboards/errors.json`
+  - Panels: live error tail (LogQL), top-10 signatures 1h, error rate time series, novel signatures callout, code → severity heatmap
+  - Single-page dashboard operator can glance at
+
+### Phase 4 — AWS observability parity
+
+- [ ] 4.1 Terraform: SNS subscriptions (email + Telegram HTTPS webhook) auto-created from `var.operator_email` and `var.telegram_webhook_url`
+  - File: `deploy/aws/terraform/sns.tf`
+  - Tests: `terraform plan` + `terraform validate` in CI
+
+- [ ] 4.2 Docker containers use `awslogs` driver in the AWS-specific compose override
+  - Files: `deploy/docker/docker-compose.aws.override.yml`, user-data.sh.tftpl
+  - Log group: `/tickvault/prod/containers/<service>`; retention 14d
+
+- [ ] 4.3 App emits CloudWatch custom metrics via a shim when `AWS_REGION` env set
+  - File: `crates/app/src/observability.rs`
+  - Uses `aws-sdk-cloudwatch` crate (already pinned — confirm with `dependency-checker`); 60s batch PutMetricData; only the 10 business-critical metrics to stay under free tier
+
+- [ ] 4.4 Secure Traefik dashboard
+  - File: `deploy/docker/traefik/traefik.yml` (remove `insecure=true`); `dynamic/services.yml` (add HTTP BasicAuth middleware, credentials from SSM)
+
+### Phase 5 — errors.summary.md (Claude-readable single-file view)
+
+- [x] 5.1 Background task inside the Rust app emits `data/logs/errors.summary.md` every 60s — markdown tables:
+  - "Active errors (last 15min)" — signature | count | severity | code | runbook | first_seen_ist
+  - "Novel today" — signatures first seen in last 24h
+  - "Infrastructure up/down" — each alert from Prometheus + CloudWatch
+  - "System KPIs" — tick rate, WS connections, memory, disk
+  - File: `crates/core/src/notification/summary_writer.rs` (new)
+  - Tests: `test_summary_file_regenerates`, `test_summary_edge_triggered_novel`
+
+- [x] 5.2 `make status` reads this file + prints dashboard
+  - File: `Makefile`, `scripts/status-dashboard.sh`
+
+### Phase 6 — Auto-triage rules engine
+
+- [x] 6.1 YAML rules file `.claude/triage/error-rules.yaml`
+  - Schema: `{ code, signature_pattern, action: "auto_fix" | "auto_restart" | "escalate" | "silence", runbook_url, confidence_threshold, cooldown_secs }`
+  - Seed rules for known recurring errors (I-P1-11 collision → silence; CandleVerificationFailed → escalate with jq'd context; Depth spot stale → auto-restart rebalancer once; Token expired → auto-refresh already handled → silence)
+
+- [x] 6.2 Triage hook `.claude/hooks/error-triage.sh`
+  - Trigger: cron (every 60s via a userland launchd/systemd-user timer) OR `Stop` / `SessionStart` hooks so it fires during Claude sessions
+  - Reads `errors.summary.md` + `error-rules.yaml` → applies rules → posts actions to Telegram and/or invokes `scripts/auto-fix-<action>.sh`
+  - Edge-triggered via `.claude/state/triage-seen.jsonl` (signature_hash + last_action_ts)
+  - Rate limit: max 10 triages/hour/signature
+
+- [~] 6.3 Novel-signature escalation
+  - When an error has `signature_hash` not in `triage-seen.jsonl`, `error-triage.sh` opens a draft GitHub Issue via existing `mcp__github__issue_write` (from the user's session) — issue body includes: code, severity, runbook, first 50 matching log lines, context links (Grafana, CloudWatch)
+
+### Phase 7 — Claude-watches-logs daemon
+
+- [x] 7.1 `/loop` skill runbook
+  - File: `.claude/triage/claude-loop-prompt.md`
+  - Prompt: "Read data/logs/errors.summary.md. For each row flagged 'ACTION_REQUIRED': investigate root cause, propose fix if tractable, open draft PR; otherwise ping operator with context."
+  - Invoked via: `/loop 5m .claude/triage/claude-loop-prompt.md`
+
+- [x] 7.2 MCP server for log access
+  - File: `scripts/mcp-servers/tickvault-logs/server.py` (new)
+  - Exposes: `tail_errors(signature, limit)`, `query_loki(logql)`, `query_cloudwatch(expression)`, `list_novel_signatures(since)`
+  - Registered in `.mcp.json`
+  - Permission-gated via `.claude/settings.json` allow list
+
+### Phase 8 — Self-healing triggers
+
+- [x] 8.1 Common auto-fix scripts
+  - `scripts/auto-fix-restart-depth.sh` — calls existing depth rebalancer reset endpoint
+  - `scripts/auto-fix-clear-spill.sh` — drains disk spill buffer after QuestDB recovery
+  - `scripts/auto-fix-refresh-instruments.sh` — triggers `POST /api/instruments/rebuild`
+  - Each script: idempotent, logs to `data/logs/auto-fix.log`, includes dry-run flag
+
+- [x] 8.2 CloudWatch webhook → Claude Code session (AWS only)
+  - Lambda function: receives SNS → invokes `tmux send-keys 'claude --resume <session_id> "triage $ALARM"'` on the EC2 via SSM RunCommand
+  - File: `deploy/aws/terraform/claude-triage-lambda.tf` + `deploy/aws/lambda/claude-triage.py`
+
+### Phase 10 — Zero-tick-loss hardening (explicit SLA)
+
+- [~] 10.1 Three-tier buffer proof
+  - `crates/core/src/pipeline/tick_processor.rs` — SPSC 65K ring → disk spill (rkyv) → WAL replay on reconnect
+  - Metric: `tv_ticks_lost_total` — must remain 0 during market hours; increments only on explicit drop decision with root cause label
+  - Test: `crates/storage/tests/zero_tick_loss_invariant.rs` — integration test kills + resumes QuestDB, drops + resumes WS, asserts final stored count = emitted count
+
+- [ ] 10.2 Sequence-hole detector
+  - For each (security_id, segment), maintain last-exchange-timestamp; gap > 2s during market hours fires `TickGapDetected` with exact missed window
+  - Already partially in `crates/trading/src/risk/tick_gap.rs` — extend + wire test
+
+- [ ] 10.3 End-to-end "no lost tick" chaos test (nightly CI only)
+  - `crates/storage/tests/chaos_zero_loss.rs`
+  - Simulates: WS random disconnect (1% per minute), QuestDB SIGSTOP for 30s, disk near-full, Valkey down
+  - Asserts: emitted = persisted after cool-down; never panic
+
+### Phase 11 — WebSocket + QuestDB resilience SLAs (chaos)
+
+- [x] 11.1-guard WS liveness SLA
+  - Reconnect latency histogram `tv_ws_reconnect_duration_ms` — p99 < 500ms
+  - Prometheus alert: `WsReconnectSlowP99` fires at > 1s for 2m
+  - Chaos test: kill WS every 5 min × 10 iterations, assert p99 SLA
+
+- [x] 11.2-guard QuestDB backpressure SLA
+  - `tv_questdb_backpressure_duration_ms`; app stays up, spills to disk
+  - Alert: `QuestDbBackpressureCritical` > 10s
+  - Chaos test: SIGSTOP QuestDB for 30s, unSTOP, assert: 0 panics + all buffered data flushed within 30s + `tv_ticks_lost_total` still 0
+
+- [x] 11.3-guard Valkey cache fallback
+  - On Valkey down, non-critical features degrade gracefully; trading continues; alert fires
+  - Chaos test: `docker kill tv-valkey`, assert app stays healthy, auto-reconnect on restart
+
+### Phase 12 — Coverage / Mutation / Fuzz ratchet (100% or fail)
+
+- [x] 12.1 Line + branch coverage 100%
+  - CI gate: `cargo llvm-cov --workspace --fail-under-lines 100 --fail-under-regions 100`
+  - File: `quality/crate-coverage-thresholds.toml` — set all crates to 100
+  - Any exemption requires a `// COVERAGE-EXEMPT: <reason>` comment + operator sign-off
+
+- [x] 12.2 Mutation score 100% (zero survivors)
+  - CI gate: `cargo mutants --workspace --error-exit-code 1 -- --release`
+  - Schedule: nightly, PR blocks if new survivor introduced
+  - File: `.github/workflows/mutation.yml` (extend)
+
+- [~] 12.3 Fuzz 24h clean
+  - CI gate: nightly runs `cargo fuzz run tick_parser` + `cargo fuzz run config_parser` for 8h each
+  - Zero crash + zero hang = pass
+  - File: `.github/workflows/fuzz.yml` (extend duration)
+
+- [ ] 12.4 `#![deny(warnings)]` workspace-wide (prod builds)
+  - All `crates/*/src/lib.rs` get `#![cfg_attr(not(test), deny(warnings))]`
+  - Any dep warning blocks the build
+
+- [x] 12.5 O(1) hot-path ratchet
+  - DHAT test budget: zero heap alloc per tick in `crates/core/tests/dhat_tick_processor.rs`
+  - Benchmark budget: `tick_pipeline_routing < 100ns`, `papaya_lookup < 50ns`, `full_tick_processing < 10µs` in `quality/benchmark-budgets.toml`
+  - CI gate: 5% regression on any budget = block
+
+- [x] 12.6 Real-time self-check on every boot
+  - `crates/app/src/main.rs` runs a 30-second smoke test at boot during market hours: synthesizes N synthetic ticks through the non-prod test pipeline, asserts they arrive in QuestDB, asserts O(1) latency samples within budget
+  - On failure → HALT + CRITICAL Telegram
+
+### Phase 9 — Dashboards + validation
+
+- [x] 9.1 Single-page "Operator Health" Grafana dashboard
+  - File: `deploy/docker/grafana/dashboards/operator-health.json`
+  - One panel for every "Is it working?" question: trading live? WS UP? depth streaming? errors rising? P&L within limits? auto-triage running? CloudWatch alarms green?
+
+- [x] 9.2 End-to-end validation script
+  - File: `scripts/validate-automation.sh`
+  - Simulates each known error code, asserts Telegram alert fires within SLA, asserts auto-fix runs (dry-run), asserts summary file regenerates
+
+## Scenarios
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Flush failure during live feed | `error!` → Telegram alert in ≤15s, counter increments, auto-clear on next successful flush |
+| 2 | Known recurring I-P1-11 collision | Logged, counted in Prometheus gauge, **no Telegram** (silenced by triage rule) |
+| 3 | Novel error signature never seen before | Telegram alert + GitHub draft Issue + `errors.summary.md` flags "novel" |
+| 4 | Depth spot stale post-market | Silenced (market-hours gate — Rule 3) |
+| 5 | CloudWatch alarm EC2 high CPU | SNS → Telegram (if subscribed) + email + optional Lambda → Claude triage |
+| 6 | Dhan token 24h expiry | Auto-refresh happens → success INFO log → no escalation |
+| 7 | Loki down | Prometheus `TargetDown` fires → operator alerted; app keeps running (errors still go Telegram via direct path) |
+| 8 | Operator wakes up at 08:00 IST | Opens Telegram, sees zero-or-few alerts; opens Grafana "Operator Health" — one page, all panels green or red with links to summary |
+
+## Tradeoffs & decisions to confirm with Parthiban
+
+1. **Loki re-add:** costs ~640MB RAM, saves 4GB QuestDB pressure via 512MB trim. Alternative: skip Loki entirely, push errors via direct Alertmanager webhook. **Default: re-add** (LogQL is worth it).
+2. **CloudWatch custom metrics:** 10 metrics × 60s batching = ~432k PutMetricData/month → still free tier. Alternative: Prometheus-only and rely on EC2 staying up. **Default: emit the 10** (belt-and-suspenders).
+3. **Claude-watches-logs via `/loop` vs cron:** `/loop` only runs when Claude Code is open; cron runs 24/7 but can't do the "novel error → open PR" flow. **Default: both** — cron posts summary + Telegram; `/loop` handles triage when Claude session is active.
+4. **GitHub Issue auto-open for novel errors:** risks noise if classifier is wrong. **Default: ON with 1-issue-per-signature-per-24h rate limit.**
+5. **Scope:** all 10 phases in one shot vs phased rollout over several PRs. **Default: phased — one PR per phase, starting with Phase 0 (critical bug fixes) immediately.**
+
+## Estimated effort
+
+- Phase 0: ~45min (mechanical edit of 39 sites + guard test)
+- Phase 1: ~3h (enum + migration across ~150 error sites)
+- Phase 2: ~1h (subscriber config + rotation)
+- Phase 3: ~2h (Docker wiring + Loki rules + dashboard)
+- Phase 4: ~3h (Terraform + awslogs + CloudWatch shim)
+- Phase 5: ~2h (summary writer + status cmd)
+- Phase 6: ~3h (YAML schema + triage hook + tests)
+- Phase 7: ~2h (MCP server + loop prompt)
+- Phase 8: ~3h (auto-fix scripts + Lambda)
+- Phase 9: ~2h (dashboard + e2e validation)
+
+**Total: ~22h of focused work across ~10 PRs.** Phase 0 is ready to execute in the same session as approval.
+
+## Open questions
+
+- (A) Approve the whole plan, phase-by-phase, or only Phase 0 now?
+- (B) Budget for Loki re-add (Q: trim QuestDB from 4GB → 3.5GB acceptable?)
+- (C) Should Claude auto-open PRs for novel errors, or always escalate to Parthiban first?
+- (D) `operator_email` and `telegram_webhook_url` for Terraform SNS subscriptions — provide now or leave as pending vars?

--- a/crates/app/src/boot_helpers.rs
+++ b/crates/app/src/boot_helpers.rs
@@ -182,6 +182,159 @@ pub fn format_cross_match_details(details: &[CrossMatchMismatch]) -> Vec<String>
         .collect()
 }
 
+/// Grouped variant of [`format_cross_match_details`] (Parthiban directive
+/// 2026-04-21): produces section headers + one compact line per issue,
+/// ordered `missing_live → value_diff → missing_historical`. The
+/// resulting `Vec<String>` concatenates to a single monospace block
+/// in Telegram.
+///
+/// Each row:
+///   `RELIANCE     2885   NSE_EQ  1m   12:00:00 IST    (no live)`
+/// or (value mismatch):
+///   `BANKNIFTY      25   IDX_I   5m   11:15:00        close   52340.25 → 52340.20`
+pub fn format_cross_match_details_grouped(details: &[CrossMatchMismatch]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+
+    let push_row_missing = |out: &mut Vec<String>, d: &CrossMatchMismatch, tag: &str| {
+        let ts_short = d
+            .timestamp_ist
+            .split('T')
+            .nth(1)
+            .and_then(|t| t.split('.').next())
+            .unwrap_or(&d.timestamp_ist);
+        out.push(format!(
+            " {sym:<10}  {sid:>6}   {seg:<6}  {tf:<3}  {ts:<8}  {tag}",
+            sym = truncate_display(&d.symbol, 10),
+            sid = &d.timestamp_ist, // placeholder; real sid comes below
+            seg = d.segment,
+            tf = d.timeframe,
+            ts = ts_short,
+            tag = tag,
+        ));
+        // rewrite: use real sid via parsing symbol-sid split
+        let _ = ts_short;
+    };
+    let _ = push_row_missing;
+
+    // Helper: format a timestamp-IST short form "HH:MM:SS".
+    let short_ts = |ts: &str| -> String {
+        ts.split('T')
+            .nth(1)
+            .and_then(|t| t.split('.').next())
+            .unwrap_or(ts)
+            .to_string()
+    };
+
+    // sid is not stored as a first-class number on CrossMatchMismatch, but the
+    // `symbol` field already includes the registry-resolved display label and
+    // falls back to the numeric id when not found. We extract what we can.
+    let row_missing_live = |d: &CrossMatchMismatch| -> String {
+        format!(
+            " {sym:<10}  {seg:<6}  {tf:<3}  {ts}   (live missing)",
+            sym = truncate_display(&d.symbol, 10),
+            seg = d.segment,
+            tf = d.timeframe,
+            ts = short_ts(&d.timestamp_ist),
+        )
+    };
+    let row_missing_historical = |d: &CrossMatchMismatch| -> String {
+        format!(
+            " {sym:<10}  {seg:<6}  {tf:<3}  {ts}   (historical missing)",
+            sym = truncate_display(&d.symbol, 10),
+            seg = d.segment,
+            tf = d.timeframe,
+            ts = short_ts(&d.timestamp_ist),
+        )
+    };
+    let row_value_diff = |d: &CrossMatchMismatch| -> String {
+        let diff_desc = if !d.field_deltas.is_empty() {
+            d.field_deltas
+                .iter()
+                .map(|f| {
+                    if f.is_integer {
+                        format!("{}: {} → {}", f.field, f.hist as i64, f.live as i64)
+                    } else {
+                        format!("{}: {:.2} → {:.2}", f.field, f.hist, f.live)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" | ")
+        } else {
+            d.diff_summary.clone()
+        };
+        format!(
+            " {sym:<10}  {seg:<6}  {tf:<3}  {ts}   {diff}",
+            sym = truncate_display(&d.symbol, 10),
+            seg = d.segment,
+            tf = d.timeframe,
+            ts = short_ts(&d.timestamp_ist),
+            diff = diff_desc,
+        )
+    };
+
+    let missing_live: Vec<&CrossMatchMismatch> = details
+        .iter()
+        .filter(|d| d.mismatch_type == "missing_live")
+        .collect();
+    let missing_historical: Vec<&CrossMatchMismatch> = details
+        .iter()
+        .filter(|d| d.mismatch_type == "missing_historical")
+        .collect();
+    let value_diffs: Vec<&CrossMatchMismatch> = details
+        .iter()
+        .filter(|d| d.mismatch_type != "missing_live" && d.mismatch_type != "missing_historical")
+        .collect();
+
+    if !missing_live.is_empty() {
+        out.push(format!(
+            "📭 MISSING LIVE  ({n})  — historical has candle, live doesn't",
+            n = missing_live.len()
+        ));
+        out.push(" Symbol      Seg     TF   Time".to_string());
+        out.push(" ──────────────────────────────────────".to_string());
+        for d in &missing_live {
+            out.push(row_missing_live(d));
+        }
+        out.push(String::new());
+    }
+
+    if !value_diffs.is_empty() {
+        out.push(format!(
+            "💱 VALUE MISMATCH  ({n})  — both present, OHLCV differs",
+            n = value_diffs.len()
+        ));
+        out.push(" Symbol      Seg     TF   Time      Δ".to_string());
+        out.push(" ──────────────────────────────────────".to_string());
+        for d in &value_diffs {
+            out.push(row_value_diff(d));
+        }
+        out.push(String::new());
+    }
+
+    if !missing_historical.is_empty() {
+        out.push(format!(
+            "📤 MISSING HISTORICAL  ({n})  — live has candle, historical doesn't",
+            n = missing_historical.len()
+        ));
+        out.push(" Symbol      Seg     TF   Time".to_string());
+        out.push(" ──────────────────────────────────────".to_string());
+        for d in &missing_historical {
+            out.push(row_missing_historical(d));
+        }
+    }
+
+    out
+}
+
+/// Truncates or pads a display name to exactly `width` chars.
+fn truncate_display(s: &str, width: usize) -> String {
+    if s.chars().count() > width {
+        s.chars().take(width).collect::<String>()
+    } else {
+        s.to_string()
+    }
+}
+
 /// Formats a single `FieldDelta` as one Telegram line:
 ///   `open      : hist=2847.50 live=2847.00  Δ=+0.50`
 ///
@@ -701,7 +854,72 @@ pub fn drain_replayed_order_updates_to_broadcast(
 mod tests {
     use super::*;
     use std::net::SocketAddr;
-    use tickvault_core::historical::cross_verify::TimeframeCoverage;
+    use tickvault_core::historical::cross_verify::{CrossMatchMismatch, TimeframeCoverage};
+
+    fn make_mismatch(
+        symbol: &str,
+        segment: &str,
+        tf: &str,
+        ts: &str,
+        kind: &str,
+    ) -> CrossMatchMismatch {
+        CrossMatchMismatch {
+            symbol: symbol.to_string(),
+            segment: segment.to_string(),
+            timeframe: tf.to_string(),
+            timestamp_ist: ts.to_string(),
+            mismatch_type: kind.to_string(),
+            hist_values: String::new(),
+            live_values: String::new(),
+            diff_summary: String::new(),
+            field_deltas: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_format_cross_match_details_grouped_orders_sections() {
+        let details = vec![
+            make_mismatch(
+                "TCS",
+                "NSE_EQ",
+                "1m",
+                "2026-04-21T11:00:00.000000Z",
+                "missing_historical",
+            ),
+            make_mismatch(
+                "RELIANCE",
+                "NSE_EQ",
+                "1m",
+                "2026-04-21T12:00:00.000000Z",
+                "missing_live",
+            ),
+            make_mismatch(
+                "NIFTY",
+                "IDX_I",
+                "5m",
+                "2026-04-21T11:15:00.000000Z",
+                "price_diff",
+            ),
+        ];
+        let lines = format_cross_match_details_grouped(&details);
+        let joined = lines.join("\n");
+        // Section ordering: missing_live → value_diff → missing_historical
+        let idx_live = joined.find("MISSING LIVE").expect("missing live section");
+        let idx_value = joined.find("VALUE MISMATCH").expect("value section");
+        let idx_hist = joined
+            .find("MISSING HISTORICAL")
+            .expect("missing historical section");
+        assert!(idx_live < idx_value);
+        assert!(idx_value < idx_hist);
+        assert!(joined.contains("RELIANCE"));
+        assert!(joined.contains("NIFTY"));
+        assert!(joined.contains("TCS"));
+    }
+
+    #[test]
+    fn test_format_cross_match_details_grouped_empty_returns_empty() {
+        assert!(format_cross_match_details_grouped(&[]).is_empty());
+    }
 
     fn make_coverage(
         timeframe: &str,

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -28,8 +28,9 @@
 use tickvault_app::boot_helpers::{
     CONFIG_BASE_PATH, CONFIG_LOCAL_PATH, FAST_BOOT_WINDOW_END, FAST_BOOT_WINDOW_START, IstTimer,
     check_clock_drift, compute_market_close_sleep, create_error_log_writer,
-    create_rolling_log_writer, effective_ws_stagger, format_bind_addr, format_cross_match_details,
-    format_timeframe_details, format_violation_details, spawn_heartbeat_watchdog,
+    create_rolling_log_writer, effective_ws_stagger, format_bind_addr,
+    format_cross_match_details_grouped, format_timeframe_details, format_violation_details,
+    spawn_heartbeat_watchdog,
 };
 use tickvault_app::{infra, observability, trading_pipeline};
 
@@ -4493,31 +4494,55 @@ fn spawn_historical_candle_fetch(
                     )
                 };
 
+                // Scope counts from the registry (IDX_I + NSE_EQ only — the
+                // cross-match applies only to indices and stock equities per
+                // Parthiban directive 2026-04-21). F&O isn't served by Dhan
+                // historical REST so it's excluded from the expected grid.
+                let (scope_indices, scope_equities) = {
+                    use tickvault_common::types::ExchangeSegment;
+                    let grouped = bg_registry.by_exchange_segment();
+                    let idx = grouped.get(&ExchangeSegment::IdxI).map_or(0, Vec::len);
+                    let eq = grouped.get(&ExchangeSegment::NseEquity).map_or(0, Vec::len);
+                    (idx, eq)
+                };
+
+                // Value-mismatch count = Pass-A mismatches excluding missing_live
+                // (Pass-A produces value_diff + missing_live rows). Pass-B produces
+                // missing_historical. Total = value_mismatches + missing_live + missing_historical.
+                let missing_historical = cross_match
+                    .mismatch_details
+                    .iter()
+                    .filter(|m| m.mismatch_type == "missing_historical")
+                    .count();
+                let value_mismatches_count = cross_match
+                    .mismatches
+                    .saturating_sub(cross_match.missing_live)
+                    .saturating_sub(missing_historical);
+
                 if cross_match.passed {
                     bg_notifier.notify(NotificationEvent::CandleCrossMatchPassed {
                         timeframes_checked: cross_match.timeframes_checked,
                         candles_compared: cross_match.candles_compared,
                         today_ist_label,
+                        scope_indices,
+                        scope_equities,
+                        per_tf_cells: cross_match.per_timeframe_mismatches.clone(),
                     });
                 } else {
-                    // Build per-timeframe summary for Telegram (e.g., "1m: 3 | 5m: 0 | 15m: 1")
-                    let tf_summary: String = cross_match
-                        .per_timeframe_mismatches
-                        .iter()
-                        .map(|(tf, count)| format!("{tf}: {count}"))
-                        .collect::<Vec<_>>()
-                        .join(" | ");
-                    let mut details = format_cross_match_details(&cross_match.mismatch_details);
-                    // Prepend per-timeframe summary as first line
-                    if !tf_summary.is_empty() {
-                        details.insert(0, format!("Per-timeframe: {tf_summary}"));
-                    }
+                    // Group mismatch details by category for Telegram.
+                    // Order: missing_live → value_diff → missing_historical.
+                    let details = format_cross_match_details_grouped(&cross_match.mismatch_details);
                     bg_notifier.notify(NotificationEvent::CandleCrossMatchFailed {
                         candles_compared: cross_match.candles_compared,
                         mismatches: cross_match.mismatches,
                         missing_live: cross_match.missing_live,
                         mismatch_details: details,
                         today_ist_label,
+                        scope_indices,
+                        scope_equities,
+                        missing_historical,
+                        value_mismatches: value_mismatches_count,
+                        per_tf_gaps: cross_match.per_timeframe_mismatches.clone(),
                     });
                 }
             }
@@ -5280,7 +5305,7 @@ mod tests {
     fn test_boot_helper_functions_callable() {
         let _ = compute_market_close_sleep("15:30:00");
         let _ = format_violation_details(&[]);
-        let _ = format_cross_match_details(&[]);
+        let _ = format_cross_match_details_grouped(&[]);
         let _ = create_log_file_writer();
     }
 

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -323,26 +323,55 @@ impl TodayIstWindow {
         })
     }
 
-    /// Returns the SQL fragment `ts >= '...' AND ts <= '...'` suitable for
-    /// dropping into any WHERE clause. Replaces the old
-    /// `ts > dateadd('d', -3, now())` 3-day window.
+    /// Returns the SQL fragment `ts >= '...' AND ts < '...'` suitable for
+    /// dropping into any WHERE clause. Window is **09:15 inclusive → 15:30
+    /// exclusive** per product spec (1m candle at 15:29:00 covers
+    /// 15:29:00–15:29:59, there is no 15:30:00 candle).
     pub fn where_clause(&self) -> String {
         format!(
-            "ts >= {start} AND ts <= {end}",
+            "ts >= {start} AND ts < {end}",
             start = self.start_sql,
             end = self.end_sql,
         )
     }
 
     /// Same as [`where_clause`] but prefixed with a table alias
-    /// (e.g. `"h"` → `h.ts >= '...' AND h.ts <= '...'`).
+    /// (e.g. `"h"` → `h.ts >= '...' AND h.ts < '...'`).
     pub fn where_clause_aliased(&self, alias: &str) -> String {
         format!(
-            "{alias}.ts >= {start} AND {alias}.ts <= {end}",
+            "{alias}.ts >= {start} AND {alias}.ts < {end}",
             start = self.start_sql,
             end = self.end_sql,
         )
     }
+
+    /// Human-readable IST session label for Telegram headers.
+    /// Example: `"2026-04-21 09:15 → 15:30 IST  (inclusive → exclusive)"`.
+    pub fn human_label(&self) -> String {
+        format!(
+            "{} 09:15 → 15:30 IST  (inclusive → exclusive)",
+            self.today_ist
+        )
+    }
+}
+
+/// Cross-match scope: only indices (IDX_I) and stock equities (NSE_EQ)
+/// are verifiable against Dhan's historical REST API. F&O (NSE_FNO,
+/// BSE_FNO) are NOT served by `/v2/charts/historical` or
+/// `/v2/charts/intraday`, so they are excluded from the cross-match
+/// expected grid.
+///
+/// Parthiban directive 2026-04-21: "this is applicable only for indices
+/// and stock equities alone".
+///
+/// Returns a SQL fragment like `segment IN ('NSE_EQ', 'IDX_I')` without a
+/// leading `AND` — caller composes with other WHERE clauses.
+pub const CROSS_MATCH_SCOPE_SQL: &str = "segment IN ('NSE_EQ', 'IDX_I')";
+
+/// Same as [`CROSS_MATCH_SCOPE_SQL`] but prefixed with a table alias
+/// (e.g. `"h"` → `h.segment IN ('NSE_EQ', 'IDX_I')`).
+pub fn cross_match_scope_aliased(alias: &str) -> String {
+    format!("{alias}.segment IN ('NSE_EQ', 'IDX_I')")
 }
 
 // ---------------------------------------------------------------------------
@@ -794,10 +823,26 @@ fn build_missing_live_mismatch(ctx: CandleContext, hist: CandleValues) -> CrossM
 /// Determines if the cross-match report should pass.
 fn determine_cross_match_passed(
     total_mismatches: usize,
+    total_missing_live: usize,
+    total_missing_historical: usize,
     total_compared: usize,
     missing_views_count: usize,
 ) -> bool {
-    total_mismatches == 0 && total_compared > 0 && missing_views_count == 0
+    // Fixed 2026-04-21 (Parthiban directive): cross-match may ONLY report OK
+    // when EVERY applicable 09:15→15:30 IST slot is present on BOTH historical
+    // and live sides AND every OHLCV value matches bit-for-bit. Any hole of
+    // any kind = FAILED.
+    //
+    // Previously this function ignored `missing_live` and `missing_historical`
+    // completely — so a day where the app was down from 12:00–13:00 would
+    // produce zero live rows for that hour, the LEFT JOIN would drop those
+    // historical rows from the detail query, `total_mismatches` stayed 0, and
+    // the operator got a misleading OK at 15:47.
+    total_mismatches == 0
+        && total_missing_live == 0
+        && total_missing_historical == 0
+        && total_compared > 0
+        && missing_views_count == 0
 }
 
 /// Parsed fields from a single QuestDB violation row.
@@ -1367,7 +1412,7 @@ pub async fn cross_match_historical_vs_live(
     let mut total_compared = 0_usize;
     let mut total_mismatches = 0_usize;
     let mut total_missing_live = 0_usize;
-    let total_missing_historical = 0_usize;
+    let mut total_missing_historical = 0_usize;
     let mut total_oi_mismatches = 0_usize;
     let mut all_details: Vec<CrossMatchMismatch> = Vec::new();
     let mut timeframes_checked = 0_usize;
@@ -1378,8 +1423,16 @@ pub async fn cross_match_historical_vs_live(
     // MV is empty, so `candles_compared` alone cannot distinguish
     // "N candles joined against live data" from "N historical rows and
     // zero matching live rows". Track whether any live MV has rows in
-    // the last 3 days separately.
+    // today's window separately.
     let mut live_candles_present = false;
+
+    // Scope filter: cross-match applies ONLY to indices (IDX_I) and stock
+    // equities (NSE_EQ) — F&O is not served by Dhan's historical REST API
+    // so those rows are excluded from both the expected grid and the
+    // detail queries below. Parthiban directive 2026-04-21.
+    let scope_h = cross_match_scope_aliased("h");
+    let scope_m = cross_match_scope_aliased("m");
+    let scope_plain = CROSS_MATCH_SCOPE_SQL;
 
     for &(hist_tf, live_table) in CROSS_MATCH_TIMEFRAMES {
         // M2: Check if the materialized view exists before JOINing.
@@ -1406,23 +1459,29 @@ pub async fn cross_match_historical_vs_live(
             continue;
         }
 
-        // Direct live-MV row count (NOT a LEFT JOIN). Determines whether
-        // there is any live data at all to compare against. If zero,
-        // we still run the per-timeframe LEFT JOIN below for completeness
-        // but the caller will refuse to emit "OK" without at least one
-        // timeframe reporting live rows.
-        let live_count_query = format!("SELECT count() FROM {} WHERE {ts_filter}", live_table);
+        // Direct live-MV row count (scope-filtered, NOT a LEFT JOIN).
+        // Determines whether there is any live data at all to compare
+        // against for IDX_I/NSE_EQ instruments.
+        let live_count_query = format!(
+            "SELECT count() FROM {} WHERE {ts_filter} AND {scope_plain}",
+            live_table
+        );
         let live_tf_rows = extract_count(&client, &base_url, &live_count_query).await;
         if live_tf_rows > 0 {
             live_candles_present = true;
         }
 
-        // Count total comparable candles for this timeframe
+        // Count total comparable historical candles for this timeframe
+        // (scope-filtered to IDX_I + NSE_EQ only). LEFT JOIN preserves
+        // every historical row even if the live twin is absent, so this
+        // count represents the expected grid size for the scope.
         let count_query = format!(
-            "SELECT count() FROM {} h \
-             LEFT JOIN {} m ON h.security_id = m.security_id AND h.ts = m.ts AND h.segment = m.segment \
-             WHERE h.timeframe = '{}' AND {ts_filter_h}",
-            QUESTDB_TABLE_HISTORICAL_CANDLES, live_table, hist_tf
+            "SELECT count() FROM {hist} h \
+             LEFT JOIN {live} m ON h.security_id = m.security_id AND h.ts = m.ts AND h.segment = m.segment \
+             WHERE h.timeframe = '{tf}' AND {ts_filter_h} AND {scope_h}",
+            hist = QUESTDB_TABLE_HISTORICAL_CANDLES,
+            live = live_table,
+            tf = hist_tf,
         );
 
         let tf_total = extract_count(&client, &base_url, &count_query).await;
@@ -1433,28 +1492,30 @@ pub async fn cross_match_historical_vs_live(
         }
         timeframes_checked = timeframes_checked.saturating_add(1);
 
-        // Fetch ALL joined rows for this timeframe — Rust applies epsilon + volume + OI checks.
-        // SQL pre-filters with generous tolerance to avoid fetching perfectly matching rows.
+        // ------------------------------------------------------------------
+        // Pass-A: historical LEFT JOIN live
+        //   Produces: value_diff rows + missing_live rows.
+        //   Scope: IDX_I + NSE_EQ only. No LIMIT — we need every row for
+        //   the exhaustive Telegram report (Parthiban directive 2026-04-21).
+        // ------------------------------------------------------------------
         let detail_query = format!(
             "SELECT h.security_id, h.segment, h.ts, \
                     h.open, h.high, h.low, h.close, h.volume, \
                     m.open, m.high, m.low, m.close, m.volume, \
                     h.open_interest, m.open_interest \
-             FROM {} h \
-             LEFT JOIN {} m ON h.security_id = m.security_id AND h.ts = m.ts AND h.segment = m.segment \
-             WHERE h.timeframe = '{}' AND {ts_filter_h} \
+             FROM {hist} h \
+             LEFT JOIN {live} m ON h.security_id = m.security_id AND h.ts = m.ts AND h.segment = m.segment \
+             WHERE h.timeframe = '{tf}' AND {ts_filter_h} AND {scope_h} \
              AND (m.open IS NULL \
                   OR abs(h.open - m.open) > {eps} \
                   OR abs(h.high - m.high) > {eps} \
                   OR abs(h.low - m.low) > {eps} \
                   OR abs(h.close - m.close) > {eps} \
                   OR abs(h.volume - m.volume) > 0 \
-                  OR abs(h.open_interest - m.open_interest) > 0) \
-             LIMIT {}",
-            QUESTDB_TABLE_HISTORICAL_CANDLES,
-            live_table,
-            hist_tf,
-            MAX_VIOLATION_DETAILS,
+                  OR abs(h.open_interest - m.open_interest) > 0)",
+            hist = QUESTDB_TABLE_HISTORICAL_CANDLES,
+            live = live_table,
+            tf = hist_tf,
             eps = CROSS_MATCH_PRICE_EPSILON,
         );
 
@@ -1472,15 +1533,53 @@ pub async fn cross_match_historical_vs_live(
             }
         }
 
-        // Track per-timeframe mismatch count for Telegram display.
-        let tf_mismatch_count = details.len();
+        // ------------------------------------------------------------------
+        // Pass-B: live LEFT JOIN historical (finds missing_historical)
+        //   Produces: missing_historical rows (live has candle, historical
+        //   doesn't). Previously declared but never populated — live runs
+        //   that out-ran Dhan's REST fetch would silently hide.
+        // ------------------------------------------------------------------
+        let missing_hist_query = format!(
+            "SELECT m.security_id, m.segment, m.ts, \
+                    m.open, m.high, m.low, m.close, m.volume \
+             FROM {live} m \
+             LEFT JOIN {hist} h ON h.security_id = m.security_id AND h.ts = m.ts AND h.segment = m.segment AND h.timeframe = '{tf}' \
+             WHERE {ts_filter_m} AND {scope_m} AND h.security_id IS NULL",
+            hist = QUESTDB_TABLE_HISTORICAL_CANDLES,
+            live = live_table,
+            tf = hist_tf,
+            ts_filter_m = today_window.where_clause_aliased("m"),
+        );
+
+        let missing_hist_details = parse_missing_historical_rows(
+            &client,
+            &base_url,
+            &missing_hist_query,
+            registry,
+            hist_tf,
+        )
+        .await;
+
+        let tf_missing_historical = missing_hist_details.len();
+        total_missing_historical = total_missing_historical.saturating_add(tf_missing_historical);
+        total_mismatches = total_mismatches.saturating_add(tf_missing_historical);
+
+        // Track per-timeframe mismatch count (Pass-A + Pass-B combined) for
+        // Telegram display.
+        let tf_mismatch_count = details.len().saturating_add(tf_missing_historical);
         per_timeframe_mismatches.push((hist_tf.to_string(), tf_mismatch_count));
 
         all_details.extend(details);
+        all_details.extend(missing_hist_details);
     }
 
-    let passed =
-        determine_cross_match_passed(total_mismatches, total_compared, missing_views.len());
+    let passed = determine_cross_match_passed(
+        total_mismatches,
+        total_missing_live,
+        total_missing_historical,
+        total_compared,
+        missing_views.len(),
+    );
 
     info!(
         timeframes_checked,
@@ -1649,6 +1748,13 @@ async fn parse_violation_rows(
 ///   h_open, h_high, h_low, h_close, h_volume,
 ///   m_open, m_high, m_low, m_close, m_volume,
 ///   h_open_interest, m_open_interest
+///
+/// NOTE: `MAX_VIOLATION_DETAILS` acts as a memory-safety ceiling, NOT a
+/// report-level truncation. The exhaustive cross-match plan (Parthiban
+/// directive 2026-04-21) requires every violation in the Telegram output;
+/// the ceiling here catches pathological query responses without silently
+/// dropping rows under normal load. If `details.len()` approaches the
+/// ceiling the operator sees WARN logs and should raise the constant.
 async fn parse_cross_match_rows_with_oi(
     client: &Client,
     base_url: &str,
@@ -1661,7 +1767,7 @@ async fn parse_cross_match_rows_with_oi(
         None => return Vec::new(),
     };
 
-    let mut details = Vec::with_capacity(data.dataset.len().min(MAX_VIOLATION_DETAILS));
+    let mut details = Vec::with_capacity(data.dataset.len());
 
     for row in &data.dataset {
         let Some(parsed) = parse_single_cross_match_row(row) else {
@@ -1671,16 +1777,83 @@ async fn parse_cross_match_rows_with_oi(
         if let Some(mismatch) = classify_parsed_cross_match_row(&parsed, registry, timeframe) {
             details.push(mismatch);
         } else {
-            // SQL pre-filter caught it but Rust-side says it's fine (e.g., volume diff < 10%)
+            // SQL pre-filter caught it but Rust-side says it's fine
             continue;
-        }
-
-        if details.len() >= MAX_VIOLATION_DETAILS {
-            break;
         }
     }
 
+    if details.len() > MAX_VIOLATION_DETAILS {
+        warn!(
+            returned = details.len(),
+            ceiling = MAX_VIOLATION_DETAILS,
+            timeframe,
+            "cross-match Pass-A returned more rows than memory ceiling — operator should raise MAX_VIOLATION_DETAILS"
+        );
+    }
+
     details
+}
+
+/// Parses Pass-B rows (live candle with no historical twin) into
+/// `CrossMatchMismatch` records tagged as `"missing_historical"`.
+///
+/// Expected columns: `security_id, segment, ts, open, high, low, close, volume`
+/// from the live materialized view. No historical columns — this row
+/// class exists precisely because the historical row is absent.
+async fn parse_missing_historical_rows(
+    client: &Client,
+    base_url: &str,
+    query: &str,
+    registry: &InstrumentRegistry,
+    timeframe: &str,
+) -> Vec<CrossMatchMismatch> {
+    let data = match execute_query(client, base_url, query).await {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+
+    let mut out = Vec::with_capacity(data.dataset.len());
+
+    for row in &data.dataset {
+        if row.len() < 8 {
+            continue;
+        }
+        let sid = row[0].as_i64().unwrap_or(0);
+        let segment = row[1].as_str().unwrap_or("").to_string();
+        let ts_value = row[2].clone();
+        let timestamp_ist = format_timestamp_ist(&ts_value);
+
+        let open = row[3].as_f64().unwrap_or(0.0);
+        let high = row[4].as_f64().unwrap_or(0.0);
+        let low = row[5].as_f64().unwrap_or(0.0);
+        let close = row[6].as_f64().unwrap_or(0.0);
+        let volume = row[7].as_i64().unwrap_or(0);
+
+        let symbol = lookup_symbol(registry, sid);
+
+        out.push(CrossMatchMismatch {
+            symbol,
+            segment,
+            timeframe: timeframe.to_string(),
+            timestamp_ist,
+            mismatch_type: "missing_historical".to_string(),
+            hist_values: "[MISSING]".to_string(),
+            live_values: format!("O={} H={} L={} C={} V={}", open, high, low, close, volume),
+            diff_summary: String::new(),
+            field_deltas: Vec::new(),
+        });
+    }
+
+    if out.len() > MAX_VIOLATION_DETAILS {
+        warn!(
+            returned = out.len(),
+            ceiling = MAX_VIOLATION_DETAILS,
+            timeframe,
+            "cross-match Pass-B returned more rows than memory ceiling — operator should raise MAX_VIOLATION_DETAILS"
+        );
+    }
+
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -1761,8 +1934,15 @@ mod tests {
         let clause = w.where_clause();
         assert!(clause.starts_with("ts >= '"), "got: {clause}");
         assert!(
-            clause.contains(" AND ts <= '"),
-            "clause must be bounded both sides: {clause}"
+            clause.contains(" AND ts < '"),
+            "clause must be bounded both sides with exclusive end: {clause}"
+        );
+        // Ratchet: window end MUST be exclusive (`<`, not `<=`).
+        // Parthiban directive 2026-04-21 — 15:30:00 is not a valid candle
+        // timestamp (last intraday candle is 15:29).
+        assert!(
+            !clause.contains(" AND ts <= '"),
+            "clause must use exclusive end `<`, not inclusive `<=`: {clause}"
         );
         assert!(clause.contains("2026-04-20T09:15:00"));
         assert!(clause.contains("2026-04-20T12:00:00"));
@@ -1774,14 +1954,48 @@ mod tests {
         let w = TodayIstWindow::from_utc(now).unwrap();
         let clause = w.where_clause_aliased("h");
         assert!(clause.starts_with("h.ts >= '"), "got: {clause}");
-        assert!(clause.contains(" AND h.ts <= '"));
+        assert!(clause.contains(" AND h.ts < '"));
+        assert!(
+            !clause.contains(" AND h.ts <= '"),
+            "aliased clause must use exclusive end: {clause}"
+        );
         // Every `ts` reference must carry the `h.` alias — there should be
-        // exactly two (one for `>=`, one for `<=`) and no bare ones.
+        // exactly two (one for `>=`, one for `<`) and no bare ones.
         assert_eq!(
             clause.matches("h.ts").count(),
             2,
             "expected exactly 2 h.ts references: {clause}"
         );
+    }
+
+    #[test]
+    fn test_cross_match_scope_sql_contains_idx_i_and_nse_eq() {
+        // Parthiban directive 2026-04-21: scope = indices + stock equities only.
+        assert!(CROSS_MATCH_SCOPE_SQL.contains("NSE_EQ"));
+        assert!(CROSS_MATCH_SCOPE_SQL.contains("IDX_I"));
+        assert!(
+            !CROSS_MATCH_SCOPE_SQL.contains("NSE_FNO"),
+            "F&O must not appear in scope: {CROSS_MATCH_SCOPE_SQL}"
+        );
+    }
+
+    #[test]
+    fn test_cross_match_scope_aliased_prefixes_alias() {
+        let s = cross_match_scope_aliased("h");
+        assert!(s.starts_with("h.segment IN"), "got: {s}");
+        assert!(s.contains("NSE_EQ"));
+        assert!(s.contains("IDX_I"));
+    }
+
+    #[test]
+    fn test_today_ist_window_human_label_has_window() {
+        let now = utc_at_ist(2026, 4, 21, 15, 30);
+        let w = TodayIstWindow::from_utc(now).unwrap();
+        let label = w.human_label();
+        assert!(label.contains("2026-04-21"));
+        assert!(label.contains("09:15"));
+        assert!(label.contains("15:30"));
+        assert!(label.contains("IST"));
     }
 
     #[test]
@@ -2982,27 +3196,45 @@ mod tests {
 
     #[test]
     fn test_determine_cross_match_passed_all_good() {
-        assert!(determine_cross_match_passed(0, 100, 0));
+        // (mismatches, missing_live, missing_historical, total_compared, missing_views)
+        assert!(determine_cross_match_passed(0, 0, 0, 100, 0));
     }
 
     #[test]
     fn test_determine_cross_match_passed_with_mismatches() {
-        assert!(!determine_cross_match_passed(5, 100, 0));
+        assert!(!determine_cross_match_passed(5, 0, 0, 100, 0));
     }
 
     #[test]
     fn test_determine_cross_match_passed_zero_compared() {
-        assert!(!determine_cross_match_passed(0, 0, 0));
+        assert!(!determine_cross_match_passed(0, 0, 0, 0, 0));
     }
 
     #[test]
     fn test_determine_cross_match_passed_with_missing_views() {
-        assert!(!determine_cross_match_passed(0, 100, 2));
+        assert!(!determine_cross_match_passed(0, 0, 0, 100, 2));
     }
 
     #[test]
     fn test_determine_cross_match_passed_mismatches_and_missing_views() {
-        assert!(!determine_cross_match_passed(3, 100, 1));
+        assert!(!determine_cross_match_passed(3, 0, 0, 100, 1));
+    }
+
+    #[test]
+    fn test_determine_cross_match_passed_false_when_missing_live_nonzero() {
+        // 2026-04-21 bug class: gaps in live candles must fail OK, not silent-skip.
+        assert!(!determine_cross_match_passed(1, 1, 0, 100, 0));
+    }
+
+    #[test]
+    fn test_determine_cross_match_passed_false_when_missing_historical_nonzero() {
+        // 2026-04-21 bug class: missing historical must also fail OK.
+        assert!(!determine_cross_match_passed(1, 0, 1, 100, 0));
+    }
+
+    #[test]
+    fn test_determine_cross_match_passed_false_when_both_missing_counters_nonzero() {
+        assert!(!determine_cross_match_passed(4, 2, 2, 100, 0));
     }
 
     // -----------------------------------------------------------------------
@@ -3282,12 +3514,12 @@ mod tests {
     #[test]
     fn test_determine_cross_match_passed_zero_mismatches_zero_compared() {
         // Zero compared = fails even with zero mismatches
-        assert!(!determine_cross_match_passed(0, 0, 0));
+        assert!(!determine_cross_match_passed(0, 0, 0, 0, 0));
     }
 
     #[test]
     fn test_determine_cross_match_passed_large_values() {
-        assert!(determine_cross_match_passed(0, 1_000_000, 0));
+        assert!(determine_cross_match_passed(0, 0, 0, 1_000_000, 0));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -364,12 +364,16 @@ pub enum NotificationEvent {
         /// Total candles compared.
         candles_compared: usize,
         /// Human-readable IST session label, e.g. `"2026-04-20 09:15–15:30 IST"`.
-        /// Empty string when the caller doesn't have a window (legacy paths).
-        /// Surfaced on the first Telegram line so the operator immediately
-        /// sees which trading session this "OK" actually verifies — fixes
-        /// the 2026-04-20 ambiguity where an OK on 12 days of accumulated
-        /// data looked like today's session was clean.
         today_ist_label: String,
+        /// Number of IDX_I (index) instruments in the verified scope.
+        /// Defaults to 0 for legacy callers — renders a blank scope breakdown.
+        scope_indices: usize,
+        /// Number of NSE_EQ (stock equity) instruments in the verified scope.
+        scope_equities: usize,
+        /// Per-timeframe cell counts: `(timeframe, cells)` e.g.
+        /// `[("1m", 79125), ("5m", 15825)]`. Rendered as a monospace
+        /// coverage table in Telegram. Empty for legacy callers.
+        per_tf_cells: Vec<(String, usize)>,
     },
 
     /// Historical vs Live candle cross-match found mismatches.
@@ -381,10 +385,21 @@ pub enum NotificationEvent {
         /// Historical candle exists but no live data (WebSocket missed ticks).
         missing_live: usize,
         /// Pre-formatted mismatch detail lines for Telegram.
+        /// Full list — no truncation (Parthiban directive 2026-04-21).
+        /// Chunked by the notification layer when >4000 chars.
         mismatch_details: Vec<String>,
         /// Human-readable IST session label, e.g. `"2026-04-20 09:15–15:30 IST"`.
-        /// See `CandleCrossMatchPassed.today_ist_label`.
         today_ist_label: String,
+        /// Number of IDX_I (index) instruments in the verified scope.
+        scope_indices: usize,
+        /// Number of NSE_EQ (stock equity) instruments in the verified scope.
+        scope_equities: usize,
+        /// Live candle exists but historical doesn't (rare — Dhan REST gap).
+        missing_historical: usize,
+        /// Both present but OHLCV differs.
+        value_mismatches: usize,
+        /// Per-timeframe gap counts: `(timeframe, gaps)`.
+        per_tf_gaps: Vec<(String, usize)>,
     },
 
     /// Historical vs Live candle cross-match skipped — no live data in
@@ -496,6 +511,112 @@ pub enum NotificationEvent {
 
     /// Custom alert from any component.
     Custom { message: String },
+}
+
+// ---------------------------------------------------------------------------
+// Cross-match Telegram rendering (extracted — Parthiban 2026-04-21)
+// ---------------------------------------------------------------------------
+
+fn render_scope_line(scope_indices: usize, scope_equities: usize) -> String {
+    let total = scope_indices.saturating_add(scope_equities);
+    if total == 0 {
+        return "🎯 Scope    Indices + Stock Equities only\n            (F&O not in Dhan historical API)".to_string();
+    }
+    format!(
+        "🎯 Scope    Indices + Stock Equities only\n            (F&O not in Dhan historical API)\n📊 Universe {total} instruments\n            • {scope_indices} indices  • {scope_equities} equities"
+    )
+}
+
+fn render_window_line(today_ist_label: &str) -> String {
+    if today_ist_label.is_empty() {
+        "📅 Window   (not supplied)".to_string()
+    } else {
+        format!("📅 Window   {today_ist_label}")
+    }
+}
+
+fn render_cross_match_ok(
+    timeframes_checked: usize,
+    candles_compared: usize,
+    today_ist_label: &str,
+    scope_indices: usize,
+    scope_equities: usize,
+    per_tf_cells: &[(String, usize)],
+) -> String {
+    let mut out = String::new();
+    out.push_str("✅ <b>CROSS-MATCH OK</b>\n\n");
+    out.push_str(&render_window_line(today_ist_label));
+    out.push_str("\n\n");
+    out.push_str(&render_scope_line(scope_indices, scope_equities));
+    out.push_str("\n\n ─── COVERAGE ──────────────────────\n<pre>");
+    if per_tf_cells.is_empty() {
+        out.push_str(&format!(
+            "Timeframes: {timeframes_checked}  Candles: {candles_compared}"
+        ));
+    } else {
+        out.push_str("   TF  │  Cells    │ Gaps │ Diffs\n");
+        out.push_str("  ─────┼───────────┼──────┼───────\n");
+        for (tf, cells) in per_tf_cells {
+            out.push_str(&format!(
+                "  {tf:>3}  │ {cells:>9}  │   0  │   0\n",
+                tf = tf,
+                cells = cells
+            ));
+        }
+    }
+    out.push_str("</pre>\n ────────────────────────────────────\n\n");
+    out.push_str("✓ All OHLCV values match bit-for-bit\n");
+    out.push_str("  zero tolerance · precision-verified");
+    out
+}
+
+#[allow(clippy::too_many_arguments)] // APPROVED: struct-equivalent unpacking of event fields; grouping adds a named struct for a private helper.
+fn render_cross_match_failed(
+    candles_compared: usize,
+    mismatches: usize,
+    missing_live: usize,
+    missing_historical: usize,
+    value_mismatches: usize,
+    mismatch_details: &[String],
+    today_ist_label: &str,
+    scope_indices: usize,
+    scope_equities: usize,
+    per_tf_gaps: &[(String, usize)],
+) -> String {
+    let mut out = String::new();
+    out.push_str("❌ <b>CROSS-MATCH FAILED</b>\n\n");
+    out.push_str(&render_window_line(today_ist_label));
+    out.push_str("\n\n");
+    out.push_str(&render_scope_line(scope_indices, scope_equities));
+    out.push_str("\n\n ─── SUMMARY ───────────────────────\n<pre>");
+    out.push_str(&format!("   🔴 Missing live       {missing_live:>6}\n"));
+    out.push_str(&format!(
+        "   🔴 Missing historical {missing_historical:>6}\n"
+    ));
+    out.push_str(&format!("   🟡 Value mismatches   {value_mismatches:>6}\n"));
+    out.push_str("  ─────────────────────────────────\n");
+    out.push_str(&format!("      Total issues       {mismatches:>6}\n"));
+    out.push_str(&format!("      Cells compared     {candles_compared:>6}"));
+    out.push_str("</pre>\n");
+
+    if !per_tf_gaps.is_empty() {
+        out.push_str("\n ─── GAPS BY TIMEFRAME ─────────────\n<pre>");
+        for (tf, gaps) in per_tf_gaps {
+            out.push_str(&format!("   {tf:>3}   {gaps:>5}\n", tf = tf, gaps = gaps));
+        }
+        out.push_str("</pre>\n");
+    }
+
+    if !mismatch_details.is_empty() {
+        out.push_str("\n📋 <b>Full list below</b>");
+        out.push_str("\n   Order: MISSING LIVE → VALUE DIFF → MISSING HIST\n\n<pre>");
+        for line in mismatch_details {
+            out.push_str(line);
+            out.push('\n');
+        }
+        out.push_str("</pre>\n🏁 End of report");
+    }
+    out
 }
 
 impl NotificationEvent {
@@ -884,49 +1005,40 @@ impl NotificationEvent {
                 timeframes_checked,
                 candles_compared,
                 today_ist_label,
-            } => {
-                let header = if today_ist_label.is_empty() {
-                    String::new()
-                } else {
-                    format!("\n<b>TODAY ONLY:</b> {today_ist_label}")
-                };
-                format!(
-                    "<b>Historical vs Live cross-match OK</b>{header}\nTimeframes: {timeframes_checked} | Candles compared: {candles_compared}\nAll OHLCV values match exactly (zero tolerance, precision-verified)"
-                )
-            }
+                scope_indices,
+                scope_equities,
+                per_tf_cells,
+            } => render_cross_match_ok(
+                *timeframes_checked,
+                *candles_compared,
+                today_ist_label,
+                *scope_indices,
+                *scope_equities,
+                per_tf_cells,
+            ),
             Self::CandleCrossMatchFailed {
                 candles_compared,
                 mismatches,
                 missing_live,
                 mismatch_details,
                 today_ist_label,
-            } => {
-                let header = if today_ist_label.is_empty() {
-                    String::new()
-                } else {
-                    format!("\n<b>TODAY ONLY:</b> {today_ist_label}")
-                };
-                let mut msg = format!(
-                    "<b>Historical vs Live cross-match FAILED</b>{header}\nCompared: {candles_compared} | Mismatches: {mismatches}"
-                );
-                if *missing_live > 0 {
-                    msg.push_str(&format!("\nMissing live: {missing_live}"));
-                }
-                if !mismatch_details.is_empty() {
-                    msg.push_str("\n\n<b>Mismatches (every timestamp with OHLCV diff):</b>");
-                    let show_count = mismatch_details.len().min(50);
-                    for line in &mismatch_details[..show_count] {
-                        msg.push_str(&format!("\n{line}"));
-                    }
-                    if mismatch_details.len() > 50 {
-                        let remaining = mismatch_details.len().saturating_sub(50);
-                        msg.push_str(&format!(
-                            "\n... +{remaining} more (full list in structured logs — query Loki/Grafana)"
-                        ));
-                    }
-                }
-                msg
-            }
+                scope_indices,
+                scope_equities,
+                missing_historical,
+                value_mismatches,
+                per_tf_gaps,
+            } => render_cross_match_failed(
+                *candles_compared,
+                *mismatches,
+                *missing_live,
+                *missing_historical,
+                *value_mismatches,
+                mismatch_details,
+                today_ist_label,
+                *scope_indices,
+                *scope_equities,
+                per_tf_gaps,
+            ),
             Self::CandleCrossMatchSkipped {
                 reason,
                 candles_compared,
@@ -1570,12 +1682,16 @@ mod tests {
         let event = NotificationEvent::CandleCrossMatchPassed {
             timeframes_checked: 5,
             candles_compared: 187500,
-            today_ist_label: String::new(),
+            today_ist_label: "2026-04-21 09:15→15:30 IST".to_string(),
+            scope_indices: 5,
+            scope_equities: 206,
+            per_tf_cells: vec![("1m".to_string(), 79125), ("5m".to_string(), 15825)],
         };
         let msg = event.to_message();
-        assert!(msg.contains("cross-match OK"));
-        assert!(msg.contains("187500"));
-        assert!(msg.contains("tolerance"));
+        assert!(msg.contains("CROSS-MATCH OK"));
+        assert!(msg.contains("79125"));
+        assert!(msg.contains("bit-for-bit"));
+        assert!(msg.contains("<pre>"));
     }
 
     #[test]
@@ -1585,16 +1701,23 @@ mod tests {
             mismatches: 12,
             missing_live: 8,
             mismatch_details: vec![
-                "\u{2022} RELIANCE (NSE_EQ) 1m @ 2026-03-18 10:15 IST\n  Hist: O=2450.0 H=2465.0\n  Live: O=2450.0 H=2463.5\n  Diff: H(-1.5)".to_string(),
+                " RELIANCE    NSE_EQ  1m   10:15:00   (live missing)".to_string(),
             ],
-            today_ist_label: String::new(),
+            today_ist_label: "2026-04-21 09:15→15:30 IST".to_string(),
+            scope_indices: 5,
+            scope_equities: 206,
+            missing_historical: 1,
+            value_mismatches: 3,
+            per_tf_gaps: vec![("1m".to_string(), 9), ("5m".to_string(), 3)],
         };
         let msg = event.to_message();
-        assert!(msg.contains("cross-match FAILED"));
-        assert!(msg.contains("Mismatches: 12"));
-        assert!(msg.contains("Missing live: 8"));
+        assert!(msg.contains("CROSS-MATCH FAILED"));
+        assert!(msg.contains("Missing live"));
+        assert!(msg.contains("Missing historical"));
+        assert!(msg.contains("Value mismatches"));
+        assert!(msg.contains("Total issues"));
         assert!(msg.contains("RELIANCE"));
-        assert!(msg.contains("H(-1.5)"));
+        assert!(msg.contains("(live missing)"));
     }
 
     #[test]
@@ -1605,6 +1728,11 @@ mod tests {
             missing_live: 8,
             mismatch_details: vec![],
             today_ist_label: String::new(),
+            scope_indices: 0,
+            scope_equities: 0,
+            missing_historical: 0,
+            value_mismatches: 4,
+            per_tf_gaps: vec![],
         };
         assert_eq!(event.severity(), Severity::High);
     }
@@ -1615,6 +1743,9 @@ mod tests {
             timeframes_checked: 5,
             candles_compared: 187500,
             today_ist_label: String::new(),
+            scope_indices: 0,
+            scope_equities: 0,
+            per_tf_cells: vec![],
         };
         assert_eq!(event.severity(), Severity::Low);
     }
@@ -2098,15 +2229,23 @@ mod tests {
 
     #[test]
     fn test_cross_match_failed_no_missing_live() {
+        // Missing-live is always rendered in the new format — but as `0` in the
+        // SUMMARY block. The top-level FAILED message still appears.
         let event = NotificationEvent::CandleCrossMatchFailed {
             candles_compared: 1000,
             mismatches: 5,
             missing_live: 0,
             mismatch_details: vec![],
             today_ist_label: String::new(),
+            scope_indices: 0,
+            scope_equities: 0,
+            missing_historical: 0,
+            value_mismatches: 5,
+            per_tf_gaps: vec![],
         };
         let msg = event.to_message();
-        assert!(!msg.contains("Missing live"));
+        assert!(msg.contains("FAILED"));
+        assert!(msg.contains("Missing live       "));
     }
 
     #[test]
@@ -2117,10 +2256,15 @@ mod tests {
             missing_live: 0,
             mismatch_details: vec![],
             today_ist_label: String::new(),
+            scope_indices: 0,
+            scope_equities: 0,
+            missing_historical: 0,
+            value_mismatches: 0,
+            per_tf_gaps: vec![],
         };
         let msg = event.to_message();
-        // The header always contains "Mismatches: N", but the details section should be absent
-        assert!(!msg.contains("<b>Mismatches:</b>"));
+        // No per-row list when mismatch_details empty.
+        assert!(!msg.contains("📋"));
     }
 
     #[test]
@@ -2204,10 +2348,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cross_match_failed_truncates_long_mismatch_details() {
-        // Truncation limit raised to 50 in a previous refactor; update the
-        // test to match. Test now uses 60 entries so the +10 more overflow
-        // is still exercised.
+    fn test_cross_match_failed_shows_every_mismatch_no_truncation() {
+        // Parthiban directive 2026-04-21: FULL LIST, no "+N more". 60 rows
+        // must all appear in the Telegram body.
         let details: Vec<String> = (0..60).map(|i| format!("mismatch {i}")).collect();
         let event = NotificationEvent::CandleCrossMatchFailed {
             candles_compared: 100,
@@ -2215,12 +2358,21 @@ mod tests {
             missing_live: 0,
             mismatch_details: details,
             today_ist_label: String::new(),
+            scope_indices: 0,
+            scope_equities: 0,
+            missing_historical: 0,
+            value_mismatches: 60,
+            per_tf_gaps: vec![],
         };
         let msg = event.to_message();
         assert!(msg.contains("mismatch 0"));
         assert!(msg.contains("mismatch 49"));
-        assert!(!msg.contains("mismatch 50"));
-        assert!(msg.contains("+10 more"));
+        assert!(msg.contains("mismatch 50"));
+        assert!(msg.contains("mismatch 59"));
+        assert!(
+            !msg.contains("more (full list"),
+            "no truncation suffix allowed"
+        );
     }
 
     // =====================================================================

--- a/crates/core/src/notification/service.rs
+++ b/crates/core/src/notification/service.rs
@@ -308,16 +308,29 @@ impl NotificationService {
                 // straight to Claude Code for debugging.
                 let message = format!("{} {}", severity.tag(), event.to_message());
 
-                // Always: Telegram
+                // Always: Telegram. Messages > 4000 chars get split into
+                // ordered chunks per Telegram's 4096-char hard limit so
+                // the cross-match FAILED report (potentially thousands of
+                // rows) can be delivered in full — Parthiban directive
+                // 2026-04-21: no truncation, full list always visible.
                 {
                     let token = bot_token.clone();
                     let chat_id = chat_id.clone();
                     let client = http_client.clone();
                     let base_url = telegram_api_base_url.clone();
-                    let msg = message.clone();
+                    let chunks = split_message_for_telegram(&message);
 
                     tokio::spawn(async move {
-                        send_telegram_message(&client, &base_url, &token, &chat_id, &msg).await;
+                        let total = chunks.len();
+                        for (idx, chunk) in chunks.iter().enumerate() {
+                            let body = if total > 1 {
+                                format!("(Part {}/{})\n{chunk}", idx.saturating_add(1), total)
+                            } else {
+                                chunk.clone()
+                            };
+                            send_telegram_message(&client, &base_url, &token, &chat_id, &body)
+                                .await;
+                        }
                     });
                 }
 
@@ -346,6 +359,65 @@ impl NotificationService {
 // ---------------------------------------------------------------------------
 // Internal HTTP Send
 // ---------------------------------------------------------------------------
+
+/// Telegram's hard message cap is 4096 characters. We target a safe ceiling
+/// below that so the `(Part i/N)` prefix + any HTML tag pair doesn't push
+/// the chunk over.
+pub(crate) const TELEGRAM_CHUNK_LIMIT_CHARS: usize = 3800;
+
+/// Splits a potentially huge Telegram message into ordered chunks, each
+/// ≤ `TELEGRAM_CHUNK_LIMIT_CHARS` characters. Splits on newline boundaries
+/// (never mid-row). Preserves open/close `<pre>` HTML tags across chunks
+/// so the monospace formatting stays intact when Telegram re-parses each
+/// chunk independently.
+///
+/// Parthiban directive 2026-04-21: cross-match FAILED report must show
+/// every violation — no truncation. On a heavy-gap day this can produce
+/// thousands of rows; chunking delivers them all as sequential Telegram
+/// messages.
+pub(crate) fn split_message_for_telegram(full: &str) -> Vec<String> {
+    if full.chars().count() <= TELEGRAM_CHUNK_LIMIT_CHARS {
+        return vec![full.to_string()];
+    }
+
+    let mut chunks: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut inside_pre = false;
+
+    for line in full.split_inclusive('\n') {
+        let would_overflow = current.chars().count().saturating_add(line.chars().count())
+            > TELEGRAM_CHUNK_LIMIT_CHARS;
+
+        if would_overflow && !current.is_empty() {
+            // Close any open <pre> before emitting the chunk so Telegram
+            // doesn't render the rest of the message as plain text.
+            if inside_pre {
+                current.push_str("</pre>");
+            }
+            chunks.push(std::mem::take(&mut current));
+            // Re-open <pre> at the top of the next chunk for continuity.
+            if inside_pre {
+                current.push_str("<pre>");
+            }
+        }
+
+        current.push_str(line);
+
+        // Track <pre> state so split/resume keeps monospace contiguous.
+        if line.contains("<pre>") {
+            inside_pre = true;
+        }
+        if line.contains("</pre>") {
+            inside_pre = false;
+        }
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+
+    chunks
+}
 
 /// Posts a message to the Telegram Bot API.
 ///
@@ -496,6 +568,89 @@ mod tests {
     fn test_disabled_service_is_not_active() {
         let service = NotificationService::disabled();
         assert!(!service.is_active());
+    }
+
+    // -----------------------------------------------------------------------
+    // split_message_for_telegram — chunking for cross-match full lists
+    // Parthiban directive 2026-04-21: full report, chunked on newline
+    // boundaries, never mid-row, preserves <pre> monospace wrappers.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_split_message_for_telegram_below_threshold_returns_single() {
+        let msg = "tiny";
+        assert_eq!(split_message_for_telegram(msg).len(), 1);
+    }
+
+    #[test]
+    fn test_chunk_below_threshold_returns_single() {
+        let msg = "short message under the limit";
+        let out = split_message_for_telegram(msg);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0], msg);
+    }
+
+    #[test]
+    fn test_chunk_splits_on_newline_boundary() {
+        // Build a message with many short lines that forces multiple chunks.
+        let line = "A".repeat(100);
+        let mut body = String::new();
+        for _ in 0..80 {
+            body.push_str(&line);
+            body.push('\n');
+        }
+        let out = split_message_for_telegram(&body);
+        assert!(
+            out.len() > 1,
+            "message of ~8000 chars must split into multiple chunks"
+        );
+        // Every chunk stays below the configured ceiling.
+        for c in &out {
+            assert!(
+                c.chars().count() <= TELEGRAM_CHUNK_LIMIT_CHARS,
+                "chunk size {} > limit {TELEGRAM_CHUNK_LIMIT_CHARS}",
+                c.chars().count()
+            );
+        }
+    }
+
+    #[test]
+    fn test_chunk_preserves_line_order() {
+        // Numbered lines so we can verify the concatenation preserves order
+        // even across chunk boundaries.
+        let mut body = String::new();
+        for i in 0..500 {
+            body.push_str(&format!("row-{i:03} {}\n", "x".repeat(60)));
+        }
+        let out = split_message_for_telegram(&body);
+        let joined = out.join("");
+        // Expected order: row-000, row-001, ..., row-499 (as substrings).
+        let idx_000 = joined.find("row-000").expect("row-000 missing");
+        let idx_499 = joined.find("row-499").expect("row-499 missing");
+        assert!(idx_000 < idx_499, "order broken across chunks");
+    }
+
+    #[test]
+    fn test_chunk_preserves_pre_tag_pairs_across_boundary() {
+        // A message that opens <pre>, has many lines, and closes </pre> must
+        // re-open <pre> at every chunk boundary so Telegram's HTML parser
+        // treats every chunk as monospace.
+        let mut body = String::from("<pre>");
+        for _ in 0..60 {
+            body.push_str(&"B".repeat(100));
+            body.push('\n');
+        }
+        body.push_str("</pre>");
+        let out = split_message_for_telegram(&body);
+        assert!(out.len() >= 2);
+        // Every chunk must contain a <pre> opener. Every chunk except the
+        // last must contain a </pre> closer emitted by the splitter.
+        for (idx, c) in out.iter().enumerate() {
+            assert!(c.contains("<pre>"), "chunk {idx} missing <pre>");
+            if idx < out.len() - 1 {
+                assert!(c.contains("</pre>"), "chunk {idx} must self-close <pre>");
+            }
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/core/tests/cross_match_exhaustive_guard.rs
+++ b/crates/core/tests/cross_match_exhaustive_guard.rs
@@ -1,0 +1,126 @@
+//! Ratchet: cross-match must be exhaustive across 09:15→15:30 IST for
+//! indices + stock equities.
+//!
+//! # Why (2026-04-21)
+//!
+//! Live 15:47 IST alert reported "OK — 116,162 candles match" despite the
+//! app restarting mid-day and leaving huge gaps in live materialized
+//! views. Root causes in `crates/core/src/historical/cross_verify.rs`:
+//!
+//! 1. `determine_cross_match_passed` ignored `missing_live`/`missing_historical`
+//! 2. Pass-B (missing_historical) was never actually run
+//! 3. Detail query had `LIMIT` truncating the real mismatch count
+//! 4. No scope filter — F&O (which Dhan doesn't even serve historically)
+//!    was implicitly in the expected grid
+//! 5. Window end was `<=` instead of `<` (15:30 is exclusive)
+//!
+//! This ratchet file source-scans cross_verify.rs so those regressions
+//! cannot be silently reintroduced.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn read(rel: &str) -> String {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p.push(rel);
+    fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+#[test]
+fn cross_verify_source_has_pass_b_for_missing_historical() {
+    let src = read("crates/core/src/historical/cross_verify.rs");
+    assert!(
+        src.contains("parse_missing_historical_rows"),
+        "Pass-B query helper `parse_missing_historical_rows` must exist so \
+         missing_historical is actually populated (was silently zero before I12)."
+    );
+    assert!(
+        src.contains("missing_historical"),
+        "cross_verify.rs MUST track missing_historical as a first-class \
+         category — Parthiban directive 2026-04-21."
+    );
+}
+
+#[test]
+fn cross_verify_source_has_scope_filter_to_idx_i_and_nse_eq() {
+    let src = read("crates/core/src/historical/cross_verify.rs");
+    assert!(
+        src.contains("CROSS_MATCH_SCOPE_SQL"),
+        "Scope constant `CROSS_MATCH_SCOPE_SQL` must exist."
+    );
+    assert!(
+        src.contains("NSE_EQ") && src.contains("IDX_I"),
+        "Scope filter must include both NSE_EQ and IDX_I."
+    );
+    assert!(
+        src.contains("cross_match_scope_aliased"),
+        "Aliased scope helper must exist for `h.segment IN (...)` / `m.segment IN (...)`."
+    );
+}
+
+#[test]
+fn cross_verify_window_end_is_exclusive() {
+    let src = read("crates/core/src/historical/cross_verify.rs");
+    // The where_clause MUST build `ts < ...` — there's no 15:30:00 candle
+    // (last 1m candle is 15:29:00).
+    assert!(
+        src.contains("\"ts >= {start} AND ts < {end}\"")
+            || src.contains("ts >= {start} AND ts < {end}"),
+        "where_clause must emit `ts < end` (exclusive), not `ts <= end`."
+    );
+}
+
+#[test]
+fn cross_verify_pass_a_detail_query_has_no_limit() {
+    // Parthiban directive 2026-04-21: the cross-match Pass-A detail query
+    // (historical LEFT JOIN live, fetching value_diff + missing_live rows)
+    // must NOT be LIMIT-capped — we need every violation for the exhaustive
+    // Telegram report. Regression = a day with >N gaps shows <N in Telegram.
+    //
+    // Narrow scan: extract the region containing the Pass-A query and
+    // assert no `LIMIT {}` substring inside it. The candle-integrity
+    // verifier uses LIMIT for a different purpose (OHLC/data scans) — we
+    // don't touch those.
+    let src = read("crates/core/src/historical/cross_verify.rs");
+    let marker = "// Pass-A: historical LEFT JOIN live";
+    let start = src
+        .find(marker)
+        .unwrap_or_else(|| panic!("Pass-A marker comment missing — refactor broke the ratchet"));
+    let end_marker = "// Pass-B:";
+    let end = src[start..]
+        .find(end_marker)
+        .map(|rel| start + rel)
+        .unwrap_or_else(|| panic!("Pass-B marker comment missing — refactor broke the ratchet"));
+    let pass_a_region = &src[start..end];
+    assert!(
+        !pass_a_region.contains("LIMIT {}"),
+        "Pass-A detail query must not be LIMIT-capped — full list required. \
+         Region scanned: {pass_a_region}"
+    );
+    assert!(
+        !pass_a_region.contains("LIMIT 500"),
+        "Pass-A detail query must not hardcode LIMIT 500. Region: {pass_a_region}"
+    );
+}
+
+#[test]
+fn cross_verify_determine_passed_requires_missing_counters_zero() {
+    let src = read("crates/core/src/historical/cross_verify.rs");
+    // The fixed `determine_cross_match_passed` signature must take
+    // missing_live AND missing_historical — both must appear in its body.
+    assert!(
+        src.contains("total_missing_live: usize"),
+        "determine_cross_match_passed must accept total_missing_live"
+    );
+    assert!(
+        src.contains("total_missing_historical: usize"),
+        "determine_cross_match_passed must accept total_missing_historical"
+    );
+    assert!(
+        src.contains("total_missing_live == 0") && src.contains("total_missing_historical == 0"),
+        "determine_cross_match_passed body MUST check both missing counters == 0. \
+         Regression = OK fires despite live gaps."
+    );
+}


### PR DESCRIPTION
## Problem (live production bug, 2026-04-21 15:47 IST)

Telegram said:
```
✅ [LOW] Historical vs Live cross-match OK
TODAY ONLY: 2026-04-21 09:15–15:30 IST
Timeframes: 4 | Candles compared: 116162
All OHLCV values match exactly (zero tolerance, precision-verified)
```

…even though the app had restarted mid-day and the live `candles_*` materialized views had huge holes. Three bugs in `crates/core/src/historical/cross_verify.rs` conspired to produce the false OK:

1. `determine_cross_match_passed` ignored `missing_live` and `missing_historical` — it only required `total_mismatches == 0`.
2. The detail-query had `LIMIT MAX_VIOLATION_DETAILS`, and `total_mismatches = details.len()` capped at that LIMIT.
3. `missing_historical` was declared as a local but never populated — there was no Pass-B query.

## Fix

### A. Window end exclusive (`ts < 15:30`, not `<=`)
Last 1m candle is 15:29:00 — there is no 15:30:00 candle.

### B. Scope filter to IDX_I + NSE_EQ only
New `CROSS_MATCH_SCOPE_SQL` constant threaded into every cross-match query. F&O isn't served by Dhan's historical REST API so it's excluded from the expected grid — cross-match has never been meaningful for F&O.

### C. Pass-B for `missing_historical`
New `parse_missing_historical_rows` helper + a second query per timeframe (`live LEFT JOIN historical WHERE h.security_id IS NULL`) populates `total_missing_historical` as a first-class category.

### D. No LIMIT on the detail query
Pass-A detail query no longer clamps at `MAX_VIOLATION_DETAILS`. The constant stays as a memory-safety ceiling with a WARN log, not silent truncation.

### E. `determine_cross_match_passed` now blocks on ANY hole
```rust
total_mismatches == 0
    && total_missing_live == 0
    && total_missing_historical == 0
    && total_compared > 0
    && missing_views == 0
```

### F. Rich Telegram format (emoji anchors + `<pre>` monospace tables)
See sample below.

### G. Telegram chunking (no truncation — full list always delivered)
`split_message_for_telegram` splits huge messages on newline boundaries, preserves `<pre>` tag continuity, caller sends sequentially with `(Part i/N)` prefixes. A day with 1,247 missing-live rows → ~28 ordered Telegram messages, every row visible.

### H. Scope-aware category grouping
`format_cross_match_details_grouped` emits compact rows grouped `MISSING LIVE → VALUE DIFF → MISSING HIST`.

## Sample Telegram output (FAILED)

```
❌ CROSS-MATCH FAILED

📅 Window   2026-04-21 09:15→15:30 IST
🎯 Scope    Indices + Stock Equities only
            (F&O not in Dhan historical API)
📊 Universe 211 instruments
            • 5 indices  • 206 equities

 ─── SUMMARY ───────────────────────
   🔴 Missing live       1,247
   🔴 Missing historical     3
   🟡 Value mismatches      17
  ─────────────────────────────────
      Total issues       1,267
      Cells compared   101,272

 ─── GAPS BY TIMEFRAME ─────────────
    1m  1,105
    5m    148
   15m     36
   60m     11
    1d      0

📋 Full list below
   Order: MISSING LIVE → VALUE DIFF → MISSING HIST

📭 MISSING LIVE (1,247) — historical has candle, live doesn't
 Symbol      Seg     TF   Time
 ──────────────────────────────────────
 RELIANCE    NSE_EQ  1m   12:00:00   (live missing)
 RELIANCE    NSE_EQ  1m   12:01:00   (live missing)
 ...

💱 VALUE MISMATCH (17) — both present, OHLCV differs
 Symbol      Seg     TF   Time      Δ
 ──────────────────────────────────────
 BANKNIFTY   IDX_I   5m   11:15:00   close: 52340.25 → 52340.20
 ...

📤 MISSING HISTORICAL (3) — live has candle, historical doesn't
 Symbol      Seg     TF   Time
 ──────────────────────────────────────
 HDFCBANK    NSE_EQ  1m   15:29:00   (historical missing)

🏁 End of report
```

## Verification

```
cargo test -p tickvault-core --lib historical::cross_verify        → 184/184 ✅
cargo test -p tickvault-core --lib notification                    → 200/200 ✅
cargo test -p tickvault-core --test cross_match_exhaustive_guard   → 5/5 ✅
cargo test --workspace --lib                                       → 6,855/6,855 ✅
cargo check --workspace                                            → clean
```

## Test plan

- [x] Unit: all existing cross-match tests rebased onto new `determine_cross_match_passed` signature
- [x] Unit: 3 new assertions for `missing_live > 0`, `missing_historical > 0`, both
- [x] Unit: 4 new chunking tests (below-threshold single, newline split, order preservation, `<pre>` continuity)
- [x] Unit: `format_cross_match_details_grouped` section ordering + empty input
- [x] Ratchet: `crates/core/tests/cross_match_exhaustive_guard.rs` — 5 source-scans (Pass-B, scope filter, exclusive window, no LIMIT, `determine` signature)
- [ ] CI green
- [ ] Manual observation: next post-market run should fire FAILED with a multi-part Telegram stream if any gaps exist

## Scope notes

- LIVE-FEED-PURITY intact — `ticks` table still populated exclusively from live WebSocket.
- `MAX_VIOLATION_DETAILS` (500) retained as a memory-safety ceiling with a WARN log, not silent truncation.
- Once-per-day success marker unchanged — the fixed FAILED path will no longer write the marker so the next restart retries from scratch.

https://claude.ai/code/session_01Cs3Z9DzSVjGj11c3iFtnxq