### PR TITLE
feat(cross-verify): post-market-only gate + 100% coverage threshold

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5170,8 +5170,15 @@ fn spawn_historical_candle_fetch(
         // Otherwise pass the window to both functions so their SQL WHERE
         // clauses are narrowed to today's 09:15-15:30 IST session.
         // -----------------------------------------------------------------
+        // 2026-04-24 Parthiban directive: cross-verify is a POST-MARKET
+        // ONLY operation. The session must be fully closed before the
+        // grid is comparable — running mid-session always yields partial
+        // coverage and a non-actionable Skipped/Failed Telegram. The
+        // new gate in `from_now_post_market_only()` returns None for
+        // both pre-market AND mid-session boots; only 15:30+ IST on a
+        // trading day produces a window.
         let today_window = if is_trading_day {
-            tickvault_core::historical::cross_verify::TodayIstWindow::from_now()
+            tickvault_core::historical::cross_verify::TodayIstWindow::from_now_post_market_only()
         } else {
             None
         };
@@ -5192,13 +5199,19 @@ fn spawn_historical_candle_fetch(
                     candles_compared: 0,
                 });
             } else {
-                // Pre-market on a trading day — silent skip per Parthiban
-                // directive. INFO log only; NO Telegram notification.
+                // Trading day, but EITHER pre-market (< 09:15 IST) OR
+                // mid-session (09:15..15:30 IST). Silent skip per
+                // Parthiban directive — INFO log only, no Telegram.
+                // Cross-verify retries on every subsequent boot until
+                // the post-market gate opens, at which point the
+                // success-marker idempotency takes over.
                 info!(
                     instruments_fetched = summary.instruments_fetched,
                     instruments_failed = summary.instruments_failed,
                     total_candles = summary.total_candles,
-                    "cross-verify + cross-match SILENTLY skipped — pre-market on trading day (will run post-market)"
+                    "cross-verify + cross-match SILENTLY skipped — \
+                     trading day but not yet post-market (15:30 IST). \
+                     Will run on the next boot scheduled at or after 15:30 IST."
                 );
             }
             return;

