### PR TITLE
deps: bump grafana-oss 12.3.3 → 13.0.1 (Rust 1.95 + reqwest 0.13 deferred)

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -266,7 +266,7 @@ services:
   # Bible #27: grafana/grafana-oss:12.3.3
   # ---------------------------------------------------------------------------
   tv-grafana:
-    image: grafana/grafana-oss:12.3.3@sha256:9e1e77ade304069aee3196e9a4f210830e96e80ce9a2640891eccc324b152faf
+    image: grafana/grafana-oss:13.0.1@sha256:3625fdfa3cab904abdf9faaff8f40de0639b456ac5c5d322964fe705051d5455
     container_name: tv-grafana
     hostname: tv-grafana
     restart: unless-stopped


### PR DESCRIPTION
## Summary

**Honest status report after attempting all 3 deferred bumps:**

| Bump | Result | Reason |
|---|---|---|
| **Grafana 12.3.3 → 13.0.1** | ✅ Bumped + SHA-pinned + 1225/1225 tests pass | Image swap is mechanical; dashboards will need manual eye-check post-merge |
| **Rust 1.93.1 → 1.95.0** | ❌ DEFERRED | First batch fix → 37 errors emerged in second wave (cascade). Strict 1.95 clippy needs structural function refactors (`too_many_arguments` 20/8) — proper migration is a multi-hour dedicated PR |
| **reqwest 0.12.15 → 0.13.2** | ❌ DEFERRED | 109 compile errors. Full API rewrite needed (rustls feature rename + HTTP/2 multiplex + TLS config + cookie store). Touches OMS api_client (real money path) — too risky to rush |

## Why I'm pushing only Grafana

I started ambitious — fixed first 13 clippy errors for Rust 1.95, but that surfaced 24 MORE errors (`duplicated attribute`, `non_binding_let_must_use`, `manual_unwrap_or_default`, `useless_cast`, `let_and_return`, `collapsible_if`, etc.). Each fix risks introducing more errors.

For a live trading system, "ship what's verified" beats "ship what's untested". Rust 1.95 + reqwest 0.13 each need their own dedicated session with proper clippy-error iteration and OMS dry-run validation.

## Test plan
- [x] `cargo test --workspace --lib` (1,225 / 1,225 pass on Rust 1.93.1)
- [x] Grafana 13.0.1 SHA verified via `docker manifest inspect`
- [ ] CI green
- [ ] **Manual post-merge**: bring up Grafana 13 locally, eyeball each of `depth-flow`, `tv-health`, `trading-pipeline` dashboards for panel rendering issues

## What's deferred + recommended next steps

| Item | Effort estimate | Recommended approach |
|---|---|---|
| Rust 1.95 | 3-4 hours | Single dedicated PR. Run `cargo clippy --workspace -- -D warnings` repeatedly, fix each error or `#[allow(...)] // APPROVED:` per CLAUDE.md rules. ~37 errors total based on first wave. |
| reqwest 0.13 | 6-8 hours | Single dedicated PR. Migration guide: https://github.com/seanmonstar/reqwest/blob/master/CHANGELOG.md. Test plan: `dry_run = true` for OMS api_client integration tests, then live paper-trading mode |

https://claude.ai/code/session_01JEvgz5GZtWwskbcBXiTPMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEvgz5GZtWwskbcBXiTPMb)_