### PR TITLE
fix(app): historical-fetch must NOT fire "OK" when zero fetched + zero candles (finding #1)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4923,14 +4923,34 @@ fn spawn_historical_candle_fetch(
         )
         .await;
 
-        if summary.instruments_failed > 0 {
+        // 2026-04-24 audit finding #1: do NOT fire "Historical candles OK"
+        // when the degenerate case `instruments_fetched == 0 &&
+        // total_candles == 0` occurs. Without this guard, a Dhan outage
+        // that returns 200-with-empty-payload, an empty universe on a
+        // mid-boot race, or a disabled-scope misconfiguration all produce
+        // a green Telegram ("Fetched: 0 / Candles: 0") — exact same bug
+        // class as the cross-match false-OK fix in PR #341. The downstream
+        // cross-verify then trusts that signal and silently passes too.
+        //
+        // Routes to HistoricalFetchFailed with a synthesized failure_reasons
+        // entry so the operator gets a clear diagnostic in Telegram.
+        let zero_fetched_degenerate =
+            summary.instruments_fetched == 0 && summary.total_candles == 0;
+        if summary.instruments_failed > 0 || zero_fetched_degenerate {
+            let mut failure_reasons = summary.failure_reasons.clone();
+            if zero_fetched_degenerate && summary.instruments_failed == 0 {
+                failure_reasons.insert(
+                    "zero_fetched_zero_candles".to_string(),
+                    summary.instruments_skipped.max(1),
+                );
+            }
             bg_notifier.notify(NotificationEvent::HistoricalFetchFailed {
                 instruments_fetched: summary.instruments_fetched,
                 instruments_failed: summary.instruments_failed,
                 total_candles: summary.total_candles,
                 persist_failures: summary.persist_failures,
                 failed_instruments: summary.failed_instruments.clone(),
-                failure_reasons: summary.failure_reasons.clone(),
+                failure_reasons,
             });
         } else {
             bg_notifier.notify(NotificationEvent::HistoricalFetchComplete {

--- a/crates/app/tests/mid_session_boot_guard.rs
+++ b/crates/app/tests/mid_session_boot_guard.rs
@@ -140,3 +140,42 @@ fn test_depth_200_main_rs_increments_spawn_counter() {
          run_two_hundred_depth_connection."
     );
 }
+
+#[test]
+fn test_historical_fetch_guards_zero_fetched_zero_candles() {
+    // 2026-04-24 audit finding #1: HistoricalFetchComplete must NOT fire
+    // when `instruments_fetched == 0 && total_candles == 0`. Without this
+    // guard, a Dhan outage that returns 200-with-empty-payload, an empty
+    // universe on a mid-boot race, or a disabled-scope misconfiguration
+    // all produced a green Telegram "Historical candles OK / Fetched: 0 /
+    // Candles: 0" — same false-OK class as the 2026-04-24 15:47 IST
+    // cross-match bug fixed in PR #341.
+    let src = read_file("crates/app/src/main.rs");
+    assert!(
+        src.contains("zero_fetched_degenerate"),
+        "2026-04-24 regression: zero_fetched_degenerate guard missing from \
+         historical-fetch success/failure routing. Without it, fresh-boot \
+         against a Dhan outage produces a false-OK Telegram."
+    );
+    assert!(
+        src.contains("\"zero_fetched_zero_candles\".to_string()"),
+        "2026-04-24 regression: failure_reasons entry for the degenerate \
+         case must include a named reason so Telegram surfaces the actual \
+         diagnostic instead of an empty breakdown."
+    );
+    // Enforce the boolean composition — both conjuncts required. If the
+    // future maintainer removes the `total_candles == 0` conjunct, the
+    // guard regresses silently (any non-zero candle count would bypass).
+    assert!(
+        src.contains("summary.instruments_fetched == 0 && summary.total_candles == 0"),
+        "2026-04-24 regression: zero_fetched_degenerate must require BOTH \
+         instruments_fetched == 0 AND total_candles == 0. Dropping either \
+         conjunct reintroduces the false-OK class."
+    );
+    // Enforce the routing — degenerate case goes to Failed variant.
+    assert!(
+        src.contains("summary.instruments_failed > 0 || zero_fetched_degenerate"),
+        "2026-04-24 regression: degenerate case must route to \
+         HistoricalFetchFailed, not HistoricalFetchComplete."
+    );
+}


### PR DESCRIPTION
## Summary

**Audit finding #1 (HIGH severity)** from the 2026-04-24 deep-audit run. Same class of false-OK bug as the cross-match coverage guard shipped in PR #341.

## The bug

Before this fix, `HistoricalFetchComplete` fired Telegram **"Historical candles OK / Fetched: 0 / Candles: 0"** whenever `summary.instruments_failed == 0`, including the degenerate cases:

| Degenerate case | Produced |
|---|---|
| Dhan REST outage returning 200-with-empty-payload | ✅ False OK |
| Empty universe on mid-boot race (CSV not yet loaded) | ✅ False OK |
| Disabled-scope misconfiguration (no instruments selected) | ✅ False OK |
| All instruments derivative/skipped (nothing to fetch) | ✅ False OK |

Downstream cross-verify then trusted that signal and silently passed too — the operator got **two** green Telegrams while zero data was actually fetched.

## The fix

| Location | Change |
|---|---|
| `crates/app/src/main.rs:4926-4942` | New boolean `zero_fetched_degenerate = (instruments_fetched == 0 && total_candles == 0)`. Both conjuncts required. Routing: `instruments_failed > 0 \|\| zero_fetched_degenerate` → `HistoricalFetchFailed`, else → `HistoricalFetchComplete` (unchanged). When degenerate case fires but `instruments_failed == 0`, synthesize failure_reasons entry `"zero_fetched_zero_candles" -> max(instruments_skipped, 1)` so Telegram surfaces a named diagnostic. |
| `crates/app/tests/mid_session_boot_guard.rs` | New regression test `test_historical_fetch_guards_zero_fetched_zero_candles` with **4 source-scan assertions**: (1) `zero_fetched_degenerate` keyword present, (2) named failure reason present, (3) BOTH conjuncts required (single-conjunct regressions caught), (4) routing targets `HistoricalFetchFailed`. |

## Test plan

- [x] `cargo test -p tickvault-app --test mid_session_boot_guard` — **8/8 pass** (1 new)
- [ ] CI workflows — will run on PR open
- [ ] Operator: next Dhan outage / empty-universe boot → expect `HistoricalFetchFailed` Telegram with `zero_fetched_zero_candles` reason instead of false `OK`

## Audit queue — this is 1 of 8 findings

The 2026-04-24 deep-audit surfaced these findings in priority order:

| # | Sev | Area | Status |
|---|---|---|---|
| 1 | HIGH | HistoricalFetchComplete false-OK | **THIS PR** |
| 2 | HIGH | TickGapTracker stall-detection poller unused | queued |
| 3 | HIGH | TickGapTracker bypassed on QuestDB flap | queued |
| 4 | MED | order_update silent-drop no counter | queued |
| 5 | MED | Grafana raw counters (not rate()) | queued |
| 6 | MED | InstrumentBuildSuccess defined but never emitted | queued |
| 7 | MED | summary_writer sync_all().ok() swallow | queued |
| 8 | LOW | MarketOpenStreamingConfirmation could read 0/5 | queued |

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_