--- a/crates/app/tests/cross_verify_post_market_only_guard.rs
+++ b/crates/app/tests/cross_verify_post_market_only_guard.rs
@@ -1,0 +1,163 @@
+//! 2026-04-24 — cross-verify post-market-only ratchet.
+//!
+//! Locks in the Parthiban directive 2026-04-24:
+//!
+//!   "cross verification should be done only one time, until or unless
+//!    it is fully successful it should run, that too only on working
+//!    trading days post-market alone only".
+//!
+//! Translates to four invariants that this test source-scans
+//! `crates/app/src/main.rs` and `crates/core/src/historical/cross_verify.rs`
+//! to enforce:
+//!
+//! 1. **`main.rs` calls `from_now_post_market_only`** — not `from_now`.
+//!    The original `from_now` returned Some during mid-session boots
+//!    (09:15+ IST) which produced partial-coverage cross-match failures;
+//!    the new constructor blocks until 15:30 IST.
+//! 2. **`CROSS_MATCH_MIN_COVERAGE_PCT == 100`** — was 90 (PR #341),
+//!    now 100 because post-market-only means the entire session is
+//!    settled. Anything less than full coverage is a real failure,
+//!    not a "session edge slop" artifact.
+//! 3. **`from_utc_post_market_only` is defined in `cross_verify.rs`**
+//!    — protects the constructor from being silently deleted in a
+//!    future refactor.
+//! 4. **The test asserting the constant is == 100** — guards against
+//!    a future PR bumping the constant back down to 90 without
+//!    reviewing the policy.
+//!
+//! These are source-scan checks, not behavioural tests. Behavioural
+//! verification of the gate semantics lives in
+//! `crates/core/src/historical/cross_verify.rs::tests::test_post_market_only_*`
+//! (6 tests covering pre-market, mid-session, boundary, late-evening,
+//! and same-day idempotency).
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/app has parent")
+        .parent()
+        .expect("crates has parent")
+        .to_path_buf()
+}
+
+fn read_file(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    fs::read_to_string(&path).unwrap_or_else(|err| panic!("cannot read {}: {err}", path.display()))
+}
+
+#[test]
+fn main_rs_uses_post_market_only_constructor_for_cross_verify_window() {
+    let main_src = read_file("crates/app/src/main.rs");
+    assert!(
+        main_src.contains("from_now_post_market_only()"),
+        "crates/app/src/main.rs MUST call \
+         `TodayIstWindow::from_now_post_market_only()` for the cross-verify \
+         window, not the unrestricted `from_now()`. The Parthiban directive \
+         2026-04-24 requires cross-verify to run ONLY post-market on \
+         trading days. Mid-session boots (09:15..15:30 IST) MUST silent-skip."
+    );
+
+    // Hard guard — the today_window assignment block must NOT call
+    // the unrestricted `from_now()`. We walk lines starting at the
+    // assignment line and check the next ~10 lines.
+    //
+    // (Other call sites of `from_now()` exist in main.rs for the
+    // today_ist date lookup in the historical-fetch decision tree —
+    // those are in a DIFFERENT block ~100 lines earlier. They are
+    // not the cross-verify window. See PR #353 / #356 for the
+    // design.)
+    let lines: Vec<&str> = main_src.lines().collect();
+    let assignment_line_idx = lines
+        .iter()
+        .position(|l| l.contains("let today_window = if is_trading_day {"))
+        .expect("today_window assignment line must exist in main.rs");
+    let window_end = (assignment_line_idx + 10).min(lines.len());
+    let window_block_lines = &lines[assignment_line_idx..window_end];
+    let window_block = window_block_lines.join("\n");
+
+    // The block must call `from_now_post_market_only`. The `_post_market_only`
+    // suffix is the discriminator from the banned `from_now()` call.
+    assert!(
+        window_block.contains("from_now_post_market_only"),
+        "today_window assignment block must call \
+         `from_now_post_market_only()`. Window block:\n{window_block}"
+    );
+
+    // Negative ratchet — the block must NOT contain a literal
+    // `::from_now()` call (with the parens, no `_post_market_only`
+    // suffix). Use `::from_now()` rather than `from_now()` so we
+    // don't false-positive on the suffix.
+    assert!(
+        !window_block.contains("::from_now()"),
+        "today_window assignment block must NOT call the unrestricted \
+         `TodayIstWindow::from_now()` — must use \
+         `::from_now_post_market_only()`. Window block:\n{window_block}"
+    );
+}
+
+#[test]
+fn cross_verify_min_coverage_constant_is_100_not_90() {
+    let src = read_file("crates/core/src/historical/cross_verify.rs");
+    assert!(
+        src.contains("pub const CROSS_MATCH_MIN_COVERAGE_PCT: u8 = 100"),
+        "CROSS_MATCH_MIN_COVERAGE_PCT MUST be 100 per Parthiban directive \
+         2026-04-24. Anything less is a partial-coverage failure that should \
+         fire HIGH, not a Skipped/OK. Found:\n{}",
+        src.lines()
+            .filter(|l| l.contains("CROSS_MATCH_MIN_COVERAGE_PCT"))
+            .take(3)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    // Negative ratchet — the old 90 value MUST NOT reappear.
+    assert!(
+        !src.contains("CROSS_MATCH_MIN_COVERAGE_PCT: u8 = 90"),
+        "CROSS_MATCH_MIN_COVERAGE_PCT must NOT regress to 90."
+    );
+}
+
+#[test]
+fn cross_verify_module_exposes_post_market_only_constructor() {
+    let src = read_file("crates/core/src/historical/cross_verify.rs");
+    assert!(
+        src.contains("pub fn from_utc_post_market_only(now_utc:"),
+        "TodayIstWindow MUST expose `pub fn from_utc_post_market_only` — \
+         the post-market-only constructor used by main.rs. Deleting it would \
+         silently regress cross-verify back to mid-session execution."
+    );
+    assert!(
+        src.contains("pub fn from_now_post_market_only()"),
+        "TodayIstWindow MUST expose `pub fn from_now_post_market_only` — \
+         the system-clock wrapper called from main.rs."
+    );
+}
+
+#[test]
+fn cross_verify_post_market_only_blocks_mid_session_in_unit_test() {
+    // Behavioural cross-check: the unit test
+    // `test_post_market_only_blocks_mid_session` MUST exist in
+    // cross_verify.rs's test module. If a future contributor deletes
+    // it, this ratchet fails so the regression is caught BEFORE the
+    // mid-session-boot bug returns.
+    let src = read_file("crates/core/src/historical/cross_verify.rs");
+    for needle in [
+        "fn test_post_market_only_blocks_pre_market",
+        "fn test_post_market_only_blocks_mid_session",
+        "fn test_post_market_only_blocks_at_session_close_boundary",
+        "fn test_post_market_only_admits_at_session_close_exact",
+        "fn test_post_market_only_admits_late_evening",
+        "fn test_post_market_only_idempotent_end_across_runs_same_day",
+    ] {
+        assert!(
+            src.contains(needle),
+            "behavioural ratchet missing: {needle} must exist in \
+             crates/core/src/historical/cross_verify.rs's test module. \
+             It enforces the post-market-only gate's semantics under \
+             pre-market / mid-session / boundary / late-evening / \
+             same-day-idempotency conditions."
+        );
+    }
+}

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -346,6 +346,58 @@ impl TodayIstWindow {
         })
     }
 
