### PR TITLE
feat: items B + real-C + I + Q — defer boot depth subscribe, 09:13 dispatcher, guard, benchmark

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2369,12 +2369,21 @@ async fn main() -> Result<()> {
                     Vec::new()
                 };
 
+                // Plan item B.2 (2026-04-23): previously we skipped spawning
+                // depth connections when no instruments could be built at
+                // boot (pre-market LTPs unavailable). This produced zero
+                // depth subscriptions until next restart. Now we ALWAYS
+                // spawn — an empty instrument list puts the connection in
+                // DEFERRED mode (socket up, no subscribe sent) and the
+                // 09:13 dispatcher (real-C) sends InitialSubscribe20 once
+                // the 09:12 close is available in the preopen buffer.
+                // 200-level gets the same treatment via `Option<u32>` for
+                // the ATM CE/PE security_id below.
                 if instruments_for_underlying.is_empty() {
                     info!(
                         underlying,
-                        "20-level depth: no instruments selected — skipping"
+                        "20-level depth: no instruments selected at boot — spawning DEFERRED connection, 09:13 dispatcher will InitialSubscribe20"
                     );
-                    continue;
                 }
 
                 // Extract ATM CE + ATM PE for 200-level depth.
@@ -2748,18 +2757,25 @@ async fn main() -> Result<()> {
                 // O(1) EXEMPT: begin — boot-time 200-level depth setup (max 2 spawns per underlying)
                 // Only NIFTY + BANKNIFTY get 200-level (4 connections within Dhan's 5 limit).
                 if *underlying == "NIFTY" || *underlying == "BANKNIFTY" {
-                    // Pair the precise CE/PE labels with their security_ids so every
-                    // downstream log line + Telegram alert identifies the exact
-                    // contract (e.g. `NIFTY-Apr2026-22500-CE`).
-                    let atm_ce_entry = atm_ce.as_ref().map(|(sid, lbl)| ("CE", *sid, lbl.clone()));
-                    let atm_pe_entry = atm_pe.as_ref().map(|(sid, lbl)| ("PE", *sid, lbl.clone()));
-                    for opt_entry in [atm_ce_entry, atm_pe_entry] {
+                    // Plan item B.2 (2026-04-23): when boot-time ATM is
+                    // unavailable (pre-market deploy before 09:00 LTPs
+                    // arrive), spawn the 200-level connection in DEFERRED
+                    // mode with `depth200_sid = None`. The 09:13 dispatcher
+                    // (real-C) will send InitialSubscribe200 once the
+                    // 09:12 close is in the preopen buffer. Label carries
+                    // "-deferred" so Telegrams + logs reflect the state.
+                    // No ERROR-level alert here — pre-market missing ATM
+                    // is EXPECTED, not a planner bug.
+                    let atm_ce_entry: (&str, Option<u32>, String) = match atm_ce.as_ref() {
+                        Some((sid, lbl)) => ("CE", Some(*sid), lbl.clone()), // O(1) EXEMPT: boot-time
+                        None => ("CE", None, format!("{underlying}-CE-deferred")), // O(1) EXEMPT: boot-time
+                    };
+                    let atm_pe_entry: (&str, Option<u32>, String) = match atm_pe.as_ref() {
+                        Some((sid, lbl)) => ("PE", Some(*sid), lbl.clone()), // O(1) EXEMPT: boot-time
+                        None => ("PE", None, format!("{underlying}-PE-deferred")), // O(1) EXEMPT: boot-time
+                    };
+                    for opt_entry in [Some(atm_ce_entry), Some(atm_pe_entry)] {
                         let Some((opt_label, depth200_sid, depth200_label)) = opt_entry else {
-                            // ERROR triggers Telegram — ATM None for major index is actionable
-                            error!(
-                                underlying,
-                                "200-level depth: no ATM CE/PE found — skipping (check subscription planner)"
-                            );
                             continue;
                         };
 
@@ -2767,12 +2783,15 @@ async fn main() -> Result<()> {
                         let depth200_client_id = ws_client_id.clone();
                         let depth200_segment = tickvault_common::types::ExchangeSegment::NseFno;
 
+                        // depth200_sid is Option<u32> (Item B.2): Some = ATM
+                        // available at boot, None = deferred until 09:13.
+                        let sid_log: i64 = depth200_sid.map_or(-1, i64::from);
                         info!(
                             underlying,
                             option = opt_label,
-                            security_id = depth200_sid,
+                            security_id = sid_log,
                             contract = %depth200_label,
-                            "spawning 200-level depth connection (contract={depth200_label}, sid={depth200_sid})"
+                            "spawning 200-level depth connection (contract={depth200_label}, sid={sid_log})"
                         );
 
                         let (tx200, mut rx200) = tokio::sync::mpsc::channel::<bytes::Bytes>(1024);
@@ -2868,8 +2887,13 @@ async fn main() -> Result<()> {
                         let d200_reconnect_notifier = Some(notifier.clone());
                         let d200_label_for_disconnect = depth200_label.clone();
                         let d200_label_for_signal = depth200_label.clone();
-                        let d200_sid_for_disconnect = depth200_sid;
-                        let d200_sid_for_signal = depth200_sid;
+                        // Use 0 sentinel for the Telegram/disconnect event
+                        // when deferred (pre-09:13 boot) — the event types
+                        // take u32 and the 09:13 dispatcher will log the
+                        // real sid via InitialSubscribe200 before any
+                        // disconnect notification is meaningful.
+                        let d200_sid_for_disconnect: u32 = depth200_sid.unwrap_or(0);
+                        let d200_sid_for_signal: u32 = depth200_sid.unwrap_or(0);
                         let d200_wal_spill = ws_frame_spill.clone();
                         let (d200_signal_tx, d200_signal_rx) =
                             tokio::sync::oneshot::channel::<()>();
@@ -2895,7 +2919,10 @@ async fn main() -> Result<()> {
                                     depth200_token,
                                     depth200_client_id,
                                     depth200_segment,
-                                    Some(depth200_sid),
+                                    // depth200_sid is already Option<u32>
+                                    // (Item B.2): None = deferred, Some =
+                                    // boot-time ATM available.
+                                    depth200_sid,
                                     depth200_label,
                                     tx200,
                                     Some(d200_signal_tx),
@@ -3308,6 +3335,18 @@ async fn main() -> Result<()> {
                 let anchor_buffer = std::sync::Arc::clone(&preopen_buffer);
                 let anchor_universe = depth_anchor_universe;
                 let anchor_calendar = std::sync::Arc::clone(&trading_calendar);
+                // Plan item real-C (2026-04-23): the 09:13 task now also
+                // dispatches InitialSubscribe20/InitialSubscribe200 commands
+                // to the depth connections spawned in DEFERRED mode (item
+                // B.2). `anchor_cmd_senders` is the per-underlying map of
+                // mpsc::Sender<DepthCommand> built when depth connections
+                // were spawned earlier in boot.
+                let anchor_cmd_senders = std::sync::Arc::clone(&depth_cmd_senders);
+                let anchor_twenty_max = config.subscription.twenty_depth_max_instruments;
+                // Live LTPs for FINNIFTY + MIDCPNIFTY (the preopen buffer
+                // only captures NIFTY + BANKNIFTY IDX_I). At 09:13 the main
+                // feed has been streaming for ~13 min so these are present.
+                let anchor_shared_spot_prices = std::sync::Arc::clone(&shared_spot_prices);
                 tokio::spawn(async move {
                     use chrono::{FixedOffset, NaiveTime, TimeZone, Utc};
                     use tickvault_common::constants::IST_UTC_OFFSET_SECONDS;
@@ -3393,6 +3432,153 @@ async fn main() -> Result<()> {
                             source_minute_slot,
                         });
                     }
+
+                    // Plan item real-C (2026-04-23): dispatch
+                    // InitialSubscribe20 + InitialSubscribe200 to depth
+                    // connections spawned in DEFERRED mode (item B.2).
+                    //
+                    // Spot prices sourced from two places, in priority order:
+                    //   1. NIFTY + BANKNIFTY: 09:12 close from the preopen
+                    //      buffer (authoritative — matches Dhan's reference).
+                    //   2. FINNIFTY + MIDCPNIFTY: live LTP from
+                    //      SharedSpotPrices (main feed has been streaming
+                    //      since 09:00 pre-open).
+                    //
+                    // Underlyings missing a spot at 09:13 are skipped with a
+                    // WARN; the depth rebalancer's 09:15 first-check gate
+                    // will pick them up once the main feed has a fresh LTP.
+                    let mut spot_map: std::collections::HashMap<String, f64> =
+                        // O(1) EXEMPT: 4-entry map built once per day
+                        std::collections::HashMap::new();
+                    {
+                        let live = anchor_shared_spot_prices.read().await;
+                        for (k, entry) in live.iter() {
+                            spot_map.insert(k.clone(), entry.price); // O(1) EXEMPT: 4 entries
+                        }
+                    }
+                    for (sym, _id) in
+                        tickvault_core::instrument::preopen_price_buffer::PREOPEN_INDEX_UNDERLYINGS
+                    {
+                        if let Some(c) = snap.get(*sym).and_then(|cl| cl.backtrack_latest()) {
+                            spot_map.insert((*sym).to_string(), c); // O(1) EXEMPT: 2 overrides
+                        }
+                    }
+
+                    let depth_ul: [&str; 4] = ["NIFTY", "BANKNIFTY", "FINNIFTY", "MIDCPNIFTY"];
+                    let today = now_ist.date_naive();
+                    let selections =
+                        tickvault_core::instrument::depth_strike_selector::select_depth_instruments(
+                            &anchor_universe,
+                            &depth_ul,
+                            &spot_map,
+                            today,
+                            tickvault_core::instrument::depth_strike_selector::DEPTH_ATM_STRIKES_EACH_SIDE,
+                        );
+                    let m_dispatch_total =
+                        metrics::counter!("tv_depth_initial_subscribe_dispatched_total");
+                    let m_dispatch_failed =
+                        metrics::counter!("tv_depth_initial_subscribe_dispatch_failed_total");
+
+                    let senders = anchor_cmd_senders.lock().await;
+                    for sel in &selections {
+                        // 20-level InitialSubscribe.
+                        let instruments: Vec<
+                            tickvault_core::websocket::types::InstrumentSubscription,
+                        > = sel
+                            .all_security_ids
+                            .iter()
+                            .take(anchor_twenty_max)
+                            .map(|&sid| {
+                                tickvault_core::websocket::types::InstrumentSubscription::new(
+                                    tickvault_common::types::ExchangeSegment::NseFno,
+                                    sid,
+                                )
+                            })
+                            .collect::<Vec<_>>(); // O(1) EXEMPT: 4 underlyings × ~49 contracts, once per day
+                        let subscribe_messages = tickvault_core::websocket::subscription_builder::build_twenty_depth_subscription_messages(
+                            &instruments,
+                            50, // Dhan max batch size for 20-level subscribe
+                        );
+
+                        if let Some(sender) = senders.get(&sel.underlying_symbol) {
+                            let cmd = tickvault_core::websocket::DepthCommand::InitialSubscribe20 {
+                                subscribe_messages: subscribe_messages.clone(), // O(1) EXEMPT: once-per-day
+                            };
+                            if sender.send(cmd).await.is_err() {
+                                error!(
+                                    underlying = %sel.underlying_symbol,
+                                    "09:13 dispatch: InitialSubscribe20 send failed — depth receiver dropped"
+                                );
+                                m_dispatch_failed.increment(1);
+                            } else {
+                                m_dispatch_total.increment(1);
+                            }
+                        } else {
+                            warn!(
+                                underlying = %sel.underlying_symbol,
+                                "09:13 dispatch: no depth_cmd_sender registered for 20-level underlying"
+                            );
+                        }
+
+                        // 200-level: only NIFTY + BANKNIFTY (Dhan 5-conn cap).
+                        if sel.underlying_symbol != "NIFTY" && sel.underlying_symbol != "BANKNIFTY"
+                        {
+                            continue;
+                        }
+                        for (opt_label, opt_sid) in [
+                            ("CE", sel.atm_ce_security_id),
+                            ("PE", sel.atm_pe_security_id),
+                        ] {
+                            let Some(sid) = opt_sid else {
+                                warn!(
+                                    underlying = %sel.underlying_symbol,
+                                    option = opt_label,
+                                    "09:13 dispatch: missing ATM CE/PE sid for 200-level"
+                                );
+                                continue;
+                            };
+                            let segment_str =
+                                tickvault_common::types::ExchangeSegment::NseFno.as_str();
+                            let sid_str = sid.to_string(); // O(1) EXEMPT: 4 per day
+                            let subscribe_message = serde_json::json!({
+                                "RequestCode": 23,
+                                "ExchangeSegment": segment_str,
+                                "SecurityId": sid_str,
+                            })
+                            .to_string(); // O(1) EXEMPT: 4 per day
+                            let key = format!("{}-{}", sel.underlying_symbol, opt_label); // O(1) EXEMPT: 4 per day
+                            if let Some(sender) = senders.get(&key) {
+                                let cmd =
+                                    tickvault_core::websocket::DepthCommand::InitialSubscribe200 {
+                                        subscribe_message,
+                                    };
+                                if sender.send(cmd).await.is_err() {
+                                    error!(
+                                        key,
+                                        "09:13 dispatch: InitialSubscribe200 send failed — depth receiver dropped"
+                                    );
+                                    m_dispatch_failed.increment(1);
+                                } else {
+                                    m_dispatch_total.increment(1);
+                                }
+                            } else {
+                                warn!(
+                                    key,
+                                    "09:13 dispatch: no depth_cmd_sender registered for 200-level key"
+                                );
+                            }
+                        }
+
+                        info!(
+                            underlying = %sel.underlying_symbol,
+                            atm_strike = sel.atm_strike,
+                            twenty_count = sel.all_security_ids.len(),
+                            atm_ce_sid = ?sel.atm_ce_security_id,
+                            atm_pe_sid = ?sel.atm_pe_security_id,
+                            "PROOF: 09:13 dispatcher sent InitialSubscribe20 + InitialSubscribe200"
+                        );
+                    }
+                    drop(senders);
                 });
             }
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2895,7 +2895,7 @@ async fn main() -> Result<()> {
                                     depth200_token,
                                     depth200_client_id,
                                     depth200_segment,
-                                    depth200_sid,
+                                    Some(depth200_sid),
                                     depth200_label,
                                     tx200,
                                     Some(d200_signal_tx),

--- a/crates/app/tests/no_boot_depth_subscribe_guard.rs
+++ b/crates/app/tests/no_boot_depth_subscribe_guard.rs
@@ -1,0 +1,250 @@
+//! Plan item I (2026-04-23, follow-up to PR #324) — source-scan guard
+//! for the "no boot-time depth subscribe" invariant.
+//!
+//! This test ratchets the architectural change shipped by items B.1,
+//! B.2 and real-C on branch `claude/continue-work-se9hG`:
+//!
+//! * **B.1** (`crates/core/src/websocket/depth_connection.rs`) —
+//!   `run_twenty_depth_connection` no longer short-circuits on empty
+//!   instruments; `run_two_hundred_depth_connection` takes
+//!   `security_id: Option<u32>`.
+//! * **B.2** (`crates/app/src/main.rs`) — boot no longer `continue`s
+//!   when `instruments_for_underlying.is_empty()`; 200-level no
+//!   longer ERRORs + skips when `atm_ce`/`atm_pe` is `None`.
+//! * **real-C** (`crates/app/src/main.rs`) — the 09:13 IST dispatcher
+//!   sends `InitialSubscribe20` / `InitialSubscribe200` via
+//!   `depth_cmd_senders`.
+//!
+//! Source-scanning is the right tool because the invariants live in
+//! `main.rs` (binary entry point) and `depth_connection.rs` (a long
+//! file with async lifetime plumbing). Behavioural assertions would
+//! need the full boot sequence (Docker, secrets, calendar) or a
+//! test harness that mocks mpsc channels + tokio clock; a mechanical
+//! scan is deterministic, cheap and immune to flake.
+//!
+//! If any assertion here fails, the PR that caused it is regressing
+//! the "depth connections stay idle until 09:13" invariant — fix the
+//! source change, not this test.
+
+use std::path::PathBuf;
+
+fn read_source(relative_path: &str) -> String {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // `crates/app` — walk up to `crates/` to reach sibling crates.
+    path.pop(); // -> crates/
+    path.push(relative_path);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("must be able to read {}: {err}", path.display()))
+}
+
+fn read_main_rs() -> String {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/main.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("must be able to read {}: {err}", path.display()))
+}
+
+// -----------------------------------------------------------------------
+// B.1 ratchets — depth_connection.rs
+// -----------------------------------------------------------------------
+
+#[test]
+fn run_twenty_depth_does_not_early_exit_on_empty_instruments() {
+    let src = read_source("core/src/websocket/depth_connection.rs");
+
+    // Negative ratchet — the legacy early-exit shape must NOT appear.
+    let legacy_pattern = "if instruments.is_empty() {\n        info!(\"20-level depth: no instruments to subscribe — skipping\");\n        return Ok(());\n    }";
+    assert!(
+        !src.contains(legacy_pattern),
+        "Item B.1 regression: `run_twenty_depth_connection` re-added the \
+         old early-exit on empty instruments. This defeats the 09:13 \
+         dispatcher — connections never stay idle waiting for \
+         InitialSubscribe20. See commit 0611a60."
+    );
+
+    // Positive ratchet — the DEFERRED-mode log line MUST be present.
+    assert!(
+        src.contains("starting 20-level depth in DEFERRED mode") || src.contains("DEFERRED mode"),
+        "Item B.1 regression: `run_twenty_depth_connection` is missing \
+         the DEFERRED-mode log. When boot passes an empty Vec, the \
+         connection must announce it is waiting for InitialSubscribe20."
+    );
+}
+
+#[test]
+fn run_two_hundred_depth_takes_optional_security_id() {
+    let src = read_source("core/src/websocket/depth_connection.rs");
+
+    // Positive ratchet — the parameter MUST be Option<u32>.
+    assert!(
+        src.contains("security_id: Option<u32>"),
+        "Item B.1 regression: `run_two_hundred_depth_connection` lost \
+         its `security_id: Option<u32>` parameter. Without `None` as \
+         the deferred sentinel, boot cannot spawn 200-level connections \
+         before the 09:13 dispatcher has picked an ATM."
+    );
+
+    // Negative ratchet — the outer function signature MUST NOT regress
+    // to the old `security_id: u32,` form.
+    assert!(
+        !src.contains("pub async fn run_two_hundred_depth_connection(\n    token_handle: TokenHandle,\n    client_id: String,\n    exchange_segment: ExchangeSegment,\n    security_id: u32,"),
+        "Item B.1 regression: `run_two_hundred_depth_connection` \
+         regressed to the old `security_id: u32` signature. Must be \
+         `security_id: Option<u32>`."
+    );
+}
+
+// -----------------------------------------------------------------------
+// B.2 ratchets — main.rs boot code
+// -----------------------------------------------------------------------
+
+#[test]
+fn boot_does_not_skip_spawn_when_instruments_empty() {
+    let src = read_main_rs();
+
+    // Negative ratchet — the legacy early-`continue` shape must NOT
+    // appear. Old behaviour was:
+    //
+    //     if instruments_for_underlying.is_empty() {
+    //         info!(..., "20-level depth: no instruments selected — skipping");
+    //         continue;
+    //     }
+    //
+    // New behaviour logs "spawning DEFERRED connection" and falls
+    // through to spawn.
+    assert!(
+        !src.contains(
+            "20-level depth: no instruments selected — skipping\"\n                    );\n                    continue;"
+        ),
+        "Item B.2 regression: main.rs re-added the `continue` that \
+         skipped depth-connection spawn when no boot-time ATM was \
+         available. This means pre-market deploys will NOT start \
+         depth sockets until next restart. Must fall through to \
+         spawn with an empty instrument list (DEFERRED mode)."
+    );
+
+    // Positive ratchet — the new DEFERRED log line MUST be present.
+    assert!(
+        src.contains("spawning DEFERRED connection"),
+        "Item B.2 regression: main.rs is missing the 'spawning \
+         DEFERRED connection' log. Boot must announce it is spawning \
+         an idle connection that will be activated by the 09:13 \
+         dispatcher."
+    );
+}
+
+#[test]
+fn boot_does_not_error_on_missing_atm_ce_pe() {
+    let src = read_main_rs();
+
+    // Negative ratchet — the legacy ERROR + `continue` on missing
+    // atm_ce/atm_pe must NOT appear. Old behaviour:
+    //
+    //     let Some((opt_label, depth200_sid, depth200_label)) = opt_entry else {
+    //         error!(
+    //             underlying,
+    //             "200-level depth: no ATM CE/PE found — skipping (check subscription planner)"
+    //         );
+    //         continue;
+    //     };
+    //
+    // New behaviour synthesises a "{UL}-{CE|PE}-deferred" label and
+    // passes `None` as the security_id so the 09:13 dispatcher can
+    // InitialSubscribe200 it later.
+    assert!(
+        !src.contains("no ATM CE/PE found — skipping (check subscription planner)"),
+        "Item B.2 regression: main.rs re-added the ERROR-level skip \
+         when boot-time ATM CE/PE is missing. Pre-market missing ATM \
+         is EXPECTED, not a planner bug — must use deferred-mode \
+         placeholder sid=None + '{{UL}}-{{CE|PE}}-deferred' label so \
+         the 09:13 dispatcher can complete the subscribe."
+    );
+
+    // Positive ratchet — the deferred-label pattern MUST appear.
+    assert!(
+        src.contains("-CE-deferred") || src.contains("-PE-deferred"),
+        "Item B.2 regression: main.rs is missing the deferred-label \
+         synthesis for 200-level. When atm_ce/atm_pe is None, boot \
+         must build a '{{UL}}-CE-deferred' / '{{UL}}-PE-deferred' \
+         label so the depth connection + cmd_senders map keys \
+         remain consistent."
+    );
+}
+
+// -----------------------------------------------------------------------
+// real-C ratchets — 09:13 dispatcher
+// -----------------------------------------------------------------------
+
+#[test]
+fn dispatcher_at_0913_sends_initial_subscribe20() {
+    let src = read_main_rs();
+
+    assert!(
+        src.contains("DepthCommand::InitialSubscribe20"),
+        "Item real-C regression: main.rs no longer references \
+         `DepthCommand::InitialSubscribe20`. The 09:13 dispatcher MUST \
+         send this command to each deferred 20-level depth connection, \
+         otherwise they stay idle forever."
+    );
+}
+
+#[test]
+fn dispatcher_at_0913_sends_initial_subscribe200() {
+    let src = read_main_rs();
+
+    assert!(
+        src.contains("DepthCommand::InitialSubscribe200"),
+        "Item real-C regression: main.rs no longer references \
+         `DepthCommand::InitialSubscribe200`. The 09:13 dispatcher MUST \
+         send this command to the NIFTY + BANKNIFTY CE/PE deferred \
+         200-level connections, otherwise those sockets stay idle \
+         forever and `MarketOpenDepthAnchor` becomes a lie."
+    );
+}
+
+#[test]
+fn dispatcher_at_0913_calls_select_depth_instruments() {
+    let src = read_main_rs();
+
+    // The dispatcher pre-commit path was a Telegram-only task. After
+    // real-C it must call the canonical ATM selector to build the
+    // 20-level subscribe list.
+    assert!(
+        src.contains("select_depth_instruments"),
+        "Item real-C regression: main.rs no longer calls \
+         `select_depth_instruments` at 09:13. Without it the dispatcher \
+         cannot compute ATM ± 24 for 20-level InitialSubscribe."
+    );
+}
+
+#[test]
+fn dispatcher_at_0913_emits_dispatch_counter() {
+    let src = read_main_rs();
+
+    // Grafana + alerting rely on this counter to verify the dispatch
+    // actually fired today. Removing the counter would make the
+    // dispatcher silent in ops.
+    assert!(
+        src.contains("tv_depth_initial_subscribe_dispatched_total"),
+        "Item real-C regression: main.rs no longer emits the \
+         `tv_depth_initial_subscribe_dispatched_total` counter from \
+         the 09:13 dispatcher. Without it ops has no way to confirm \
+         that InitialSubscribe actually fired today."
+    );
+}
+
+#[test]
+fn dispatcher_uses_preopen_buffer_and_shared_spot_prices() {
+    let src = read_main_rs();
+
+    // Dual spot-price source — 09:12 close for NIFTY + BANKNIFTY,
+    // live LTP for FINNIFTY + MIDCPNIFTY.
+    assert!(
+        src.contains("anchor_buffer") && src.contains("anchor_shared_spot_prices"),
+        "Item real-C regression: the 09:13 dispatcher must read BOTH \
+         the preopen_buffer (`anchor_buffer`) and SharedSpotPrices \
+         (`anchor_shared_spot_prices`). NIFTY/BANKNIFTY get 09:12 \
+         close from the buffer; FINNIFTY/MIDCPNIFTY get live LTP \
+         from SharedSpotPrices."
+    );
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -71,5 +71,9 @@ harness = false
 name = "ws_reader_frame_handle"
 harness = false
 
+[[bench]]
+name = "phase2_dispatch"
+harness = false
+
 [package.metadata.cargo-machete]
 ignored = ["ahash", "arrayvec", "bytes", "chrono-tz", "failsafe", "loom", "papaya", "rtrb", "zerocopy"]

--- a/crates/core/benches/phase2_dispatch.rs
+++ b/crates/core/benches/phase2_dispatch.rs
@@ -1,0 +1,197 @@
+//! Benchmark: Phase 2 dispatch path — `select_depth_instruments`.
+//!
+//! Plan item Q (unified 09:12 subscription): the real-C dispatcher at
+//! 09:13 IST must compute the per-underlying ATM ± 24 selection once
+//! per day. Although this is a cold path (runs once, not per tick),
+//! we still want a fast budget so that (a) the dispatcher never
+//! drifts into hundred-ms territory that would delay depth sockets
+//! past 09:13:30 IST, and (b) any O(n²) regression in the option-chain
+//! binary-search path is caught at review time.
+//!
+//! # Budget
+//!
+//! `phase2_compute_subscriptions < 1 ms` for a realistic universe
+//! (4 depth underlyings × 200 strikes per chain).
+//!
+//! In practice the function is dominated by `find_atm_security_ids`
+//! (one binary search per underlying) and an ATM ± 24 slice of the
+//! sorted calls/puts vectors, so the real cost is ≤ a few µs. The
+//! 1 ms budget is a generous ceiling that catches accidental
+//! worst-case O(n²) regressions without being so tight that a
+//! debug-build noise spike fails CI.
+
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::time::Duration;
+
+use chrono::{FixedOffset, NaiveDate, Utc};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use tickvault_common::instrument_types::{
+    ExpiryCalendar, FnoUniverse, OptionChain, OptionChainEntry, OptionChainKey,
+    UniverseBuildMetadata,
+};
+use tickvault_core::instrument::depth_strike_selector::{
+    DEPTH_ATM_STRIKES_EACH_SIDE, select_depth_instruments,
+};
+
+/// Build a synthetic option chain centered around `atm_strike` with
+/// `strikes` entries on each side (total = 2 * strikes + 1 CE + same PE).
+/// Strike spacing is fixed at 100.0 to mimic NIFTY-style chains.
+fn make_chain(
+    underlying: &str,
+    expiry: NaiveDate,
+    atm_strike: f64,
+    strikes_each_side: usize,
+    base_security_id: u32,
+) -> OptionChain {
+    let total = 2 * strikes_each_side + 1;
+    let mut calls = Vec::with_capacity(total);
+    let mut puts = Vec::with_capacity(total);
+    for i in 0..total {
+        let offset = i as f64 - strikes_each_side as f64;
+        let strike = atm_strike + offset * 100.0;
+        let sid_ce = base_security_id + (i as u32) * 2;
+        let sid_pe = sid_ce + 1;
+        calls.push(OptionChainEntry {
+            security_id: sid_ce,
+            strike_price: strike,
+            lot_size: 50,
+        });
+        puts.push(OptionChainEntry {
+            security_id: sid_pe,
+            strike_price: strike,
+            lot_size: 50,
+        });
+    }
+    OptionChain {
+        underlying_symbol: underlying.to_string(),
+        expiry_date: expiry,
+        calls,
+        puts,
+        future_security_id: None,
+    }
+}
+
+/// Build a realistic FnoUniverse with 4 depth underlyings, each with
+/// 200 strikes per chain and the nearest-expiry entry populated.
+fn make_depth_universe() -> FnoUniverse {
+    let today = Utc::now()
+        .with_timezone(&FixedOffset::east_opt(19_800).unwrap())
+        .date_naive();
+    let nearest_expiry = today + chrono::Duration::days(7);
+
+    let mut option_chains: HashMap<OptionChainKey, OptionChain> = HashMap::with_capacity(4);
+    let mut expiry_calendars: HashMap<String, ExpiryCalendar> = HashMap::with_capacity(4);
+
+    // 200 strikes per chain = 100 each side of ATM.
+    let strikes_each_side = 100;
+
+    let specs = [
+        ("NIFTY", 22_500.0, 100_000_u32),
+        ("BANKNIFTY", 50_000.0, 200_000_u32),
+        ("FINNIFTY", 23_000.0, 300_000_u32),
+        ("MIDCPNIFTY", 12_500.0, 400_000_u32),
+    ];
+
+    for (symbol, atm, base_sid) in specs {
+        let chain = make_chain(symbol, nearest_expiry, atm, strikes_each_side, base_sid);
+        option_chains.insert(
+            OptionChainKey {
+                underlying_symbol: symbol.to_string(),
+                expiry_date: nearest_expiry,
+            },
+            chain,
+        );
+        expiry_calendars.insert(
+            symbol.to_string(),
+            ExpiryCalendar {
+                underlying_symbol: symbol.to_string(),
+                expiry_dates: vec![nearest_expiry],
+            },
+        );
+    }
+
+    FnoUniverse {
+        underlyings: HashMap::new(),
+        derivative_contracts: HashMap::new(),
+        instrument_info: HashMap::new(),
+        option_chains,
+        expiry_calendars,
+        subscribed_indices: Vec::new(),
+        build_metadata: UniverseBuildMetadata {
+            csv_source: "bench".to_string(),
+            csv_row_count: 0,
+            parsed_row_count: 0,
+            index_count: 0,
+            equity_count: 0,
+            underlying_count: 0,
+            derivative_count: 0,
+            option_chain_count: 0,
+            build_duration: Duration::ZERO,
+            build_timestamp: Utc::now().with_timezone(&FixedOffset::east_opt(19_800).unwrap()),
+        },
+    }
+}
+
+fn make_spot_prices() -> HashMap<String, f64> {
+    let mut map = HashMap::with_capacity(4);
+    map.insert("NIFTY".to_string(), 22_510.5);
+    map.insert("BANKNIFTY".to_string(), 50_075.2);
+    map.insert("FINNIFTY".to_string(), 22_980.0);
+    map.insert("MIDCPNIFTY".to_string(), 12_540.0);
+    map
+}
+
+fn bench_phase2_compute_subscriptions(c: &mut Criterion) {
+    let universe = make_depth_universe();
+    let spot_prices = make_spot_prices();
+    let today = Utc::now()
+        .with_timezone(&FixedOffset::east_opt(19_800).unwrap())
+        .date_naive();
+    let underlyings: [&str; 4] = ["NIFTY", "BANKNIFTY", "FINNIFTY", "MIDCPNIFTY"];
+
+    c.bench_function("phase2/compute_subscriptions", |b| {
+        b.iter(|| {
+            let selections = select_depth_instruments(
+                black_box(&universe),
+                black_box(&underlyings),
+                black_box(&spot_prices),
+                black_box(today),
+                black_box(DEPTH_ATM_STRIKES_EACH_SIDE),
+            );
+            black_box(selections);
+        });
+    });
+}
+
+fn bench_phase2_compute_subscriptions_single_underlying(c: &mut Criterion) {
+    // Isolates per-underlying cost so regressions in binary search or
+    // strike-range slicing are easy to pinpoint.
+    let universe = make_depth_universe();
+    let spot_prices = make_spot_prices();
+    let today = Utc::now()
+        .with_timezone(&FixedOffset::east_opt(19_800).unwrap())
+        .date_naive();
+    let underlyings: [&str; 1] = ["NIFTY"];
+
+    c.bench_function("phase2/compute_subscriptions_single", |b| {
+        b.iter(|| {
+            let selections = select_depth_instruments(
+                black_box(&universe),
+                black_box(&underlyings),
+                black_box(&spot_prices),
+                black_box(today),
+                black_box(DEPTH_ATM_STRIKES_EACH_SIDE),
+            );
+            black_box(selections);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_phase2_compute_subscriptions,
+    bench_phase2_compute_subscriptions_single_underlying,
+);
+criterion_main!(benches);

--- a/crates/core/src/websocket/depth_connection.rs
+++ b/crates/core/src/websocket/depth_connection.rs
@@ -156,25 +156,44 @@ pub async fn run_twenty_depth_connection(
     mut cmd_rx: mpsc::Receiver<DepthCommand>,
     notifier: Option<Arc<crate::notification::NotificationService>>,
 ) -> Result<(), WebSocketError> {
-    if instruments.is_empty() {
-        info!("20-level depth: no instruments to subscribe — skipping");
-        return Ok(());
-    }
-
+    // Plan item B (2026-04-23): empty `instruments` is NO LONGER an early-
+    // exit path. Under the unified 09:12 close flow, boot callers pass an
+    // empty list intentionally; the connection opens idle (socket up,
+    // authenticated, no subscribe sent) and waits for a
+    // `DepthCommand::InitialSubscribe20` from the 09:13 dispatcher before
+    // it starts streaming. `subscription_messages` being empty is the
+    // sentinel — see `connect_and_run_depth` which sends only when the
+    // slice is non-empty.
     let instrument_count = instruments.len().min(DEPTH_SUBSCRIPTION_BATCH_SIZE);
     let prefix = format!("{DEPTH_CONNECTION_PREFIX}-{underlying_label}"); // O(1) EXEMPT: boot-time
 
-    info!(
-        instrument_count,
-        underlying = %underlying_label,
-        "starting 20-level depth WebSocket connection"
-    );
+    if instrument_count == 0 {
+        info!(
+            underlying = %underlying_label,
+            "{prefix}: starting 20-level depth in DEFERRED mode — awaiting InitialSubscribe20 from 09:13 dispatcher"
+        );
+    } else {
+        info!(
+            instrument_count,
+            underlying = %underlying_label,
+            "starting 20-level depth WebSocket connection"
+        );
+    }
 
-    // Pre-build subscription messages (reused across reconnects).
-    let subscription_messages = build_twenty_depth_subscription_messages(
-        &instruments[..instrument_count],
-        DEPTH_SUBSCRIPTION_BATCH_SIZE,
-    );
+    // Pre-build subscription messages (reused across reconnects). Empty
+    // slice when deferred — the connect loop treats empty as "skip the
+    // initial subscribe step" and relies on InitialSubscribe20 to kick
+    // in via the command channel.
+    // Deferred-mode empty Vec is allocated once per depth connection at
+    // boot (4 connections total across NIFTY/BANKNIFTY/FINNIFTY/MIDCPNIFTY).
+    let subscription_messages: Vec<String> = if instrument_count == 0 {
+        Vec::new() // O(1) EXEMPT: boot-time deferred-mode empty sentinel
+    } else {
+        build_twenty_depth_subscription_messages(
+            &instruments[..instrument_count],
+            DEPTH_SUBSCRIPTION_BATCH_SIZE,
+        )
+    };
 
     let reconnect_counter = AtomicU64::new(0);
     // O(1) EXEMPT: metric handle created once at boot, not per tick
@@ -352,14 +371,25 @@ async fn connect_and_run_depth(
             source: err,
         })?;
 
-    info!(
-        instrument_count,
-        "{prefix}: connected — sending subscriptions"
-    );
+    if subscription_messages.is_empty() {
+        // Plan item B (2026-04-23): deferred mode — connection is up but no
+        // subscribe has been sent. The 09:13 dispatcher will send an
+        // `InitialSubscribe20` via the command channel once the 09:12 close
+        // is available. Until then, Dhan's 10s server pings keep the
+        // socket alive and the watchdog quiet.
+        info!(
+            "{prefix}: connected in DEFERRED mode — no subscribe sent, awaiting InitialSubscribe20"
+        );
+    } else {
+        info!(
+            instrument_count,
+            "{prefix}: connected — sending subscriptions"
+        );
+    }
 
     let (mut write, mut read) = ws_stream.split();
 
-    // Send subscription messages
+    // Send subscription messages (empty slice in deferred mode = no-op).
     for msg in subscription_messages {
         write
             .send(Message::Text(msg.clone().into()))
@@ -371,11 +401,13 @@ async fn connect_and_run_depth(
         debug!("{prefix}: subscription sent");
     }
 
-    info!(
-        instrument_count,
-        subscription_count = subscription_messages.len(),
-        "{prefix}: all subscriptions sent — reading depth frames"
-    );
+    if !subscription_messages.is_empty() {
+        info!(
+            instrument_count,
+            subscription_count = subscription_messages.len(),
+            "{prefix}: all subscriptions sent — reading depth frames"
+        );
+    }
 
     // Metrics — labeled per underlying so Grafana can distinguish connections.
     let m_frames = metrics::counter!("tv_depth_20lvl_frames_total", "underlying" => underlying_label.to_string());
@@ -658,7 +690,7 @@ pub async fn run_two_hundred_depth_connection(
     token_handle: TokenHandle,
     client_id: String,
     exchange_segment: ExchangeSegment,
-    security_id: u32,
+    security_id: Option<u32>,
     label: String,
     frame_sender: mpsc::Sender<Bytes>,
     connected_signal: Option<tokio::sync::oneshot::Sender<()>>,
@@ -667,22 +699,46 @@ pub async fn run_two_hundred_depth_connection(
     notifier: Option<Arc<crate::notification::NotificationService>>,
 ) -> Result<(), WebSocketError> {
     let segment_str = exchange_segment.as_str();
-    let sid_str = security_id.to_string(); // O(1) EXEMPT: boot-time
 
-    // 200-level uses flat JSON (no InstrumentList array)
-    let subscribe_msg = serde_json::json!({
-        "RequestCode": 23,
-        "ExchangeSegment": segment_str,
-        "SecurityId": sid_str,
-    })
-    .to_string(); // O(1) EXEMPT: boot-time
+    // Plan item B (2026-04-23): `security_id == None` = deferred mode.
+    // Connect idle, skip sending initial subscribe; wait for
+    // `DepthCommand::InitialSubscribe200` from the 09:13 dispatcher.
+    // Internal code below carries `u32` with 0 as the "unassigned"
+    // sentinel — callers must never pass `Some(0)` because the
+    // SubscribeRequest JSON `"SecurityId":"0"` would be rejected by
+    // Dhan. The inner `connect_and_run_200_depth` treats an empty
+    // `subscribe_msg` as a no-op for the initial subscribe step.
+    let deferred = security_id.is_none();
+    let security_id: u32 = security_id.unwrap_or(0);
+    // Deferred-mode empty String is allocated once per 200-level depth
+    // connection at boot (max 4 — NIFTY CE/PE + BANKNIFTY CE/PE).
+    let subscribe_msg: String = if deferred {
+        String::new() // O(1) EXEMPT: boot-time deferred-mode empty sentinel
+    } else {
+        let sid_str = security_id.to_string(); // O(1) EXEMPT: boot-time
+        // 200-level uses flat JSON (no InstrumentList array)
+        serde_json::json!({
+            "RequestCode": 23,
+            "ExchangeSegment": segment_str,
+            "SecurityId": sid_str,
+        })
+        .to_string() // O(1) EXEMPT: boot-time
+    };
 
-    info!(
-        label,
-        security_id,
-        segment = segment_str,
-        "starting 200-level depth WebSocket connection"
-    );
+    if deferred {
+        info!(
+            label,
+            segment = segment_str,
+            "starting 200-level depth WebSocket connection in DEFERRED mode — awaiting InitialSubscribe200"
+        );
+    } else {
+        info!(
+            label,
+            security_id,
+            segment = segment_str,
+            "starting 200-level depth WebSocket connection"
+        );
+    }
 
     let reconnect_counter = AtomicU64::new(0);
     let prefix = format!("depth-200lvl-{label}"); // O(1) EXEMPT: boot-time
@@ -870,27 +926,42 @@ async fn connect_and_run_200_depth(
             source: err,
         })?;
 
-    info!(
-        security_id,
-        label = %label,
-        "{prefix}: connected — sending subscription"
-    );
+    if subscribe_msg.is_empty() {
+        // Plan item B (2026-04-23): deferred mode — socket authenticated
+        // but no subscribe sent. `InitialSubscribe200` via `cmd_rx` will
+        // kick in at 09:12:30 IST. Dhan's 10s server pings keep the
+        // watchdog quiet in the meantime. `security_id` is the 0 sentinel
+        // passed by the outer `run_two_hundred_depth_connection` when the
+        // caller supplies `None`.
+        info!(
+            label = %label,
+            "{prefix}: connected in DEFERRED mode — no subscribe sent, awaiting InitialSubscribe200"
+        );
+    } else {
+        info!(
+            security_id,
+            label = %label,
+            "{prefix}: connected — sending subscription"
+        );
+    }
 
     let (mut write, mut read) = ws_stream.split();
 
-    write
-        .send(Message::Text(subscribe_msg.to_string().into()))
-        .await
-        .map_err(|err| WebSocketError::ConnectionFailed {
-            url: DHAN_TWO_HUNDRED_DEPTH_WS_BASE_URL.to_string(),
-            source: err,
-        })?;
+    if !subscribe_msg.is_empty() {
+        write
+            .send(Message::Text(subscribe_msg.to_string().into()))
+            .await
+            .map_err(|err| WebSocketError::ConnectionFailed {
+                url: DHAN_TWO_HUNDRED_DEPTH_WS_BASE_URL.to_string(),
+                source: err,
+            })?;
 
-    info!(
-        security_id,
-        label = %label,
-        "{prefix}: subscription sent — reading 200-level depth frames"
-    );
+        info!(
+            security_id,
+            label = %label,
+            "{prefix}: subscription sent — reading 200-level depth frames"
+        );
+    }
 
     // Metrics — labeled per underlying for Grafana differentiation.
     let m_frames =
@@ -908,7 +979,14 @@ async fn connect_and_run_200_depth(
     // points directly at the dead contract.
     let activity_counter = Arc::new(AtomicU64::new(0));
     let watchdog_notify = Arc::new(tokio::sync::Notify::new());
-    let watchdog_label = format!("depth-200-{label}-sid{security_id}"); // O(1) EXEMPT: one alloc per connect cycle
+    // Plan item B (2026-04-23): `security_id == 0` = DEFERRED sentinel
+    // (outer caller passed `None`). Label differentiates so a fired
+    // watchdog alert is unambiguous about what hasn't been subscribed.
+    let watchdog_label = if security_id == 0 {
+        format!("depth-200-{label}-deferred") // O(1) EXEMPT: one alloc per connect cycle
+    } else {
+        format!("depth-200-{label}-sid{security_id}") // O(1) EXEMPT: one alloc per connect cycle
+    };
     let watchdog = ActivityWatchdog::new(
         watchdog_label.clone(),
         Arc::clone(&activity_counter),
@@ -1186,13 +1264,21 @@ mod tests {
         assert_eq!(delay_6, 30000); // 500 * 64 = 32000, capped at 30000
     }
 
+    /// Plan item B (2026-04-23): verifies that empty `instruments` is NO
+    /// LONGER an early-exit `Ok(())` path — the connection function
+    /// attempts to enter the connect loop so it can wait for
+    /// `InitialSubscribe20` from the 09:13 dispatcher. We prove the old
+    /// early-exit is gone by asserting the future does NOT complete
+    /// within a short timeout (the real code will either connect to
+    /// Dhan or retry-backoff on NoTokenAvailable — either way it is
+    /// NOT an immediate `Ok(())`).
     #[tokio::test]
-    async fn test_run_twenty_depth_empty_instruments_returns_ok() {
+    async fn test_run_twenty_depth_empty_instruments_enters_deferred_mode_not_early_ok() {
         let (tx, _rx) = mpsc::channel(16);
         let token_handle: TokenHandle =
             std::sync::Arc::new(arc_swap::ArcSwap::new(std::sync::Arc::new(None)));
         let (_cmd_tx, cmd_rx) = mpsc::channel(4);
-        let result = run_twenty_depth_connection(
+        let fut = run_twenty_depth_connection(
             token_handle,
             "test".to_string(),
             vec![],
@@ -1202,9 +1288,16 @@ mod tests {
             None,
             cmd_rx,
             None, // no notifier in unit test
-        )
-        .await;
-        assert!(result.is_ok());
+        );
+        // Old behaviour: empty instruments returned `Ok(())` synchronously
+        // before any async yield. If the future completes inside 200ms,
+        // the old early-exit is back — fail loudly.
+        let outcome = tokio::time::timeout(Duration::from_millis(200), fut).await;
+        assert!(
+            outcome.is_err(),
+            "empty instruments must enter the connect/reconnect loop (deferred mode); \
+             early-exit Ok(()) regression detected. Result = {outcome:?}"
+        );
     }
 
     #[test]

--- a/quality/benchmark-budgets.toml
+++ b/quality/benchmark-budgets.toml
@@ -22,6 +22,7 @@ registry_get             = 50           # <50ns  — matches registry/get_hit, r
 token_handle             = 50           # <50ns  — matches token_handle/load (arc-swap hot-path read)
 f32_to_f64_clean         = 50           # <50ns  — matches f32_to_f64_clean/* (storage precision conversion)
 ws_reader_frame_handle   = 5000         # <5μs  — STAGE-D P7.6: counter bump + WAL append + dispatch per frame. Generous ceiling because WAL append includes one heap alloc + one crossbeam try_send; measured ~1-3μs in criterion, budget gives 2× headroom for noisy CI runners.
+phase2_compute_subscriptions = 1000000  # <1ms  — Plan item Q (2026-04-23): cold-path 09:13 dispatcher computes ATM±24 for 4 depth underlyings × 200-strike option chains. Measured ~4.3μs; 1ms budget gives ~230× headroom so accidental O(n²) regressions fail CI without being tight enough to flake on noisy runners.
 
 # Trading crate — OMS
 oms_state_transition     = 100          # <100ns — matches oms/state_transition


### PR DESCRIPTION
## Summary

Follow-up to PR #324 — ships the four items that were deferred in that merge. Completes the unified 09:12 subscription architecture: depth connections open idle at boot, the 09:13 IST dispatcher activates them using the authoritative 09:12 close, a source-scan guard ratchets the invariant, and a benchmark pins the dispatch latency.

## Items shipped

| Item | Commit | What |
|------|--------|------|
| **B.1** | `0611a60` | `depth_connection.rs`: `run_twenty_depth_connection` accepts empty instruments (connects idle); `run_two_hundred_depth_connection` takes `security_id: Option<u32>` (None = deferred) |
| **B.2 + real-C** | `a347584` | `main.rs`: boot always spawns depth connections (no more `continue` on empty), 200-level falls through with `None` sid when ATM missing; 09:13 IST dispatcher reads 09:12 close + live LTP, computes ATM via `select_depth_instruments`, sends `DepthCommand::InitialSubscribe20` + `InitialSubscribe200` via `depth_cmd_senders` |
| **I** | `a15c8ca` | `crates/app/tests/no_boot_depth_subscribe_guard.rs` — 9 source-scan ratchets locking in B.1 + B.2 + real-C |
| **Q** | `bc30bec` | `crates/core/benches/phase2_dispatch.rs` — Criterion benchmark for `select_depth_instruments`, measured **4.3 µs** for 4 underlyings × 200 strikes per chain, budget **1 ms** in `quality/benchmark-budgets.toml` |

## Why this matters

Before: a pre-market deploy (08:xx) meant depth connections were never spawned at all, because boot-time ATM selection failed when no LTPs were available yet. The operator had to restart the app after market open to get depth data flowing. The previous `09:13` task only fired an "anchor" Telegram — it didn't actually dispatch subscribes.

After: every boot spawns depth sockets immediately in DEFERRED mode. The 09:13:00 IST task reads the 09:12 close from `preopen_buffer` for NIFTY + BANKNIFTY (authoritative, matches Dhan's reference) and live LTP from `SharedSpotPrices` for FINNIFTY + MIDCPNIFTY, computes ATM ± 24, and sends `InitialSubscribe20` / `InitialSubscribe200` commands on the same sockets — zero disconnect, zero tick gap.

## New metrics

- `tv_depth_initial_subscribe_dispatched_total` — increments on every successful `DepthCommand::InitialSubscribe20` / `InitialSubscribe200` send from the 09:13 dispatcher.
- `tv_depth_initial_subscribe_dispatch_failed_total` — increments on mpsc send failures (depth receiver dropped).

## Test plan

- [x] `cargo check --workspace` clean (only the 2 pre-existing `bg_data_collection_*` warnings from main)
- [x] `cargo test -p tickvault-core --lib websocket::depth_connection` — 26 tests pass incl. new `test_run_twenty_depth_empty_instruments_enters_deferred_mode_not_early_ok` (200ms timeout assertion)
- [x] `cargo test -p tickvault-app --test no_boot_depth_subscribe_guard` — 9/9 pass
- [x] `cargo bench -p tickvault-core --bench phase2_dispatch -- --quick` — 4.3 µs total / 1.05 µs per underlying, well under 1 ms budget
- [x] Item I ratchets the exact invariant strings added by items B + real-C, so any regression will fail the build

## Risk

- **Deferred mode socket stays alive without subscribe:** Dhan's 10s server pings keep the watchdog from firing (verified in `depth_connection.rs` Ping handler — `activity_counter.fetch_add` runs on every `Some(Ok(_))` frame including Ping/Pong).
- **09:13 dispatcher fires on non-trading days:** guarded by `anchor_calendar.is_trading_day(today_ist)` — skips with INFO log on weekends/holidays.
- **Late-start (app boots at 09:14):** dispatcher's `if now_time >= target` check skips with INFO log; the existing rebalancer's 09:15 first-check gate picks up depth from live LTPs instead.
- **mpsc receiver dropped:** `tv_depth_initial_subscribe_dispatch_failed_total` increments + ERROR log; this should only happen if a depth connection task has already crashed, which fires its own Telegram alert.

https://claude.ai/code/session_01N9umDtALCM7xFy7kVazzNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9umDtALCM7xFy7kVazzNy)_