### PR TITLE
fix(dashboards): show tick-drop/spill counters as increase(), not raw (finding #5)

### DIFF
--- a/deploy/docker/grafana/dashboards/operator-health.json
+++ b/deploy/docker/grafana/dashboards/operator-health.json
@@ -578,7 +578,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "tv_ticks_dropped_total",
+          "expr": "increase(tv_ticks_dropped_total[5m])",
           "refId": "A"
         }
       ],
@@ -694,7 +694,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "tv_ticks_spilled_total",
+          "expr": "increase(tv_ticks_spilled_total[5m])",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary

**Audit finding #5 (MEDIUM)** — dashboards lying about tick-drop/spill counts.

`deploy/docker/grafana/dashboards/operator-health.json` had two panels showing raw Prometheus counter values:

| Line | Metric | Before |
|---|---|---|
| 581 | `tv_ticks_dropped_total` | `"expr": "tv_ticks_dropped_total"` |
| 697 | `tv_ticks_spilled_total` | `"expr": "tv_ticks_spilled_total"` |

**Problem:** after a process restart the counter resets to 0 and the panel reads "0 dropped". Operator sees "no drops" and assumes all is well — even while drops are actively happening AGAIN in the current session. Raw counters hide ongoing failures behind every restart boundary.

## Fix

Wrap both expressions in `increase(...[5m])`:

| Line | Metric | After |
|---|---|---|
| 581 | `tv_ticks_dropped_total` | `"expr": "increase(tv_ticks_dropped_total[5m])"` |
| 697 | `tv_ticks_spilled_total` | `"expr": "increase(tv_ticks_spilled_total[5m])"` |

`increase()` correctly handles counter resets (Prometheus treats a decrease as a reset and counts forward from 0). After a restart the panel shows "0 dropped in last 5 min" (TRUE); once drops resume, the panel climbs immediately.

## Test plan

- [x] JSON parses successfully (`python3 json.load`)
- [x] `cargo test -p tickvault-storage --test grafana_dashboard_snapshot_filter_guard` — **23/23 pass** (dashboard snapshot meta-guard still green)
- [ ] CI workflows — will run on PR open
- [ ] Operator: restart the app → expect panels to show `0` briefly then climb as drops happen (not a flat lifetime counter)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_