### PR TITLE
feat(app): emit InstrumentBuildSuccess on both boot paths (finding #6)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -737,6 +737,23 @@ async fn main() -> Result<()> {
         let (subscription_plan, fresh_universe, _needs_persist) =
             load_instruments(&config, is_trading, trading_calendar.as_ref()).await;
 
+        // Audit finding #6 (2026-04-24): emit InstrumentBuildSuccess when
+        // instruments load successfully. Previously only the FAILURE path
+        // (`InstrumentBuildFailed`) fired a Telegram, leaving operators
+        // without a positive signal that the daily rebuild succeeded.
+        if let Some(ref u) = fresh_universe {
+            let source = if _needs_persist {
+                "rkyv_cache"
+            } else {
+                "fresh_csv_build"
+            };
+            fast_notifier.notify(NotificationEvent::InstrumentBuildSuccess {
+                source: source.to_string(),
+                derivative_count: u.derivative_contracts.len(),
+                underlying_count: u.underlyings.len(),
+            });
+        }
+
         // --- WebSocket pool create (channel only, NOT spawned yet) ---
         let (pool_receiver, ws_pool_ready) = match create_websocket_pool(
             &token_handle,
@@ -1717,6 +1734,25 @@ async fn main() -> Result<()> {
     // To avoid DOUBLE persistence on FreshBuild, only persist if CachedPlan.
     let (subscription_plan, slow_boot_universe, needs_instrument_persist) =
         load_instruments(&config, is_trading, trading_calendar.as_ref()).await;
+
+    // Audit finding #6 (2026-04-24): emit InstrumentBuildSuccess when
+    // instruments load successfully on the standard-boot path. Mirrors
+    // the fast-boot emission above. Before this, only failure produced
+    // a Telegram — operators had no positive "instruments rebuilt OK"
+    // signal.
+    if let Some(ref u) = slow_boot_universe {
+        let source = if needs_instrument_persist {
+            "rkyv_cache"
+        } else {
+            "fresh_csv_build"
+        };
+        notifier.notify(NotificationEvent::InstrumentBuildSuccess {
+            source: source.to_string(),
+            derivative_count: u.derivative_contracts.len(),
+            underlying_count: u.underlyings.len(),
+        });
+    }
+
     // Only persist for CachedPlan (not yet persisted). FreshBuild already
     // persisted inside load_or_build_instruments — double-write creates
     // duplicate rows in the same timestamp second.

--- a/crates/app/tests/mid_session_boot_guard.rs
+++ b/crates/app/tests/mid_session_boot_guard.rs
@@ -125,6 +125,39 @@ fn test_depth_200_has_initial_stagger_constant() {
 }
 
 #[test]
+fn test_instrument_build_success_event_is_emitted_on_both_boot_paths() {
+    // 2026-04-24 audit finding #6: InstrumentBuildSuccess was defined and
+    // unit-tested but NEVER emitted in production. Only the FAILURE path
+    // (InstrumentBuildFailed) fired, so operators had no positive Telegram
+    // signal that the daily instrument rebuild succeeded.
+    //
+    // This guard ensures InstrumentBuildSuccess is fired from BOTH the
+    // fast-boot and slow-boot load_instruments call sites.
+    let src = read_file("crates/app/src/main.rs");
+    let emissions = src
+        .matches("NotificationEvent::InstrumentBuildSuccess")
+        .count();
+    assert!(
+        emissions >= 2,
+        "2026-04-24 regression: InstrumentBuildSuccess must be emitted from \
+         BOTH boot paths (fast-boot + slow-boot). Found only {emissions} emission(s). \
+         Without both, one boot path regresses to silent-success behaviour."
+    );
+    // The source tag must be one of the two expected values — not a blank
+    // or generic string.
+    assert!(
+        src.contains("\"fresh_csv_build\""),
+        "2026-04-24 regression: source tag for FreshBuild must be \
+         'fresh_csv_build' (distinguishes from cache-hit path)."
+    );
+    assert!(
+        src.contains("\"rkyv_cache\""),
+        "2026-04-24 regression: source tag for CachedPlan must be \
+         'rkyv_cache' (distinguishes from fresh-csv path)."
+    );
+}
+
+#[test]
 fn test_depth_200_main_rs_increments_spawn_counter() {
     let src = read_file("crates/app/src/main.rs");
     assert!(


### PR DESCRIPTION
## Summary

**Audit finding #6 (MEDIUM)** — observability gap.

`NotificationEvent::InstrumentBuildSuccess` is defined in `events.rs:445`, severity-tagged (`Severity::Low`), and has unit tests — but was **never emitted in production code**. Only the failure path (`InstrumentBuildFailed`) fired Telegram, so operators had no positive signal that the daily 08:15 IST instrument rebuild succeeded.

## Fix

| Location | Change |
|---|---|
| `crates/app/src/main.rs:737` (fast-boot) | After `load_instruments` returns, emit `NotificationEvent::InstrumentBuildSuccess` with `source`, `derivative_count`, `underlying_count` |
| `crates/app/src/main.rs:1719` (slow-boot) | Mirror the same emission so operators get the signal regardless of boot path |

`source` tag distinguishes the two paths:
- `"fresh_csv_build"` — FreshBuild variant (built from Dhan CSV download)
- `"rkyv_cache"` — CachedPlan variant (loaded from zero-copy rkyv cache)

## Regression guard

New test `test_instrument_build_success_event_is_emitted_on_both_boot_paths` in `crates/app/tests/mid_session_boot_guard.rs`:
1. Source-scan asserts ≥2 emission sites in main.rs
2. Asserts `"fresh_csv_build"` source tag present
3. Asserts `"rkyv_cache"` source tag present

## Test plan

- [x] `cargo test -p tickvault-app --test mid_session_boot_guard` — **8/8 pass** (1 new)
- [x] `cargo check -p tickvault-app` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI workflows — will run on PR open
- [ ] Operator: next boot → expect green `InstrumentBuildSuccess` Telegram with `source` + counts

## Audit queue

| # | Sev | Area | Status |
|---|---|---|---|
| 1 | HIGH | HistoricalFetchComplete false-OK | PR #342 (pending merge) |
| 2 | HIGH | TickGapTracker stall-detection poller unused | queued |
| 3 | HIGH | TickGapTracker bypassed on QuestDB flap | queued |
| 4 | MED | order_update silent-drop no counter | queued |
| 5 | MED | Grafana raw counters (not rate()) | queued |
| 6 | MED | InstrumentBuildSuccess defined but never emitted | **THIS PR** |
| 7 | MED | summary_writer sync_all().ok() swallow | queued |
| 8 | LOW | MarketOpenStreamingConfirmation could read 0/5 | queued |

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_