### PR TITLE
fix(notification): route 09:15:30 heartbeat to Failed variant on 0 main feed (finding #8)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -3501,13 +3501,32 @@ async fn main() -> Result<()> {
                         order_update = oms,
                         "PROOF: market-open streaming confirmation fired @ 09:15:30 IST"
                     );
-                    heartbeat_notifier.notify(NotificationEvent::MarketOpenStreamingConfirmation {
-                        main_feed_active: main_active,
-                        main_feed_total: tickvault_common::constants::MAX_WEBSOCKET_CONNECTIONS,
-                        depth_20_active: d20,
-                        depth_200_active: d200,
-                        order_update_active: oms,
-                    });
+                    // Audit finding #8 (2026-04-24): when main feed is 0 at the
+                    // 09:15:30 heartbeat, this is NOT a positive "streaming live"
+                    // signal — it's a catastrophic missed market open. Route to
+                    // the High-severity Failed variant so the operator pages,
+                    // not to the Info-severity Confirmation that reads confusingly
+                    // as "Streaming live / Main feed: 0/5".
+                    if main_active == 0 {
+                        heartbeat_notifier.notify(NotificationEvent::MarketOpenStreamingFailed {
+                            main_feed_active: main_active,
+                            main_feed_total: tickvault_common::constants::MAX_WEBSOCKET_CONNECTIONS,
+                            depth_20_active: d20,
+                            depth_200_active: d200,
+                            order_update_active: oms,
+                        });
+                    } else {
+                        heartbeat_notifier.notify(
+                            NotificationEvent::MarketOpenStreamingConfirmation {
+                                main_feed_active: main_active,
+                                main_feed_total:
+                                    tickvault_common::constants::MAX_WEBSOCKET_CONNECTIONS,
+                                depth_20_active: d20,
+                                depth_200_active: d200,
+                                order_update_active: oms,
+                            },
+                        );
+                    }
                 });
             }
 

--- a/crates/app/tests/mid_session_boot_guard.rs
+++ b/crates/app/tests/mid_session_boot_guard.rs
@@ -211,6 +211,32 @@ fn test_per_instrument_stall_poller_is_wired() {
 }
 
 #[test]
+fn test_market_open_streaming_routes_to_failed_when_main_feed_is_zero() {
+    // 2026-04-24 audit finding #8: when main_feed_active == 0 at the
+    // 09:15:30 heartbeat, the event MUST route to MarketOpenStreamingFailed
+    // (Severity::High), NOT to MarketOpenStreamingConfirmation
+    // (Severity::Info). Without this branch, a catastrophic "no connections
+    // at market open" scenario shows up as "Streaming live / Main feed: 0/5"
+    // in Telegram — Info severity, wakes nobody up.
+    let src = read_file("crates/app/src/main.rs");
+    assert!(
+        src.contains("NotificationEvent::MarketOpenStreamingFailed"),
+        "2026-04-24 regression: MarketOpenStreamingFailed routing missing. \
+         When main_feed_active == 0 at 09:15:30 IST, operator must page via \
+         the High-severity Failed variant, not the Info-severity Confirmation."
+    );
+    // Branch predicate must be `main_active == 0` — if someone relaxes it
+    // to `main_active < 5` or similar, the normal degraded-but-still-streaming
+    // case flips to High-severity noise.
+    assert!(
+        src.contains("if main_active == 0 {"),
+        "2026-04-24 regression: MarketOpenStreamingFailed gate must be \
+         `main_active == 0` exactly — relaxing to `< 5` etc. produces \
+         false pages for degraded-but-streaming pool states."
+    );
+}
+
+#[test]
 fn test_historical_fetch_guards_zero_fetched_zero_candles() {
     // 2026-04-24 audit finding #1: HistoricalFetchComplete must NOT fire
     // when `instruments_fetched == 0 && total_candles == 0`. Without this

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -212,6 +212,22 @@ pub enum NotificationEvent {
         order_update_active: bool,
     },
 
+    /// Audit finding #8 (2026-04-24): when the 09:15:30 heartbeat fires
+    /// but the main-feed connection count is 0, the situation is the
+    /// OPPOSITE of "streaming OK" — it's a catastrophic missed market
+    /// open. The heartbeat codepath previously fired `MarketOpenStreaming
+    /// Confirmation` (Severity::Info) even in that case, reading as
+    /// "Streaming live @ 09:15:30 IST / Main feed: 0/5" which is confusing
+    /// and under-alerted. This variant fires at Severity::High so the
+    /// operator pages immediately instead of mistaking it for a heartbeat.
+    MarketOpenStreamingFailed {
+        main_feed_active: usize,
+        main_feed_total: usize,
+        depth_20_active: usize,
+        depth_200_active: usize,
+        order_update_active: bool,
+    },
+
     /// Plan item C (2026-04-22, visibility version): once-per-day audit
     /// trail of what NIFTY + BANKNIFTY 09:12 closes were used as the
     /// authoritative anchor for the day's depth ATM. The 60s depth
@@ -908,6 +924,23 @@ impl NotificationEvent {
                      Order updates: {oms}"
                 )
             }