+    /// Post-market-only constructor (Parthiban directive 2026-04-24).
+    ///
+    /// Returns `Some(window)` only after 15:30 IST on the current
+    /// trading day. Used by cross-verification to enforce the "post-
+    /// market only" gate — verification needs the FULL session's live
+    /// data, so running it mid-session always yields partial coverage
+    /// and a non-actionable Skipped/Failed Telegram.
+    ///
+    /// Behaviour:
+    /// - Before 09:15 IST: `None` (pre-market, same as `from_utc`)
+    /// - 09:15 IST – 15:29:59 IST: `None` (NEW — mid-session blocked)
+    /// - 15:30 IST onwards: `Some(window)` with end pinned to 15:30 IST
+    ///
+    /// The returned window's `end_sql` is always exactly 15:30 IST —
+    /// not "now" clipped to 15:30. This guarantees idempotent SQL
+    /// queries: a 16:00 IST run and a 19:00 IST run both query the
+    /// SAME bound, so QuestDB's plan cache + DEDUP semantics behave
+    /// identically. The cross-verify success marker file then makes
+    /// successful runs idempotent across boots within the same day.
+    ///
+    /// Pure function — caller passes the UTC clock (production uses
+    /// `Utc::now()` via `from_now_post_market_only`). Tests drive
+    /// determinism by passing a fixed `DateTime<Utc>`.
+    // TEST-EXEMPT: covered by 6 `test_post_market_only_*` unit tests in this module's `tests` submodule (pre-market, mid-session, close-boundary, post-market admission, late-evening, same-day idempotency). Pub-fn-test guard's heuristic doesn't auto-match the `_post_market_only` prefix.
+    pub fn from_utc_post_market_only(now_utc: DateTime<Utc>) -> Option<Self> {
+        let ist = FixedOffset::east_opt(IST_UTC_OFFSET_SECONDS)?;
+        let now_ist = now_utc.with_timezone(&ist);
+        let today_ist = now_ist.date_naive();
+        let start_naive: NaiveDateTime = today_ist.and_hms_opt(9, 15, 0)?;
+        let market_end_naive: NaiveDateTime = today_ist.and_hms_opt(15, 30, 0)?;
+        let now_naive = now_ist.naive_local();
+        // Hard gate: must be at or after 15:30 IST on a trading day.
+        // Pre-market (< 09:15) AND mid-session (09:15..15:30) BOTH
+        // return None — verification only runs after the session
+        // closes so the full 09:15-15:30 grid is comparable.
+        if now_naive < market_end_naive {
+            return None;
+        }
+        Some(Self {
+            today_ist,
+            start_sql: format!("'{}'", start_naive.format("%Y-%m-%dT%H:%M:%S.000000Z")),
+            end_sql: format!("'{}'", market_end_naive.format("%Y-%m-%dT%H:%M:%S.000000Z")),
+        })
+    }
+
+    /// Production wrapper: post-market-only window from system clock.
+    /// See [`from_utc_post_market_only`] for the behavioural contract.
+    // TEST-EXEMPT: one-line wrapper over `from_utc_post_market_only` (which is itself covered by 6 `test_post_market_only_*` unit tests). Same pattern as the existing `from_now()` wrapper which is also exempt.
+    pub fn from_now_post_market_only() -> Option<Self> {
+        Self::from_utc_post_market_only(Utc::now())
+    }
+
     /// Returns the SQL fragment `ts >= '...' AND ts < '...'` suitable for
     /// dropping into any WHERE clause. Window is **09:15 inclusive → 15:30
     /// exclusive** per product spec (1m candle at 15:29:00 covers
