### PR TITLE
fix(ws): defer main-feed + order-update connect until 09:00 IST

### DIFF
--- a/crates/common/src/market_hours.rs
+++ b/crates/common/src/market_hours.rs
@@ -81,6 +81,44 @@ pub fn is_within_market_hours_ist() -> bool {
     (TICK_PERSIST_START_SECS_OF_DAY_IST..TICK_PERSIST_END_SECS_OF_DAY_IST).contains(&sec_of_day)
 }
 
+/// Returns the number of seconds until the next `TICK_PERSIST_START_SECS_OF_DAY_IST`
+/// (09:00 IST). Returns `0` when currently within market hours.
+///
+/// Used by WebSocket boot gates that want to defer TCP connect until market
+/// open rather than flap against Dhan's pre-market idle-socket resets.
+///
+/// # Complexity
+/// O(1): same path as `is_within_market_hours_ist` plus arithmetic.
+///
+/// # Upper bound
+/// At most 24 hours minus the `[09:00, 15:30)` window, i.e. 17h30m = 63,000 s.
+///
+/// # Test override
+/// When `TEST_FORCE_IN_MARKET_HOURS` is set, returns `0` — same semantics as
+/// "currently in market hours".
+#[allow(clippy::cast_possible_truncation)] // APPROVED: secs-of-day and diff fit u32 by construction
+#[inline]
+// TEST-EXEMPT: covered by secs_until_next_open_returns_zero_during_market_hours, secs_until_next_open_bounded_below_one_day, secs_until_next_open_positive_when_off_hours below
+pub fn secs_until_next_market_open_ist() -> u64 {
+    if is_within_market_hours_ist() {
+        return 0;
+    }
+    let now_utc_secs = chrono::Utc::now().timestamp();
+    let sec_of_day = now_utc_secs
+        .saturating_add(i64::from(IST_UTC_OFFSET_SECONDS))
+        .rem_euclid(i64::from(SECONDS_PER_DAY)) as u32;
+    let open = TICK_PERSIST_START_SECS_OF_DAY_IST;
+    let day = SECONDS_PER_DAY;
+    // If sec_of_day < open → today, later. If sec_of_day >= open (we're past
+    // 09:00 but not within hours, i.e. >= 15:30) → next day's open.
+    let until = if sec_of_day < open {
+        open - sec_of_day
+    } else {
+        day - sec_of_day + open
+    };
+    u64::from(until)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +154,46 @@ mod tests {
     fn window_bounds_come_from_tick_persist_constants() {
         assert_eq!(TICK_PERSIST_START_SECS_OF_DAY_IST, 9 * 3600);
         assert_eq!(TICK_PERSIST_END_SECS_OF_DAY_IST, 15 * 3600 + 30 * 60);
+    }
+
+    // ----- secs_until_next_market_open_ist ----------------------------------
+
+    #[test]
+    fn secs_until_next_open_returns_zero_during_market_hours() {
+        set_test_force_in_market_hours(true);
+        assert_eq!(secs_until_next_market_open_ist(), 0);
+        set_test_force_in_market_hours(false);
+    }
+
+    /// Upper-bound sanity: 24h == 86,400s. The answer must be less than
+    /// 24h because there is at most one full day between two 09:00 IST
+    /// market opens.
+    #[test]
+    fn secs_until_next_open_bounded_below_one_day() {
+        let secs = secs_until_next_market_open_ist();
+        assert!(
+            secs < u64::from(SECONDS_PER_DAY),
+            "secs_until_next_market_open_ist() = {secs} must be < 24h ({})",
+            SECONDS_PER_DAY
+        );
+    }
+
+    /// If NOT in market hours, the helper MUST return a positive number of
+    /// seconds; returning 0 off-hours would make the boot-time defer loop
+    /// a no-op and re-introduce the flap.
+    #[test]
+    fn secs_until_next_open_positive_when_off_hours() {
+        // Force off-hours by clearing the override (default state).
+        set_test_force_in_market_hours(false);
+        if !is_within_market_hours_ist() {
+            assert!(
+                secs_until_next_market_open_ist() > 0,
+                "off-hours must return > 0 secs"
+            );
+        }
+        // If the real wall-clock happens to be inside [09:00, 15:30) IST
+        // while CI runs this test, we can't deterministically assert > 0
+        // — but `secs_until_next_open_returns_zero_during_market_hours`
+        // covers that direction.
     }
 }

--- a/crates/core/src/websocket/connection_pool.rs
+++ b/crates/core/src/websocket/connection_pool.rs
@@ -267,12 +267,25 @@ impl WebSocketConnectionPool {
             }
 
             let conn = Arc::clone(conn);
-            handles.push(tokio::spawn(async move { conn.run().await }));
+            let defer_label = format!("conn={idx}");
+            handles.push(tokio::spawn(async move {
+                // Off-hours boot gate: if the app starts outside
+                // [09:00, 15:30) IST, sleep until the next 09:00 IST
+                // BEFORE opening any TCP socket. Eliminates the pre-market
+                // disconnect/reconnect flap Parthiban reported on
+                // 2026-04-24 at 07:40 IST.
+                crate::websocket::market_hours_gate::defer_until_market_open_ist(
+                    "main_feed",
+                    &defer_label,
+                )
+                .await;
+                conn.run().await
+            }));
 
             info!(
                 connection_id = idx,
                 total = self.connections.len(),
-                "Spawned WebSocket connection"
+                "Spawned WebSocket connection (task started; may defer connect if off-hours)"
             );
         }
 

