### PR TITLE
fix(ws): order-update broadcast drops now ERROR + counter (finding #4)

### DIFF
--- a/crates/core/src/websocket/order_update_connection.rs
+++ b/crates/core/src/websocket/order_update_connection.rs
@@ -353,8 +353,33 @@ async fn connect_and_listen(
                             "order update received"
                         );
                         // Broadcast to subscribers (OMS, notification, etc.).
-                        // If no receivers, send returns Err — that's fine, just discard.
-                        let _ = order_sender.send(update);
+                        // 2026-04-24 audit finding #4: previously discarded the
+                        // SendError with "no receivers — that's fine". BUT if
+                        // the OMS subscriber task panics or drops its receiver
+                        // mid-session, filled-order updates are silently lost
+                        // (status stays Pending → reconciliation alert fires
+                        // ≥60s later — too slow + too indirect). Now we emit
+                        // an ERROR + increment a Prometheus counter so the
+                        // drop is observable in real time.
+                        //
+                        // `broadcast::Sender::send` returns Err only when there
+                        // are zero active receivers. During normal operation
+                        // at least one OMS task IS subscribed; zero receivers
+                        // means the subscriber task crashed or the channel
+                        // was torn down — both are real bugs worth paging.
+                        //
+                        // Zero-alloc hot path: the `broadcast::error::SendError(T)`
+                        // gives back the original `update` on failure, so we can
+                        // read order_no from `err.0` without cloning. The happy
+                        // path (success) does not touch err at all.
+                        if let Err(err) = order_sender.send(update) {
+                            metrics::counter!("tv_order_update_broadcast_drops_total").increment(1);
+                            error!(
+                                order_no = %err.0.order_no,
+                                "order update broadcast dropped — no active receivers \
+                                 (OMS subscriber likely crashed or channel torn down)"
+                            );
+                        }
                     }
                     Err(err) => {
                         // Not a valid order update — check if it's an auth error.


### PR DESCRIPTION
## Summary

**Audit finding #4 (MEDIUM)** — silently dropped order-update broadcasts.

`order_update_connection.rs:357` previously discarded `broadcast::Sender::send`'s `SendError` with the comment "no receivers — that's fine". **Not fine.** `broadcast::Sender::send` returns `Err` only when there are zero active receivers. Under normal operation the OMS subscriber IS attached; zero receivers means the subscriber task crashed or the channel was torn down — both are real bugs that silently lose order-fill updates.

## Failure chain without the fix

| Step | What happens |
|---|---|
| 1 | OMS task panics mid-session, drops its receiver |
| 2 | Order fills on the exchange; filled-update arrives via WS |
| 3 | `order_sender.send(update)` returns `Err(SendError(update))` — silently discarded |
| 4 | OMS state machine stays stuck at `Pending` |
| 5 | ≥60s later, reconciliation task detects mismatch → MEDIUM alert |
| 6 | Operator sees misleading "state-machine mismatch" alert, NOT the actual "broadcast lost" root cause |

## Fix

Replace `let _ = order_sender.send(update);` with an error-logged branch that also increments a new Prometheus counter. Zero-alloc hot path — `broadcast::error::SendError(T)` gives back the original value, so `err.0.order_no` reads without cloning.

## New metric

| Name | Type | Meaning |
|---|---|---|
| `tv_order_update_broadcast_drops_total` | counter | Monotonic count of dropped order-update broadcasts. Normal = 0. Non-zero = page. |

## Test plan

- [x] `cargo check -p tickvault-core` — clean
- [x] `cargo test -p tickvault-core --lib order_update` — **117/117 pass**
- [x] `cargo fmt --check` — clean
- [x] Banned-pattern scanner (no `.clone()` on hot path) — clean
- [ ] CI workflows — will run on PR open

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_