### PR TITLE
fix(notification): propagate sync_all error in atomic_write (finding #7)

### DIFF
--- a/crates/core/src/notification/summary_writer.rs
+++ b/crates/core/src/notification/summary_writer.rs
@@ -386,13 +386,22 @@ fn escape_md(s: &str) -> String {
 }
 
 /// Atomic write: `{path}.tmp` → rename → `{path}`.
+///
+/// 2026-04-24 audit finding #7: previously `f.sync_all().ok()` silently
+/// discarded the flush-to-disk error. After a hard poweroff the rename
+/// could promote a partially-flushed file, and `errors.summary.md` is
+/// part of the zero-touch triage chain (see observability-architecture.md)
+/// so silent staleness matters. The sync error now propagates via `?` so
+/// the caller can retry on the next 60s tick instead of shipping a
+/// potentially-unflushed file to the rename step.
 fn atomic_write(path: &Path, contents: &str) -> Result<()> {
     let tmp = path.with_extension("md.tmp");
     {
         let mut f = fs::File::create(&tmp).with_context(|| format!("create {}", tmp.display()))?;
         f.write_all(contents.as_bytes())
             .with_context(|| format!("write {}", tmp.display()))?;
-        f.sync_all().ok();
+        f.sync_all()
+            .with_context(|| format!("sync_all {}", tmp.display()))?;
     }
     fs::rename(&tmp, path)
         .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;


### PR DESCRIPTION
## Summary

**Audit finding #7 (MEDIUM)** — silent failure in atomic file write.

`crates/core/src/notification/summary_writer.rs::atomic_write` called `f.sync_all().ok()` — **silently discarding the flush-to-disk error**. After a hard poweroff, the subsequent `fs::rename` would promote a potentially-unflushed file. `errors.summary.md` is part of the zero-touch triage chain (see `.claude/rules/project/observability-architecture.md`) so silent staleness erodes the "Claude watches logs" automation contract.

## Fix

| Before | After |
|---|---|
| `f.sync_all().ok();` | `f.sync_all().with_context(|| format!("sync_all {}", tmp.display()))?;` |

Error now propagates up to the caller (summary writer task). The caller already retries every 60s, so a transient sync error triggers a retry on the next tick instead of silently corrupting the file.

## Test plan

- [x] `cargo test -p tickvault-core --lib summary_writer` — **22/22 pass** (all existing atomic_write tests unchanged)
- [x] `cargo fmt --check` — clean
- [ ] CI workflows — will run on PR open

## Why no new test

The fix is a 1-line defensive improvement that strictly matches the error-propagation pattern of the adjacent `File::create` and `write_all` calls in the same function. Simulating a `sync_all` failure requires disk-error injection which is complex and low-value for a 3-LOC defensive change. The existing 22 tests cover the happy path, and the change is visible in `cargo fmt`-enforced source.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_