--- a/crates/core/src/websocket/connection_pool.rs
+++ b/crates/core/src/websocket/connection_pool.rs
@@ -1053,6 +1053,43 @@ mod tests {
 
     // --- spawn_all() Tests ---
 
+    /// RAII guard: pin `is_within_market_hours_ist()` to `true` for the
+    /// lifetime of the guard.
+    ///
+    /// The off-hours boot gate added in `market_hours_gate.rs` (2026-04-24,
+    /// fix-offhours-ws-connect-flap) otherwise sleeps each `spawn_all` task
+    /// until the next 09:00 IST, which would hang every `test_spawn_all_*`
+    /// when CI runs outside market hours (most of the 24-hour day).
+    /// Wrapping each test with this guard forces the gate to short-circuit
+    /// and preserves the pre-fix test semantics (tasks run immediately).
+    ///
+    /// **Race-safe:** a process-global refcount ensures the override stays
+    /// `true` until the LAST concurrent guard drops. Without this,
+    /// `cargo test` running tests in parallel would see test A's drop
+    /// flip the atomic to `false` while test B's tasks are still parked
+    /// at the gate, re-introducing the exact hang this guard exists to
+    /// prevent.
+    static MARKET_HOURS_GUARD_REFCOUNT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    struct MarketHoursTestGuard;
+    impl MarketHoursTestGuard {
+        fn new() -> Self {
+            MARKET_HOURS_GUARD_REFCOUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            tickvault_common::market_hours::set_test_force_in_market_hours(true);
+            Self
+        }
+    }
+    impl Drop for MarketHoursTestGuard {
+        fn drop(&mut self) {
+            let prev =
+                MARKET_HOURS_GUARD_REFCOUNT.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            // Only clear the override when we were the LAST guard holding it.
+            if prev == 1 {
+                tickvault_common::market_hours::set_test_force_in_market_hours(false);
+            }
+        }
+    }
+
     /// Session 8 final-sweep helper — drain all spawned WebSocket tasks for
     /// test cleanup without hanging. Signals graceful shutdown first, then
     /// aborts each handle so the task exits even if the deeper connection
@@ -1072,6 +1109,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_all_returns_correct_number_of_handles() {
+        let _guard = MarketHoursTestGuard::new();
         let pool = WebSocketConnectionPool::new(
             make_test_token_handle(), // No token → connections will fail
             "test-client".to_string(),
@@ -1101,6 +1139,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_all_empty_pool_returns_handles() {
+        let _guard = MarketHoursTestGuard::new();
         let pool = WebSocketConnectionPool::new(
             make_test_token_handle(),
             "test-client".to_string(),
@@ -1125,6 +1164,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_all_tasks_return_reconnection_exhausted() {
+        let _guard = MarketHoursTestGuard::new();
         let pool = WebSocketConnectionPool::new(
             make_test_token_handle(),
             "test-client".to_string(),
@@ -1395,6 +1435,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_all_with_single_connection() {
+        let _guard = MarketHoursTestGuard::new();
         let config = DhanConfig {
             max_websocket_connections: 1,
             ..make_test_dhan_config()
@@ -1423,6 +1464,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_all_with_stagger_returns_correct_handles() {
+        let _guard = MarketHoursTestGuard::new();
         let pool = WebSocketConnectionPool::new(
             make_test_token_handle(),
             "test-client".to_string(),
@@ -1570,6 +1612,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_all_zero_stagger_is_instant() {
+        let _guard = MarketHoursTestGuard::new();
         let pool = WebSocketConnectionPool::new(
             make_test_token_handle(),
             "test-client".to_string(),

--- a/crates/core/src/websocket/market_hours_gate.rs
+++ b/crates/core/src/websocket/market_hours_gate.rs
@@ -1,0 +1,176 @@
+//! Off-hours WebSocket connect gate.
+//!
+//! **Directive:** Parthiban, 2026-04-24 — "inside market hours it should
+//! never ever happen right dude". Pre-market Dhan's WebSocket servers
+//! (`api-feed.dhan.co`, `api-order-update.dhan.co`, etc.) TCP-RST every
+//! idle connection. Our reconnect loop then re-dials, Dhan RSTs again,
+//! the cycle repeats for ~1.5 hours until 09:00 IST. This burns CPU,
+//! bandwidth, and Telegram alerts for zero data, AND risks bleeding the
+//! reconnect storm into market open where tick loss is unacceptable.
+//!
+//! The fix is to not connect at all until market open. This module
+//! provides the async gate that every WebSocket entry-point must call
+//! before opening its first TCP socket.
+//!
+//! # When this fires
+//! - App boots at 06:00 IST → `defer_until_market_open_ist` sleeps ~3h
+//!   until 09:00 IST, then returns. Main feed + order update sockets
+//!   open at 09:00 with zero flap.
+//! - App boots at 10:00 IST (inside market hours) → helper returns
+//!   immediately. No behaviour change from the pre-2026-04-24 code.
+//! - App boots at 16:00 IST (post-market) → helper sleeps until the
+//!   next day's 09:00 IST. Same rationale — Dhan resets idle sockets
+//!   post-market too.
+//!
+//! # Scope — does NOT replace existing reconnect throttling
+//! This gate applies ONCE, at task start, before the first connect.
+//! Once a connection is up and then drops mid-session, the existing
+//! reconnect loops (in `connection.rs`, `order_update_connection.rs`,
+//! `depth_connection.rs`) own the reconnect cadence. Their existing
+//! 3-consecutive-failure off-hours give-up logic still fires.
+
+use std::time::Duration;
+
+use tracing::info;
+
+use tickvault_common::market_hours::{is_within_market_hours_ist, secs_until_next_market_open_ist};
+
+/// Metric name emitted when a WebSocket task defers its boot connect.
+/// Label `ws_kind` carries one of `main_feed`, `order_update`, `depth_20`,
+/// `depth_200` so Prometheus can attribute the defer to a specific
+/// subsystem.
+pub const WS_BOOT_DEFER_METRIC: &str = "tv_websocket_boot_connect_deferred_total";
+
+/// Metric name emitted when the boot defer completes and the task is
+/// released to open its first TCP socket.
+pub const WS_BOOT_DEFER_RELEASED_METRIC: &str = "tv_websocket_boot_connect_defer_released_total";
+
+/// Sleeps until the next 09:00 IST market open if the current wall clock
+/// is outside `[09:00, 15:30)` IST. Returns immediately when inside
+/// market hours or when the test override is set.
+///
+/// # Arguments
+/// * `ws_kind` — short tag for logs + metric label (e.g. `"main_feed"`,
+///   `"order_update"`). Must be `'static` so the tracing call site can
+///   use it without allocation on the hot path.
+/// * `task_label` — additional context for the log (e.g. connection
+///   index, contract name). Can be empty.
+///
+/// # Behaviour
+/// - In market hours → returns immediately, emits no log, no metric.
+/// - Off hours → logs `info!`, increments the defer counter, sleeps the
+///   computed duration, increments the release counter, returns.
+///
+/// # Cancellation safety
+/// The wait is a single `tokio::time::sleep`, which is cancel-safe.
+/// Callers that want to cancel the defer (e.g. on graceful shutdown)
+/// should race this future against their shutdown signal via
+/// `tokio::select!`.
+// TEST-EXEMPT: covered by defer_returns_immediately_during_market_hours below + two source-scanning regression guards
+pub async fn defer_until_market_open_ist(ws_kind: &'static str, task_label: &str) {
+    if is_within_market_hours_ist() {
+        return;
+    }
+
+    let secs = secs_until_next_market_open_ist();
+    // secs == 0 would mean "in market hours", which the early return above
+    // already handled. Defensive saturating addition so a bad clock never
+    // produces a zero-length sleep that silently disables the gate.
+    let sleep_secs = secs.max(1);
+
+    info!(
+        ws_kind,
+        task_label,
+        sleep_secs,
+        "WebSocket boot connect deferred — outside market hours [09:00, 15:30) IST. \
+         Pre/post-market Dhan TCP-RSTs every idle socket, so we wait until the \
+         next 09:00 IST before opening any TCP connection."
+    );
+    metrics::counter!(WS_BOOT_DEFER_METRIC, "ws_kind" => ws_kind).increment(1);
+
+    tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
+
+    info!(
+        ws_kind,
+        task_label,
+        slept_secs = sleep_secs,
+        "WebSocket boot connect gate released — market hours entered, proceeding to connect"
+    );
+    metrics::counter!(WS_BOOT_DEFER_RELEASED_METRIC, "ws_kind" => ws_kind).increment(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tickvault_common::market_hours::set_test_force_in_market_hours;
+
+    /// When forced in-market, the helper must return immediately — verified
+    /// by bounding the elapsed wall-clock time to well under one second.
+    #[tokio::test]
+    async fn defer_returns_immediately_during_market_hours() {
+        set_test_force_in_market_hours(true);
+        let start = std::time::Instant::now();
+        defer_until_market_open_ist("test_kind", "test_label").await;
+        let elapsed = start.elapsed();
+        set_test_force_in_market_hours(false);
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "defer_until_market_open_ist must return immediately in market hours, \
+             took {:?}",
+            elapsed
+        );
+    }
+
+    /// The metric name constants must stay stable — Prometheus dashboards
+    /// and alert rules reference them by literal string.
+    #[test]
+    fn metric_names_are_stable() {
+        assert_eq!(
+            WS_BOOT_DEFER_METRIC, "tv_websocket_boot_connect_deferred_total",
+            "metric name MUST NOT change — Grafana dashboards reference it by literal"
+        );
+        assert_eq!(
+            WS_BOOT_DEFER_RELEASED_METRIC, "tv_websocket_boot_connect_defer_released_total",
+            "metric name MUST NOT change — Grafana dashboards reference it by literal"
+        );
+    }
+
+    /// Regression guard: `connection_pool::spawn_all` MUST call
+    /// `defer_until_market_open_ist("main_feed", ...)` inside the per-task
+    /// `tokio::spawn` closure. If anyone removes the gate, this test fails
+    /// at `cargo test` time — before the flap ever reaches prod again.
+    #[test]
+    fn regression_main_feed_pool_wires_the_defer_gate() {
+        let src = include_str!("../../src/websocket/connection_pool.rs");
+        assert!(
+            src.contains("market_hours_gate::defer_until_market_open_ist"),
+            "connection_pool.rs MUST call \
+             crate::websocket::market_hours_gate::defer_until_market_open_ist \
+             before conn.run().await. Off-hours connect flap regression guard."
+        );
+        assert!(
+            src.contains("\"main_feed\""),
+            "connection_pool.rs MUST tag the defer call with ws_kind=\"main_feed\" \
+             so Prometheus can attribute the defer to the main feed pool."
+        );
+    }
+
+    /// Regression guard: `order_update_connection::run_order_update_connection`
+    /// MUST call the defer gate at task entry.
+    #[test]
+    fn regression_order_update_wires_the_defer_gate() {
+        let src = include_str!("../../src/websocket/order_update_connection.rs");
+        assert!(
+            src.contains("market_hours_gate::defer_until_market_open_ist"),
+            "order_update_connection.rs MUST call \
+             crate::websocket::market_hours_gate::defer_until_market_open_ist \
+             at the top of run_order_update_connection. Off-hours connect flap \
+             regression guard."
+        );
+        assert!(
+            src.contains("\"order_update\""),
+            "order_update_connection.rs MUST tag the defer call with \
+             ws_kind=\"order_update\"."
+        );
+    }
+}

--- a/crates/core/src/websocket/mod.rs
+++ b/crates/core/src/websocket/mod.rs
@@ -16,6 +16,7 @@ pub mod activity_watchdog;
 pub mod connection;
 pub mod connection_pool;
 pub mod depth_connection;
+pub mod market_hours_gate;
 pub mod order_update_connection;
 pub mod pool_watchdog;
 pub mod subscription_builder;

--- a/crates/core/src/websocket/order_update_connection.rs
+++ b/crates/core/src/websocket/order_update_connection.rs
@@ -76,6 +76,17 @@ pub async fn run_order_update_connection(
 
     info!("order update WebSocket starting");
 
+    // Off-hours boot gate: Dhan's `api-order-update.dhan.co` TCP-RSTs idle
+    // sockets outside market hours. If we open a socket at 06:00 IST the
+    // server resets it within seconds, and the reconnect loop flaps until
+    // 09:00 IST. Defer the first connect until market open to eliminate
+    // the flap (Parthiban directive, 2026-04-24).
+    crate::websocket::market_hours_gate::defer_until_market_open_ist(
+        "order_update",
+        "run_order_update_connection",
+    )
+    .await;
+
     loop {
         // Snapshot the failure count BEFORE the connect attempt. If the
         // attempt succeeds AND this counter is > 0, we have just


### PR DESCRIPTION
## Summary

Eliminates the pre-market **WebSocket disconnect/reconnect flap** Parthiban observed on 2026-04-24T07:40 IST — 5× main-feed disconnects + order-update reconnect storm, all tagged `[off-hours, auto-reconnecting]`. Defers the **initial boot connect** for both WebSockets until `09:00 IST`; inside market hours behaviour is unchanged (instant connect + existing reconnect loops).

Parthiban directive: _"inside market hours it should never ever happen right dude"_. This PR makes that true by never opening the first TCP socket outside the market-hours window.

## Prod log evidence (2026-04-24T07:40 IST)

```
[LOW] WebSocket 1/5 disconnected [off-hours, auto-reconnecting]
WebSocket protocol error: Connection reset without closing handshake
[LOW] WebSocket 2/5 disconnected [off-hours, auto-reconnecting]
...
[MEDIUM] Order Update WS reconnected — Recovered after 2 consecutive failures
```

Cycle repeats every few minutes from app-start until `09:00 IST`.

## Root cause

Main-feed (`wss://api-feed.dhan.co`) and order-update (`wss://api-order-update.dhan.co`) both open their TCP sockets at boot regardless of wall-clock. Outside `[09:00, 15:30) IST` Dhan's servers TCP-RST every idle socket within seconds. Our reconnect loop successfully re-handshakes, which **resets the `3-consecutive-failures` off-hours give-up counter to 0** — so the flap never terminates. Burns CPU, bandwidth, Telegram alerts, and risks bleeding into market open where tick loss is unacceptable.

## Fix

New `tickvault_core::websocket::market_hours_gate` module with `defer_until_market_open_ist(ws_kind, task_label)` async helper. Wired into:

- **`WebSocketConnectionPool::spawn_all`** — each per-connection `tokio::spawn` closure awaits the gate before `conn.run().await`. Handles are returned immediately so market-close abort (`handle.abort()`) still works.
- **`run_order_update_connection`** — gate awaited at function entry, before the reconnect loop.

At `09:00 IST` both paths release together and open exactly one clean TCP socket. Existing mid-session reconnect loops and the `3-consecutive-failures` off-hours give-up rule continue to own post-9:00 behaviour.

Pure helper `secs_until_next_market_open_ist()` added to `tickvault_common::market_hours` — keeps `tickvault-common` free of tokio while centralising the arithmetic.

## Observability

Two new Prometheus counters label the defer by `ws_kind` (`main_feed`, `order_update`):
- `tv_websocket_boot_connect_deferred_total{ws_kind=...}` — fires when a task parks
- `tv_websocket_boot_connect_defer_released_total{ws_kind=...}` — fires when the gate releases

## Regression guards (all source-scanning)

| Test | Purpose |
|---|---|
| `regression_main_feed_pool_wires_the_defer_gate` | `connection_pool.rs` must call the gate with `ws_kind="main_feed"` |
| `regression_order_update_wires_the_defer_gate` | `order_update_connection.rs` must call it with `ws_kind="order_update"` |
| `metric_names_are_stable` | Prometheus metric-name constants pinned |
| `defer_returns_immediately_during_market_hours` | Async short-circuit verified via elapsed < 200 ms |
| `secs_until_next_open_returns_zero_during_market_hours` | Respects `TEST_FORCE_IN_MARKET_HOURS` |
| `secs_until_next_open_bounded_below_one_day` | Arithmetic upper bound |
| `secs_until_next_open_positive_when_off_hours` | Off-hours never returns 0 (would silently disable the gate) |

## Test results

- 611/611 `tickvault-common` lib tests pass
- Gate module: 4/4 tests pass (including both source-scan regression guards)
- `cargo fmt --check` clean for core + common
- No new clippy warnings introduced

## Scope

Main-feed + order-update only. **Depth (20/200-level) already has its own 09:13 IST dispatcher and DEFERRED-mode spawn** (commit `cc74145`), so this PR leaves depth alone — adding another gate would risk the known-working dispatcher flow. Follow-up if depth flap is observed.

## Test plan

- [x] Unit: 7 tests across the new module + helper, all passing
- [x] Source-scan regression guards lock in the wiring
- [x] Format + scoped tests green
- [ ] Live smoke: boot app at ~08:55 IST — verify only ONE `WebSocket 1/5 connected` burst at 09:00, zero disconnect/reconnect events in `[08:55, 09:05)`
- [ ] Live smoke: check `tv_websocket_boot_connect_deferred_total` in Prometheus = 5 (main feed) + 1 (order update) = 6 after an off-hours boot

https://claude.ai/code/session_0153UbB8gKi2aWNs6Zqr1aiz

---
_Generated by [Claude Code](https://claude.ai/code/session_0153UbB8gKi2aWNs6Zqr1aiz)_