### PR TITLE
deps: bundle 7 dependabot PRs (5 actions + 2 cargo) into single merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1044,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1539,6 +1559,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3004,6 +3025,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3072,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3575,7 +3613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3592,7 +3630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3879,7 +3917,7 @@ dependencies = [
  "criterion",
  "figment",
  "proptest",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rkyv",
  "rustls-webpki 0.103.13",
  "secrecy",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -46,7 +46,7 @@ uuid = { workspace = true }
 aws-lc-sys = "0.40.0"
 aws-lc-rs = "1.16.3"
 rustls-webpki = "0.103.13"
-rand = "0.9.4"
+rand = "0.10.1"
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,19 @@ skip = [
     # call sites, intentional.
     { crate = "tokio-tungstenite", reason = "axum 0.8 uses 0.28, core uses 0.29 for Dhan WS" },
     { crate = "tungstenite", reason = "follows tokio-tungstenite version split" },
+    # --- Crypto stack version split (introduced 2026-04-25 by aws-sigv4 1.4.3 + rand 0.10) ---
+    # aws-sigv4 1.4.3 bumped to sha2 0.11 / digest 0.11 family while many
+    # other transitive deps (sha1, criterion, etc.) still use the 0.10
+    # family. rand 0.10's chacha20 brings cpufeatures 0.3 alongside
+    # the existing 0.2 used by sha2 0.10.x. All transitive — not on our
+    # direct dep tree. Cannot be unified until upstream consolidates.
+    { crate = "cpufeatures", reason = "rand 0.10 chacha20 uses 0.3, sha2 0.10 uses 0.2" },
+    { crate = "digest", reason = "aws-sigv4 1.4.3 uses 0.11, sha1/criterion use 0.10" },
+    { crate = "block-buffer", reason = "follows digest version split (0.10/0.12)" },
+    { crate = "crypto-common", reason = "follows digest version split (0.1/0.2)" },
+    { crate = "hmac", reason = "aws-sigv4 1.4.3 uses 0.13, totp-rs uses 0.12" },
+    { crate = "sha2", reason = "aws-sigv4 1.4.3 uses 0.11, totp-rs/digest use 0.10" },
+    { crate = "typenum", reason = "transitive splits 1.19/1.20 across digest 0.10/0.11" },
     # toml_edit 0.22 (direct) + toml_edit 0.23 (via cargo-deny internal) etc.
     # causes winnow 0.6 + 0.7 duplicate through toml_edit's parser stack.
     { crate = "winnow", reason = "toml_edit + figment parser version split" },


### PR DESCRIPTION
## Summary

Consolidates 7 outstanding dependabot PRs into a single mergeable PR. All version bumps verified to compile cleanly + critical tests pass.

## Bundled PRs

| PR | Type | Bump | Status |
|---|---|---|---|
| #359 | actions | aws-actions/configure-aws-credentials v4 → v6 | included |
| #360 | actions | actions/github-script v7 → v9 | included |
| #361 | actions | actions/cache v4 → v5 | included |
| #362 | actions | peter-evans/create-pull-request v7 → v8 | included |
| #363 | actions | actions/download-artifact v4 → v8 | included |
| #364 | cargo | cargo-patch-and-minor group (10 updates) | included |
| #365 | cargo | rand 0.9.4 → 0.10.1 | included (manual; conflicted with #364 in lockfile) |

## Cargo bumps (workspace-pinned)

| Crate | From | To | Risk |
|---|---|---|---|
| tokio | 1.51.1 | 1.52.1 | minor — safe |
| axum | 0.8.8 | 0.8.9 | patch |
| redis | 1.1.0 | 1.2.0 | minor — safe |
| rkyv | 0.8.15 | 0.8.16 | patch |
| rustls | 0.23.37 | 0.23.39 | patch |
| aws-config | 1.8.15 | 1.8.16 | patch |
| aws-sdk-sns | 1.98.0 | 1.99.0 | minor |
| aws-sdk-ssm | 1.108.0 | 1.109.0 | minor |
| clap | 4.6.0 | 4.6.1 | patch |
| uuid | 1.23.0 | 1.23.1 | patch |
| **rand** | **0.9.4** | **0.10.1** | major — but **unused in our code** (CVE-pin only); both versions coexist in lockfile via transitive deps |

## GitHub Actions bumps

| Action | From | To | Workflow scope |
|---|---|---|---|
| aws-actions/configure-aws-credentials | v4 | v6 | deploy-aws.yml |
| actions/github-script | v7 | v9 | chaos-nightly, dep-freshness-nightly, full-test-nightly, fuzz, safety |
| actions/cache | v4 | v5 | chaos-nightly, dep-freshness-nightly, deploy-aws |
| peter-evans/create-pull-request | v7 | v8 | dep-freshness-nightly |
| actions/download-artifact | v4 | v8 | deploy-aws.yml |

## rand 0.9 → 0.10 verification

`grep -rn 'rand::\|::thread_rng\|\.gen(\|\.gen_range' crates/**/*.rs` returns **zero hits** — `rand` is declared in `crates/common/Cargo.toml:49` purely as a CVE-pin to force a non-vulnerable version into the dep tree (per the comment block at `crates/common/Cargo.toml:39-44`). The 0.10 API breaks (`gen` → `random`) don't affect us.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo test -p tickvault-common --lib` (622/622 pass)
- [ ] CI green
- [ ] Live nightly workflow verification (after merge — `chaos-nightly`, `safety`, `fuzz` all touch the bumped actions)

## After merge

I'll close PRs #359-#365 with a reference to this consolidated PR.

https://claude.ai/code/session_01JEvgz5GZtWwskbcBXiTPMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEvgz5GZtWwskbcBXiTPMb)_