@@ -845,13 +897,20 @@ fn build_missing_live_mismatch(ctx: CandleContext, hist: CandleValues) -> CrossM
 
 /// Cross-match coverage threshold (percent).
 ///
-/// Live candles must cover at least this % of the historical grid for
-/// `determine_cross_match_passed` to return true. Set to 90 to allow the
-/// natural slop at session edges (pre-open minute closes, 15:29:59 last-second
-/// slot, rare MV refresh lag) while still catching the 2026-04-24
-/// "booted at 14:54 IST but got CROSS-MATCH OK at 15:47" class of false
-/// positive (actual coverage ~10%).
-pub const CROSS_MATCH_MIN_COVERAGE_PCT: u8 = 90;
+/// Live candles must cover this exact % of the historical grid for
+/// `determine_cross_match_passed` to return true. Set to **100**
+/// (Parthiban directive 2026-04-24): the verification is "done" only
+/// when EVERY historical candle has a matching live candle. Anything
+/// less is `CandleCrossMatchFailed` HIGH with a specific diagnostic
+/// listing the gap, not a `Skipped` LOW.
+///
+/// Pre-2026-04-24 the threshold was 90% which permitted partial-OK on
+/// edge cases (pre-open minute closes, 15:29:59 last-second slot, rare
+/// materialized-view refresh lag). With the new 15:30+ post-market-
+/// only gate (`TodayIstWindow::from_now_post_market_only`) the entire
+/// 09:15-15:30 grid is settled by the time we run, so 100% is the
+/// only correct success criterion.
+pub const CROSS_MATCH_MIN_COVERAGE_PCT: u8 = 100;
 
 /// Computes the live-vs-historical coverage percentage as integer 0..=100.
 ///
@@ -2156,6 +2215,141 @@ mod tests {
     }
 
     #[test]
