### PR TITLE
deps: bulk-bump Docker (8) + Actions (3) + teloxide + tracing-appender

### DIFF
--- a/.github/workflows/chaos-nightly.yml
+++ b/.github/workflows/chaos-nightly.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chaos-logs
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain 1.93.1
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
@@ -115,7 +115,7 @@ jobs:
         crate: [common, storage, core, trading, api, app]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain 1.93.1
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
@@ -150,7 +150,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain 1.93.1
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
@@ -180,7 +180,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain 1.93.1 + llvm-tools
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: target/llvm-cov/coverage.json

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"

--- a/.github/workflows/claude-mobile-command.yml
+++ b/.github/workflows/claude-mobile-command.yml
@@ -80,7 +80,7 @@ jobs:
           git config user.email "claude-cowork[bot]@users.noreply.github.com"
 
       - name: Run Claude Co-work
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 25

--- a/.github/workflows/claude-triage-loop.yml
+++ b/.github/workflows/claude-triage-loop.yml
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Co-work triage pass
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 9

--- a/.github/workflows/dep-freshness-nightly.yml
+++ b/.github/workflows/dep-freshness-nightly.yml
@@ -47,7 +47,7 @@ jobs:
       report: ${{ steps.scan.outputs.report }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @master, supply-chain hardening 2026-04-25)
@@ -89,7 +89,7 @@ jobs:
     if: needs.scan.outputs.patch_count != '0' && needs.scan.outputs.patch_count != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @master, supply-chain hardening 2026-04-25)

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -49,7 +49,7 @@ jobs:
       binary_artifact_name: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @master, supply-chain hardening 2026-04-25)
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload artifact
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tickvault-binary
           path: target/release/tickvault