+            Self::MarketOpenStreamingFailed {
+                main_feed_active,
+                main_feed_total,
+                depth_20_active,
+                depth_200_active,
+                order_update_active,
+            } => {
+                let oms = if *order_update_active { "1/1" } else { "0/1" };
+                format!(
+                    "<b>MARKET OPEN STREAMING FAILED @ 09:15:30 IST</b>\n\
+                     Main feed: {main_feed_active}/{main_feed_total} — NO CONNECTIONS\n\
+                     Depth-20: {depth_20_active}/4\n\
+                     Depth-200: {depth_200_active}/4\n\
+                     Order updates: {oms}\n\
+                     Action: check pool watchdog, token validity, Dhan status."
+                )
+            }
             Self::MarketOpenDepthAnchor {
                 underlying,
                 close_0912,
@@ -1508,6 +1541,7 @@ impl NotificationEvent {
             Self::WebSocketPoolRecovered { .. } => Severity::Medium,
             Self::WebSocketPoolHalt { .. } => Severity::High,
             Self::MarketOpenStreamingConfirmation { .. } => Severity::Info,
+            Self::MarketOpenStreamingFailed { .. } => Severity::High,
             Self::MarketOpenDepthAnchor { .. } => Severity::Info,
             Self::DepthIndexLtpTimeout { .. } => Severity::High,
             Self::DepthUnderlyingMissing { .. } => Severity::High,


### PR DESCRIPTION
## Summary

**Audit finding #8 (LOW)** — heartbeat under-alerts on catastrophic no-connections case.

When the 09:15:30 IST "market-open streaming confirmation" heartbeat fires with `main_feed_active == 0`, the operator previously received:

```
[Severity::Info] Streaming live @ 09:15:30 IST
Main feed: 0/5
Depth-20: 0/4
...
```

Info severity does NOT page. So a catastrophic "no connections at market open" scenario is indistinguishable from a healthy heartbeat at a glance.

## Fix

| Condition | Before | After |
|---|---|---|
| `main_feed_active > 0` | `MarketOpenStreamingConfirmation` (Info) | unchanged |
| `main_feed_active == 0` | `MarketOpenStreamingConfirmation` (Info, under-alerts) | **`MarketOpenStreamingFailed` (High, pages)** |

New variant `MarketOpenStreamingFailed` at Severity::High with explicit title **"MARKET OPEN STREAMING FAILED"** + action line "check pool watchdog, token validity, Dhan status."

Predicate is `== 0` exactly — relaxing to `< 5` would convert degraded-but-streaming pool states into High-severity noise.

## Regression guard

`test_market_open_streaming_routes_to_failed_when_main_feed_is_zero` source-scan asserts:
1. `MarketOpenStreamingFailed` emission present in main.rs
2. Branch predicate is `if main_active == 0 {` exactly

## Test plan

- [x] `cargo check -p tickvault-core -p tickvault-app` — clean
- [x] `cargo test -p tickvault-app --test mid_session_boot_guard` — **9/9 pass** (1 new)
- [x] `cargo test -p tickvault-core --lib notification::events` — 128/128 pass
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_