### PR TITLE
feat(hooks): auto-run doctor + validate-automation + mcp-doctor on every session start

### DIFF
--- a/.claude/hooks/session-auto-health.sh
+++ b/.claude/hooks/session-auto-health.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# .claude/hooks/session-auto-health.sh
+#
+# Fires on every SessionStart (startup + resume). Runs the three
+# automation primitives the operator asked to happen "automatically
+# every session":
+#
+#   1. `scripts/doctor.sh`                — infrastructure health snapshot
+#   2. `scripts/validate-automation.sh`   — ratchet audit (30 checks)
+#   3. `scripts/mcp-doctor.sh`            — MCP server connectivity
+#
+# Outputs go to `data/logs/session-auto-health.YYYY-MM-DD-HHMM.log`
+# so we don't pollute the operator's terminal. The startup time of a
+# Claude session is NOT gated on these runs — they are launched with
+# `nohup` + `&` and detached.
+#
+# If any script exits non-zero the summary line is still emitted at
+# session start so the operator sees a red/green indicator without
+# having to open the log file.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+LOG_DIR="$PROJECT_DIR/data/logs"
+mkdir -p "$LOG_DIR"
+
+TS="$(date +%Y-%m-%d-%H%M)"
+LOG="$LOG_DIR/session-auto-health.$TS.log"
+SUMMARY="$LOG_DIR/session-auto-health.latest.txt"
+
+# Header (synchronous — operator sees this instantly on session start).
+{
+  echo "--- session-auto-health.sh ---"
+  echo "started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "project: $PROJECT_DIR"
+  echo "log:     $LOG"
+} >&2
+
+# Wrap all three in a single background subshell so they run in series
+# without blocking session start. Writes a one-line verdict to SUMMARY
+# when done; `session-sanity.sh` (the other SessionStart hook) reads
+# that file if present on the NEXT session start.
+(
+  exec > "$LOG" 2>&1
+  echo "[auto-health] run $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  STATUS="ok"
+
+  run_stage() {
+    local name="$1"
+    local cmd="$2"
+    echo "--- stage: $name ---"
+    if bash -c "$cmd"; then
+      echo "[$name] PASS"
+    else
+      echo "[$name] FAIL"
+      STATUS="fail"
+    fi
+  }
+
+  if [[ -x "$PROJECT_DIR/scripts/doctor.sh" ]]; then
+    run_stage "doctor" "$PROJECT_DIR/scripts/doctor.sh"
+  else
+    echo "[doctor] SKIP (scripts/doctor.sh missing)"
+  fi
+
+  if [[ -x "$PROJECT_DIR/scripts/validate-automation.sh" ]]; then
+    run_stage "validate-automation" "$PROJECT_DIR/scripts/validate-automation.sh"
+  else
+    echo "[validate-automation] SKIP (script missing)"
+  fi
+
+  if [[ -x "$PROJECT_DIR/scripts/mcp-doctor.sh" ]]; then
+    run_stage "mcp-doctor" "$PROJECT_DIR/scripts/mcp-doctor.sh"
+  else
+    echo "[mcp-doctor] SKIP (script missing)"
+  fi
+
+  echo "[auto-health] verdict: $STATUS  at  $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "$STATUS $TS" > "$SUMMARY"
+) </dev/null >/dev/null 2>&1 &
+disown || true
+
+# Also print the last cycle's verdict (if any) so the operator sees
+# state IMMEDIATELY instead of having to wait for the next cycle.
+if [[ -f "$SUMMARY" ]]; then
+  echo "prev-cycle verdict: $(cat "$SUMMARY")" >&2
+else
+  echo "prev-cycle verdict: (none yet — first run in progress)" >&2
+fi
+
+echo "--- session-auto-health.sh dispatched ---" >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -171,6 +171,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-sanity.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-auto-health.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

**Addresses Parthiban directive:** *"every new or existing Claude code session or every new Claude cowork task or existing should automatically do everything as an automated process always"*.

Before: `SessionStart` fired only `session-sanity.sh` (session collision detection + auto-save daemon startup). Operators had to manually run `make doctor` / `scripts/validate-automation.sh` / `scripts/mcp-doctor.sh` to know whether infrastructure + ratchets + MCP connectivity were healthy.

After: a second `SessionStart` hook entry fires `session-auto-health.sh` which runs all three scripts in the background, writes a verdict line to `data/logs/session-auto-health.latest.txt`, and prints the PREVIOUS cycle's verdict to stderr immediately on session start so the operator has an instant red/green indicator without waiting for this cycle's ~30-60s run to finish.

## Files changed (2 files, +97 LOC)

| File | Change |
|---|---|
| `.claude/hooks/session-auto-health.sh` | New hook script (87 LOC). Dispatches doctor + validate-automation + mcp-doctor in a detached background subshell. Writes verdict to log + summary file. Skips gracefully if any script is missing. |
| `.claude/settings.json` | SessionStart entry now has 2 hooks: existing `session-sanity.sh` PLUS new `session-auto-health.sh` |

## Non-blocking by design

| Property | Implementation |
|---|---|
| Session startup latency | <100 ms added (just dispatch) |
| Actual work | Detached via `( ... ) </dev/null >/dev/null 2>&1 &` + `disown` |
| Operator sees | Prev cycle's verdict immediately on session start; current cycle's verdict written to `session-auto-health.latest.txt` for the next session |
| Missing scripts | Skip gracefully (`SKIP:` line), no `FAIL:` |

## Outputs

| Path | Purpose |
|---|---|
| `data/logs/session-auto-health.YYYY-MM-DD-HHMM.log` | Full run transcript per session |
| `data/logs/session-auto-health.latest.txt` | One-line verdict (`ok YYYY-MM-DD-HHMM` or `fail YYYY-MM-DD-HHMM`) |

## Test plan

- [x] `bash -n .claude/hooks/session-auto-health.sh` — syntax clean
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` — settings still valid JSON
- [x] Executable bit set via `chmod +x`
- [ ] CI workflows — will run on PR open
- [ ] Next SessionStart event → operator sees "prev-cycle verdict" line in stderr immediately

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_