@@ -124,7 +124,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout (for deploy scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download built binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/full-test-nightly.yml
+++ b/.github/workflows/full-test-nightly.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tracing-opentelemetry = "0.32.1"
 # Phase 2 of plans/active-plan.md: hourly-rotated ERROR-only JSONL stream
 # at data/logs/errors.jsonl so Claude Code / Loki / summary_writer can tail
 # a structured, append-only file instead of parsing journald prose.
-tracing-appender = "0.2.3"
+tracing-appender = "0.2.5"
 
 # ---- Section 6: Trading Domain — Auth ----
 arc-swap = "1.9.1"
@@ -134,7 +134,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 uuid = { version = "1.23.0", features = ["v4", "serde"] }
 
 # ---- Section 18: Telegram Alerts ----
-teloxide = { version = "0.13.0", features = ["macros"] }
+teloxide = { version = "0.17.0", features = ["macros"] }
 
 # ---- Section 13: Dev/Test Dependencies ----
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   # Bible #16: questdb/questdb:9.3.2
   # ---------------------------------------------------------------------------
   tv-questdb:
-    image: questdb/questdb:9.3.2@sha256:f8802d6ffa8c855fc3f9f69e86aaabcc4ee4d921e6755af4690b0b0290036517
+    image: questdb/questdb:9.3.5@sha256:5b6f1518296b45aa9ba049382b11b15cfb71e39d8b9dd5634683184bbd97bf0b
     container_name: tv-questdb
     hostname: tv-questdb
     restart: unless-stopped
@@ -114,7 +114,7 @@ services:
   # Bible #18: valkey/valkey:9.0.2-alpine
   # ---------------------------------------------------------------------------
   tv-valkey:
-    image: valkey/valkey:9.0.2-alpine@sha256:68677f85c863830af7836ff07c4a13b7f085ebeff62f4dedb71499ca27d229f2
+    image: valkey/valkey:9.0.3-alpine@sha256:f741f6f4080be5f2bc213f31206a608bee5369ab617a03d6970b800ee60a00c5
     container_name: tv-valkey
     hostname: tv-valkey
     restart: unless-stopped
@@ -152,7 +152,7 @@ services:
   # Bible: oliver006/redis_exporter:v1.67.0
   # ---------------------------------------------------------------------------
   tv-valkey-exporter:
-    image: oliver006/redis_exporter:v1.67.0@sha256:120f7ec77293459ccfdad66bb1db75ab72e8bfeab99f58b1cc2564cadcd7a9e7
+    image: oliver006/redis_exporter:v1.82.0@sha256:4b467f718ea9f62fe47b87ce39039ebeedff7764c40fde2a129913484fff716f
     container_name: tv-valkey-exporter
     hostname: tv-valkey-exporter
     restart: unless-stopped
@@ -183,7 +183,7 @@ services:
   # Bible #28: prom/prometheus:v3.9.1
   # ---------------------------------------------------------------------------
   tv-prometheus:
-    image: prom/prometheus:v3.9.1@sha256:1f0f50f06acaceb0f5670d2c8a658a599affe7b0d8e78b898c1035653849a702
+    image: prom/prometheus:v3.11.2@sha256:3674db04d3640d2157de57f8679dbe8dbc10a673e6d63ec58d9430e34abbfe68
     container_name: tv-prometheus
     hostname: tv-prometheus
     restart: unless-stopped
@@ -225,7 +225,7 @@ services:
   # Pinned: prom/alertmanager:v0.28.1
   # ---------------------------------------------------------------------------
   tv-alertmanager:
-    image: prom/alertmanager:v0.28.1@sha256:27c475db5fb156cab31d5c18a4251ac7ed567746a2483ff264516437a39b15ba
+    image: prom/alertmanager:v0.32.0@sha256:fe1f57b89ec7b94928746e61d9924cafd3674c688e3c7c3ad9600d8ef5da6cf9
     container_name: tv-alertmanager
     hostname: tv-alertmanager
     restart: unless-stopped
@@ -316,7 +316,7 @@ services:
   # Bible #79: traefik:v3.6.8
   # ---------------------------------------------------------------------------
   tv-traefik:
-    image: traefik:v3.6.8@sha256:90099f8948c828ecf0ababd711a4359a2443eba12261c1df2f548a3b1d815938
+    image: traefik:v3.6.14@sha256:e08f2a770aee6b838b4c1be5fe25569a653b1592e4673a240414bc8bc4ad0aaa
     container_name: tv-traefik
     hostname: tv-traefik
     restart: unless-stopped
@@ -359,7 +359,7 @@ services:
   tv-loki:
     # 2026-04-25: SHA256 digest pinned per CLAUDE.md "All images pinned with
     # SHA256 digest". Linux/amd64 digest from Docker Hub registry.
-    image: grafana/loki:3.6.6@sha256:ea32fad24c19145c73c606409d20db34a5b1d1d22c3fd7075bac3a40487c7a42
+    image: grafana/loki:3.7.1@sha256:1694e9237e2b3d7cd4ad959bae1f21e12b6184d886d7412bd1b939fb0dd4e75c
     container_name: tv-loki
     hostname: tv-loki
     profiles:
@@ -391,7 +391,7 @@ services:
   tv-alloy:
     # 2026-04-25: SHA256 digest pinned per CLAUDE.md "All images pinned with
     # SHA256 digest". Linux/amd64 digest from Docker Hub registry.
-    image: grafana/alloy:v1.8.0@sha256:769a27e1b26fcd37f7f7c611fff66d0f550d4888c7698c2396bf50b68fdc952f
+    image: grafana/alloy:v1.16.0@sha256:c12b05c77378537384f4082011855338de4558d258a1f3351862b73a920ea55c
     container_name: tv-alloy
     hostname: tv-alloy
     profiles:


### PR DESCRIPTION
## Summary

Maximally-safe bulk version bumps across all 4 dependency categories. **3 high-risk bumps deferred** with explicit reasons; pushing only what compiles + passes 1,225 tests.

## ✅ Bumped (compiled clean + 1,225/1,225 lib tests pass)

### Cargo workspace deps
| Crate | From | To | Notes |
|---|---|---|---|
| teloxide | 0.13.0 | 0.17.0 | Telegram alerts; 4 minors but compiled clean |
| tracing-appender | 0.2.3 | 0.2.5 | Powers errors.jsonl appender (Phase 2 observability) |

### Docker images (8 — all SHA-pinned)
| Image | From | To | SHA |
|---|---|---|---|
| questdb/questdb | 9.3.2 | 9.3.5 | `sha256:5b6f1518…` |
| valkey/valkey | 9.0.2-alpine | 9.0.3-alpine | `sha256:f741f6f4…` |
| oliver006/redis_exporter | v1.67.0 | v1.82.0 | `sha256:4b467f71…` |
| prom/prometheus | v3.9.1 | v3.11.2 | `sha256:3674db04…` |
| prom/alertmanager | v0.28.1 | v0.32.0 | `sha256:fe1f57b8…` |
| traefik | v3.6.8 | v3.6.14 | `sha256:e08f2a77…` |
| grafana/loki | 3.6.6 | 3.7.1 | `sha256:1694e923…` |
| grafana/alloy | v1.8.0 | v1.16.0 | `sha256:c12b05c7…` |

### GitHub Actions
| Action | From | To |
|---|---|---|
| actions/checkout | v4 / v5 | v6 |
| actions/upload-artifact | v4 | v7 |
| anthropics/claude-code-action | beta | v1 (GA) |

## 🔴 DEFERRED (require dedicated migration sessions)

| Bump | Why deferred | Recommended next step |
|---|---|---|
| **Rust 1.93.1 → 1.95.0** | 14 new clippy errors: `too_many_arguments` (20/8), `manual_range_contains`, `collapsible_if`, doc-list-indentation. Pre-existing patterns 1.95's stricter clippy now flags. Fixing all requires architectural refactor of multiple functions. | Separate PR: fix clippy errors first, then bump toolchain |
| **reqwest 0.12.15 → 0.13.2** | **109 compilation errors.** Massive API rewrite: `rustls-tls` → `rustls` feature rename, default HTTP/2 multiplexing change, TLS configuration overhaul, cookie store API change. Used in OMS api_client (live order placement!) and historical fetcher. | Separate PR: dedicated migration session with `dry_run = true` strategy testing |
| **grafana/grafana-oss 12.3.3 → 13.0.1** | Breaking dashboard schema. `depth-flow.json`, `tv-health.json`, `trading-pipeline.json` would all need manual re-validation. | Separate PR: backup current dashboards, bump Grafana, manually verify each panel renders |

## Stages executed (in order)

1. ✅ Stage 4 — tracing-appender 0.2.3 → 0.2.5 (cargo check clean)
2. ✅ Stage 6 — teloxide 0.13.0 → 0.17.0 (cargo check clean)
3. ✅ Stage 2 — 8 Docker images + SHAs via `docker manifest inspect`
4. ✅ Stage 3 — GitHub Actions checkout/upload-artifact/claude-code-action
5. ❌ Stage 1 — Rust 1.95 reverted after clippy errors
6. ❌ Stage 5 — reqwest 0.13 reverted after 109 errors
7. ❌ Stage 7 — Grafana 13 not attempted (breaking dashboards)
8. ✅ Final — `cargo test --workspace --lib`: 1,225 / 1,225 pass

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --lib` (1,225 / 1,225 pass)
- [x] All 8 Docker SHA digests validated via `docker manifest inspect`
- [ ] CI green
- [ ] Live verification on next docker-compose restart (post-merge)

## What's NOT done

| Concern | Status |
|---|---|
| `cargo audit` (CVE scan) | Not installed locally; CI's Security & Audit job will run it |
| `cargo deny check` (license/banned) | Not installed locally; CI will run; expect 0 new duplicates beyond what's already in deny.toml |
| Integration tests with live Docker | Requires `docker compose up` + market hours — manual post-merge step |
| Loom / fuzz / mutation / sanitizer tests | Out of session scope — covered weekly in CI |

https://claude.ai/code/session_01JEvgz5GZtWwskbcBXiTPMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEvgz5GZtWwskbcBXiTPMb)_