### PR TITLE
fix(depth): post-market + SID=0 disconnects route to Low severity not High

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2725,10 +2725,25 @@ async fn main() -> Result<()> {
                     .await
                     {
                         tracing::error!(?err, "20-level depth connection terminated");
-                        d20_notifier.notify(NotificationEvent::DepthTwentyDisconnected {
-                            underlying: d20_label_for_disconnect,
-                            reason: format!("{err}"),
-                        });
+                        // Q5 (2026-04-23): route to Low-severity off-hours
+                        // variant when outside 09:00-15:30 IST. Same
+                        // anti-spam pattern as `WebSocketDisconnectedOffHours`
+                        // and `depth_rebalancer` stale-spot edge trigger —
+                        // a post-market boot shouldn't fire [HIGH] SMS for
+                        // an expected no-data disconnect.
+                        if tickvault_common::market_hours::is_within_market_hours_ist() {
+                            d20_notifier.notify(NotificationEvent::DepthTwentyDisconnected {
+                                underlying: d20_label_for_disconnect,
+                                reason: format!("{err}"),
+                            });
+                        } else {
+                            d20_notifier.notify(
+                                NotificationEvent::DepthTwentyDisconnectedOffHours {
+                                    underlying: d20_label_for_disconnect,
+                                    reason: format!("{err}"),
+                                },
+                            );
+                        }
                         d20_health.set_depth_20_connections(
                             d20_health.depth_20_connections().saturating_sub(1),
                         );
@@ -2938,13 +2953,34 @@ async fn main() -> Result<()> {
                                     security_id = d200_sid_for_disconnect,
                                     "200-level depth connection terminated"
                                 );
-                                d200_notifier.notify(
-                                    NotificationEvent::DepthTwoHundredDisconnected {
-                                        contract: d200_label_for_disconnect,
-                                        security_id: d200_sid_for_disconnect,
-                                        reason: format!("{err}"),
-                                    },
-                                );
+                                // Q5 (2026-04-23): route to Low-severity
+                                // off-hours variant when outside market
+                                // hours OR when the subscription fell
+                                // through to the deferred placeholder
+                                // (SecurityId=0). The 2026-04-23 post-
+                                // market boot fired 4× [HIGH] alerts with
+                                // SID=0 because no spot LTP arrived to
+                                // pick the ATM — pure Telegram noise.
+                                let use_off_hours_variant = d200_sid_for_disconnect == 0
+                                    || !tickvault_common::market_hours::is_within_market_hours_ist(
+                                    );
+                                if use_off_hours_variant {
+                                    d200_notifier.notify(
+                                        NotificationEvent::DepthTwoHundredDisconnectedOffHours {
+                                            contract: d200_label_for_disconnect,
+                                            security_id: d200_sid_for_disconnect,
+                                            reason: format!("{err}"),
+                                        },
+                                    );
+                                } else {
+                                    d200_notifier.notify(
+                                        NotificationEvent::DepthTwoHundredDisconnected {
+                                            contract: d200_label_for_disconnect,
+                                            security_id: d200_sid_for_disconnect,
+                                            reason: format!("{err}"),
+                                        },
+                                    );
+                                }
                                 d200_health.set_depth_200_connections(
                                     d200_health.depth_200_connections().saturating_sub(1),
                                 );

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -269,6 +269,19 @@ pub enum NotificationEvent {
     /// 20-level depth WebSocket disconnected.
     DepthTwentyDisconnected { underlying: String, reason: String },
 
+    /// 20-level depth WebSocket disconnected OUTSIDE market hours, OR with a
+    /// placeholder (SecurityId=0) subscription. Fires at `Severity::Low` so
+    /// the operator sees the event in Telegram but gets no SMS escalation.
+    ///
+    /// Rationale (Q5, 2026-04-23): a post-market boot cannot populate
+    /// `SharedSpotPrices` (main feed streams zero ticks after 15:30 IST),
+    /// so the ATM selector falls through to the "deferred" placeholder
+    /// (SecurityId=0). The depth connection then hits Dhan's TCP-reset
+    /// after 60 reconnect attempts and fires a `[HIGH]` disconnect alert
+    /// — which is exactly the anti-pattern we killed for the 15:45 IST
+    /// depth-stale-spot storm. Same rule as `WebSocketDisconnectedOffHours`.
+    DepthTwentyDisconnectedOffHours { underlying: String, reason: String },
+
     /// 20-level depth WebSocket reconnected after a transient disconnect.
     /// Fires on every successful reconnect, inside or outside market
     /// hours (Parthiban directive 2026-04-21 — full audit trail on all
@@ -286,6 +299,17 @@ pub enum NotificationEvent {
 
     /// 200-level depth WebSocket disconnected.
     DepthTwoHundredDisconnected {
+        contract: String,
+        security_id: u32,
+        reason: String,
+    },
+
+    /// 200-level depth disconnected OUTSIDE market hours, OR with a
+    /// placeholder (SecurityId=0) subscription. Fires at `Severity::Low` so
+    /// a post-market boot storm (4× contracts × 60 reconnect attempts)
+    /// doesn't escalate to SMS. See [`Self::DepthTwentyDisconnectedOffHours`]
+    /// for the full rationale — same rule, 200-level variant.
+    DepthTwoHundredDisconnectedOffHours {
         contract: String,
         security_id: u32,
         reason: String,
@@ -927,6 +951,11 @@ impl NotificationEvent {
             Self::DepthTwentyDisconnected { underlying, reason } => {
                 format!("<b>Depth 20-level DISCONNECTED</b>\nUnderlying: {underlying}\n{reason}")
             }
+            Self::DepthTwentyDisconnectedOffHours { underlying, reason } => {
+                format!(
+                    "<b>Depth 20-level disconnected (off-hours / no-data)</b>\nUnderlying: {underlying}\n{reason}"
+                )
+            }
             Self::DepthTwentyReconnected { underlying } => {
                 format!("<b>Depth 20-level reconnected</b>\nUnderlying: {underlying}")
             }
@@ -945,6 +974,15 @@ impl NotificationEvent {
             } => {
                 format!(
                     "<b>Depth 200-level DISCONNECTED</b>\nContract: {contract}\nSecurityId: {security_id}\n{reason}"
+                )
+            }
+            Self::DepthTwoHundredDisconnectedOffHours {
+                contract,
+                security_id,
+                reason,
+            } => {
+                format!(
+                    "<b>Depth 200-level disconnected (off-hours / no-data)</b>\nContract: {contract}\nSecurityId: {security_id}\n{reason}"
                 )
             }
             Self::DepthTwoHundredReconnected {
@@ -1337,8 +1375,10 @@ impl NotificationEvent {
             Self::QuestDbReconnected { .. } => Severity::Medium,
             Self::WebSocketReconnected { .. } => Severity::Medium,
             Self::DepthTwentyDisconnected { .. } => Severity::High,
+            Self::DepthTwentyDisconnectedOffHours { .. } => Severity::Low,
             Self::DepthTwentyReconnected { .. } => Severity::Medium,
             Self::DepthTwoHundredDisconnected { .. } => Severity::High,
+            Self::DepthTwoHundredDisconnectedOffHours { .. } => Severity::Low,
             Self::DepthTwoHundredReconnected { .. } => Severity::Medium,
             Self::OrderUpdateDisconnected { .. } => Severity::High,
             Self::OrderUpdateReconnected { .. } => Severity::Medium,
@@ -1493,6 +1533,76 @@ mod tests {
             !msg.contains("token=secret"),
             "URL query params must be redacted: {msg}"
         );
+    }
+
+    // Q5 regression pins (2026-04-23): post-market depth disconnects fire
+    // Low, not High. A boot at 18:05 IST with 4× [HIGH] depth-200 alerts
+    // (all SecurityId=0, contracts labeled "*-deferred") was pure Telegram
+    // noise because no live spot LTP arrived after 15:30 IST to populate
+    // the ATM selector. These pins enforce the Low routing.
+
+    #[test]
+    fn test_depth_20_disconnected_off_hours_is_low() {
+        let event = NotificationEvent::DepthTwentyDisconnectedOffHours {
+            underlying: "NIFTY".to_string(),
+            reason: "Reconnection failed after 20 attempts".to_string(),
+        };
+        assert_eq!(
+            event.severity(),
+            Severity::Low,
+            "post-market depth-20 disconnect must be Low to avoid SMS escalation"
+        );
+    }
+
+    #[test]
+    fn test_depth_200_disconnected_off_hours_is_low() {
+        let event = NotificationEvent::DepthTwoHundredDisconnectedOffHours {
+            contract: "NIFTY-PE-deferred".to_string(),
+            security_id: 0,
+            reason: "Reconnection failed after 60 attempts".to_string(),
+        };
+        assert_eq!(
+            event.severity(),
+            Severity::Low,
+            "post-market / SID=0 depth-200 disconnect must be Low"
+        );
+    }
+
+    #[test]
+    fn test_depth_20_disconnected_in_hours_still_high() {
+        // Severity-flip guard: a real in-market-hours disconnect must
+        // stay High so the operator gets SMS. If this ever flips to Low
+        // by accident, we'd go silent on real outages.
+        let event = NotificationEvent::DepthTwentyDisconnected {
+            underlying: "NIFTY".to_string(),
+            reason: "Dhan TCP reset".to_string(),
+        };
+        assert_eq!(event.severity(), Severity::High);
+    }
+
+    #[test]
+    fn test_depth_200_disconnected_in_hours_still_high() {
+        let event = NotificationEvent::DepthTwoHundredDisconnected {
+            contract: "NIFTY-Jun2026-25650-CE".to_string(),
+            security_id: 72271,
+            reason: "Dhan TCP reset".to_string(),
+        };
+        assert_eq!(event.severity(), Severity::High);
+    }
+
+    #[test]
+    fn test_depth_200_disconnected_off_hours_message_mentions_off_hours() {
+        let event = NotificationEvent::DepthTwoHundredDisconnectedOffHours {
+            contract: "BANKNIFTY-CE-deferred".to_string(),
+            security_id: 0,
+            reason: "no reason".to_string(),
+        };
+        let msg = event.to_message();
+        assert!(
+            msg.contains("off-hours") || msg.contains("no-data"),
+            "message must distinguish off-hours variant: {msg}"
+        );
+        assert!(msg.contains("BANKNIFTY-CE-deferred"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Post-market boot at 2026-04-23 18:05 IST fired **4× `[HIGH]` Depth 200-level DISCONNECTED** Telegram alerts:

```
⚠ [HIGH] Depth 200-level DISCONNECTED
Contract: NIFTY-PE-deferred     SecurityId: 0    Reconnection failed after 60 attempts
Contract: NIFTY-CE-deferred     SecurityId: 0    Reconnection failed after 60 attempts
Contract: BANKNIFTY-PE-deferred SecurityId: 0    Reconnection failed after 60 attempts
Contract: BANKNIFTY-CE-deferred SecurityId: 0    Reconnection failed after 60 attempts
```

Those are pure Telegram spam — same anti-pattern we killed for the 15:45 IST stale-spot storm and `WebSocketDisconnectedOffHours`. Root cause:

1. Boot at 18:05 IST (market closed at 15:30)
2. Main feed connects but streams zero ticks post-market
3. `SharedSpotPrices` never populated → ATM selector returns "deferred" placeholder with `SecurityId=0`
4. 200-depth subscribe fires with SID=0 → Dhan TCP-resets → 60 retry attempts exhaust
5. `ReconnectionExhausted` → `DepthTwoHundredDisconnected` at `Severity::High` → SMS escalation

## Fix

Two new `Severity::Low` variants:
- `DepthTwentyDisconnectedOffHours`
- `DepthTwoHundredDisconnectedOffHours`

At the emission sites in `main.rs`, branch on:
- **Depth-20:** `!is_within_market_hours_ist()` → route to off-hours variant
- **Depth-200:** `security_id == 0 || !is_within_market_hours_ist()` → route to off-hours variant

Covers both the "post-market boot" and "deferred placeholder SID=0" cases with a single helper (`tickvault_common::market_hours::is_within_market_hours_ist()`).

## Tests (+5)

All in `crates/core/src/notification/events::tests`:
- `test_depth_20_disconnected_off_hours_is_low`
- `test_depth_200_disconnected_off_hours_is_low`
- `test_depth_20_disconnected_in_hours_still_high` — severity-flip guard
- `test_depth_200_disconnected_in_hours_still_high` — severity-flip guard
- `test_depth_200_disconnected_off_hours_message_mentions_off_hours`

## Verification

- `cargo test -p tickvault-core --lib notification::` → **230 passed** (up from 225), 0 failed
- `cargo check -p tickvault-core -p tickvault-app --lib` clean
- `cargo fmt --check` clean
- `cargo clippy` — 0 new warnings in touched regions

## Aligns with existing anti-spam patterns

- `WebSocketDisconnectedOffHours` (Severity::Low) added 2026-04-22
- Depth rebalancer market-hours gate + edge-triggered stale alert (2026-04-17, audit-findings Rule 3 + Rule 4)
- Same `is_within_market_hours_ist()` helper from `tickvault_common::market_hours`

## Test plan

- [ ] Redeploy tickvault with this fix + PR #332 landed
- [ ] Boot post-market → confirm depth disconnects fire as `[LOW] Depth 200-level disconnected (off-hours / no-data)` instead of `[HIGH]`
- [ ] Boot during market hours with a real Dhan server-side issue → confirm disconnects still fire as `[HIGH]` with SMS

https://claude.ai/code/session_013HPKTjcgkrYMSsVm3tNi39

---
_Generated by [Claude Code](https://claude.ai/code/session_0194Cc98d2ppQ68GmxUGWttX)_