+    fn test_post_market_only_blocks_pre_market() {
+        // 2026-04-21 03:00 UTC = 08:30 IST — well before market open.
+        // The post-market-only constructor must return None.
+        let now = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDate::from_ymd_opt(2026, 4, 21)
+                .unwrap()
+                .and_hms_opt(3, 0, 0)
+                .unwrap(),
+            Utc,
+        );
+        assert!(
+            TodayIstWindow::from_utc_post_market_only(now).is_none(),
+            "08:30 IST is pre-market — must return None"
+        );
+    }
+
+    #[test]
+    fn test_post_market_only_blocks_mid_session() {
+        // 2026-04-21 06:30 UTC = 12:00 IST — mid-session. The
+        // ORIGINAL `from_utc` returns Some here (window 09:15..12:00),
+        // but the post-market-only constructor must return None to
+        // enforce "only run after the session closes".
+        let now = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDate::from_ymd_opt(2026, 4, 21)
+                .unwrap()
+                .and_hms_opt(6, 30, 0)
+                .unwrap(),
+            Utc,
+        );
+        assert!(
+            TodayIstWindow::from_utc(now).is_some(),
+            "guard test: 12:00 IST IS within original from_utc window"
+        );
+        assert!(
+            TodayIstWindow::from_utc_post_market_only(now).is_none(),
+            "12:00 IST is mid-session — post-market-only must return None"
+        );
+    }
+
+    #[test]
+    fn test_post_market_only_blocks_at_session_close_boundary() {
+        // 2026-04-21 09:59:59 UTC = 15:29:59 IST — last second of the
+        // trading session. Must return None — the gate fires AT 15:30,
+        // not at 15:29:59.
+        let now = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDate::from_ymd_opt(2026, 4, 21)
+                .unwrap()
+                .and_hms_opt(9, 59, 59)
+                .unwrap(),
+            Utc,
+        );
+        assert!(
+            TodayIstWindow::from_utc_post_market_only(now).is_none(),
+            "15:29:59 IST is still in-session — must return None"
+        );
+    }
+
+    #[test]
+    fn test_post_market_only_admits_at_session_close_exact() {
+        // 2026-04-21 10:00:00 UTC = 15:30:00 IST — first second
+        // post-market. Must return Some(window) with end pinned to 15:30.
+        let now = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDate::from_ymd_opt(2026, 4, 21)
+                .unwrap()
+                .and_hms_opt(10, 0, 0)
+                .unwrap(),
+            Utc,
+        );
+        let window = TodayIstWindow::from_utc_post_market_only(now)
+            .expect("15:30:00 IST is post-market — must return Some");
+        assert!(
+            window.end_sql.contains("15:30:00"),
+            "end_sql must be pinned to 15:30:00 exactly, got {}",
+            window.end_sql
+        );
+        assert!(
+            window.start_sql.contains("09:15:00"),
+            "start_sql must be 09:15:00, got {}",
+            window.start_sql
+        );
+    }
+
+    #[test]
+    fn test_post_market_only_admits_late_evening() {
+        // 2026-04-21 15:00 UTC = 20:30 IST — well after market close.
+        // Must return Some with end STILL pinned at 15:30 (not 20:30).
+        let now = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDate::from_ymd_opt(2026, 4, 21)
+                .unwrap()
+                .and_hms_opt(15, 0, 0)
+                .unwrap(),
+            Utc,
+        );
+        let window = TodayIstWindow::from_utc_post_market_only(now)
+            .expect("20:30 IST is post-market — must return Some");
+        assert!(
+            window.end_sql.contains("15:30:00"),
+            "post-market window's end_sql must be FIXED at 15:30, not now-clipped. \
+             Got: {}",
+            window.end_sql
+        );
+    }
+
+    #[test]
+    fn test_post_market_only_idempotent_end_across_runs_same_day() {
+        // Two boots on the same trading day (16:00 IST and 19:00 IST)
+        // must produce IDENTICAL end_sql so QuestDB query plans + DEDUP
+        // semantics are deterministic. This is what makes "run on every
+        // boot until success marker" safe — repeated runs query the
+        // same bound.
+        let day = NaiveDate::from_ymd_opt(2026, 4, 21).unwrap();
+        let evening_a = DateTime::<Utc>::from_naive_utc_and_offset(
+            day.and_hms_opt(10, 30, 0).unwrap(), // 16:00 IST
+            Utc,
+        );
+        let evening_b = DateTime::<Utc>::from_naive_utc_and_offset(
+            day.and_hms_opt(13, 30, 0).unwrap(), // 19:00 IST
+            Utc,
+        );
+        let win_a = TodayIstWindow::from_utc_post_market_only(evening_a)
+            .expect("16:00 IST must produce a window");
+        let win_b = TodayIstWindow::from_utc_post_market_only(evening_b)
+            .expect("19:00 IST must produce a window");
+        assert_eq!(
+            win_a.end_sql, win_b.end_sql,
+            "post-market end_sql must be IDENTICAL across the same day's boots — \
+             otherwise the success-marker idempotency model breaks"
+        );
+        assert_eq!(
+            win_a.start_sql, win_b.start_sql,
+            "post-market start_sql must also be identical (always 09:15)"
+        );
+    }
+
+    #[test]
     fn test_from_utc_is_stable_across_day_boundary() {
         // 2026-04-20 23:59 UTC == 2026-04-21 05:29 IST — still today-ist = 21,
         // but 05:29 is pre-market → None.
@@ -3406,8 +3600,15 @@ mod tests {
 
     #[test]
     fn test_determine_cross_match_passed_true_at_exact_threshold() {
-        // 90% coverage is the minimum acceptable.
-        assert!(determine_cross_match_passed(0, 0, 0, 100, 0, 90));
+        // 2026-04-24: threshold is now 100% (was 90%). Anything less
+        // is a HIGH FAILED, not an OK. The post-market-only gate
+        // upstream guarantees the full 09:15-15:30 grid is settled
+        // by the time this fn runs, so 100% is achievable.
+        assert!(determine_cross_match_passed(0, 0, 0, 100, 0, 100));
+        // 90% no longer passes — partial coverage is a failure.
+        assert!(!determine_cross_match_passed(0, 0, 0, 100, 0, 90));
+        // 99% no longer passes either — strict 100% only.
+        assert!(!determine_cross_match_passed(0, 0, 0, 100, 0, 99));
     }
 
     #[test]
@@ -3448,10 +3649,16 @@ mod tests {
     }
 
     #[test]
-    fn test_cross_match_min_coverage_pct_constant_is_90() {
-        // Document the policy value. If Parthiban ever tightens the
-        // threshold, this ratchet highlights the change in a diff review.
-        assert_eq!(CROSS_MATCH_MIN_COVERAGE_PCT, 90);
+    fn test_cross_match_min_coverage_pct_constant_is_100() {
+        // Parthiban directive 2026-04-24: cross-verify is "done" only
+        // when EVERY historical OHLCV candle matches a live candle.
+        // 100% is the only valid success threshold; 90% (the prior
+        // value) was a soft compromise that masked partial coverage.
+        // The new post-market-only gate
+        // (`TodayIstWindow::from_now_post_market_only`) ensures we
+        // only run after the full session has settled, so 100% is
+        // achievable, not aspirational.
+        assert_eq!(CROSS_MATCH_MIN_COVERAGE_PCT, 100);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Why this PR exists

Per Parthiban directive 2026-04-24: *"cross verification should be done only one time, until or unless it is fully successful it should run, that too only on working trading days post-market alone only"*.

Three concrete behavior changes flow from this:

| Rule | Mechanism |
|---|---|
| **Run only post-market (≥ 15:30 IST)** | New `TodayIstWindow::from_now_post_market_only()` constructor; main.rs uses it instead of `from_now()` |
| **Retry until fully successful** | Already in place — success marker only writes on success; re-boot triggers re-run |
| **"Fully successful" = 100% match** | `CROSS_MATCH_MIN_COVERAGE_PCT` bumped from 90 → 100 |

## Behaviour matrix

| Boot time (IST) | Pre-fix | Post-fix |
|---|---|---|
| 08:45 (pre-market) | Silent skip (INFO) | Silent skip (INFO) — same |
| 12:00 (mid-session) | Run → usually Skipped/Failed | **Silent skip (INFO) — NEW** |
| 16:30 (post-market, no marker) | Run → pass/skipped/failed | **Run → pass or HIGH failure** (no Skipped path on coverage) |
| 19:00 (post-market, marker exists) | Silent skip (idempotent) | Silent skip — same |
| Saturday (any clock) | "weekend" SKIPPED notification | Same |

## Why pin `end_sql` to 15:30 (not "now")

`from_now_post_market_only()` returns a window with `end_sql` ALWAYS pinned to exactly 15:30 IST — not "now-clipped" like the original `from_now()`. This matters because: every same-day boot must produce the IDENTICAL SQL bound, so QuestDB query plans + DEDUP semantics behave deterministically. Without this pin, a 16:00 boot would query `09:15..16:00` and a 19:00 boot would query `09:15..19:00`, breaking the "retry until success" idempotency model.

## Why 100% (not 90%)

PR #341's `CROSS_MATCH_MIN_COVERAGE_PCT = 90` was a soft compromise to allow session-edge slop (pre-open minute closes, 15:29:59 last-second slot, MV refresh lag). With the new post-market-only gate the entire 09:15-15:30 grid is **settled by the time we run**. Anything less than 100% means we have a real data gap that the operator needs to act on — promoting it to LOW Skipped would hide that.

## Tests (10 new + 1 updated)

| File | Test | Purpose |
|---|---|---|
| `cross_verify.rs` (unit) | `test_post_market_only_blocks_pre_market` | 08:30 IST → None |
| `cross_verify.rs` (unit) | `test_post_market_only_blocks_mid_session` | 12:00 IST → None; cross-checks `from_utc` returns Some |
| `cross_verify.rs` (unit) | `test_post_market_only_blocks_at_session_close_boundary` | 15:29:59 IST → None |
| `cross_verify.rs` (unit) | `test_post_market_only_admits_at_session_close_exact` | 15:30:00 IST → Some, end pinned |
| `cross_verify.rs` (unit) | `test_post_market_only_admits_late_evening` | 20:30 IST → Some, end PINNED at 15:30 |
| `cross_verify.rs` (unit) | `test_post_market_only_idempotent_end_across_runs_same_day` | 16:00 + 19:00 boots produce identical end_sql |
| `cross_verify.rs` (unit) | `test_cross_match_min_coverage_pct_constant_is_100` | (was `_is_90`) — also rejects 90% and 99% |
| `cross_verify_post_market_only_guard.rs` (integration) | `main_rs_uses_post_market_only_constructor_for_cross_verify_window` | main.rs source-scan: positive + negative ratchet |
| `cross_verify_post_market_only_guard.rs` (integration) | `cross_verify_min_coverage_constant_is_100_not_90` | Negative ratchet (90 must NOT reappear) |
| `cross_verify_post_market_only_guard.rs` (integration) | `cross_verify_module_exposes_post_market_only_constructor` | Both constructors must remain pub |
| `cross_verify_post_market_only_guard.rs` (integration) | `cross_verify_post_market_only_blocks_mid_session_in_unit_test` | All 6 behavioural tests must remain present |

## Validation

```
cargo build -p tickvault-core -p tickvault-app           → clean
cargo test -p tickvault-core --lib historical            → 430 pass (was 424; +6)
cargo test -p tickvault-app --tests                      → 503+ pass (incl. 4 new ratchets)
cargo test -p tickvault-app --test cross_verify_post_market_only_guard → 4 pass
cargo fmt -p tickvault-app -p tickvault-core             → clean
bash .claude/hooks/pub-fn-test-guard.sh . all            → PASS (untested-pub-fn count stable at 132)
```

## Test plan

- [ ] Boot post-market (≥ 15:30 IST) on a trading day with no success marker:
  - Cross-verify runs end-to-end
  - If 100% match: HIGH `CandleCrossMatchPassed` + success marker written
  - If < 100%: HIGH `CandleCrossMatchFailed` with specific gap diagnostic
- [ ] Boot mid-session (e.g. 12:00 IST) on a trading day:
  - Silent INFO log only ("not yet post-market")
  - No Telegram
- [ ] Boot post-market on a trading day with success marker present:
  - Silent skip (idempotent)
- [ ] Boot Saturday: "weekend" SKIPPED Telegram

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SBw9FYCBtmvjiyrEuPr5t)_