### PR TITLE
deps(toolchain): Rust 1.93.1 -> 1.95.0

### DIFF
--- a/.github/workflows/chaos-nightly.yml
+++ b/.github/workflows/chaos-nightly.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: '1.93.1'
+          toolchain: '1.95.0'
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain 1.93.1
+      - name: Install Rust toolchain 1.95.0
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
         with:
-          toolchain: '1.93.1'
+          toolchain: '1.95.0'
           components: rustfmt, clippy
 
       - name: Cache cargo registry + build
@@ -117,10 +117,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain 1.93.1
+      - name: Install Rust toolchain 1.95.0
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
         with:
-          toolchain: '1.93.1'
+          toolchain: '1.95.0'
 
       - name: Cache cargo registry + build
         uses: Swatinem/rust-cache@v2
@@ -152,10 +152,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain 1.93.1
+      - name: Install Rust toolchain 1.95.0
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
         with:
-          toolchain: '1.93.1'
+          toolchain: '1.95.0'
 
       - name: Install cargo-audit + cargo-deny
         run: |
@@ -182,10 +182,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain 1.93.1 + llvm-tools
+      - name: Install Rust toolchain 1.95.0 + llvm-tools
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
         with:
-          toolchain: '1.93.1'
+          toolchain: '1.95.0'
           components: llvm-tools-preview
 
       - name: Cache cargo + llvm-cov build

--- a/.github/workflows/dep-freshness-nightly.yml
+++ b/.github/workflows/dep-freshness-nightly.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @master, supply-chain hardening 2026-04-25)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -94,7 +94,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @master, supply-chain hardening 2026-04-25)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Run scanner to identify patch drifts
         id: identify

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @master, supply-chain hardening 2026-04-25)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
           targets: x86_64-unknown-linux-gnu
 
       - name: Cache cargo registry + target

--- a/.github/workflows/full-test-nightly.yml
+++ b/.github/workflows/full-test-nightly.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # SHA-pinned (was @stable, supply-chain hardening 2026-04-25)
         with:
-          toolchain: '1.93.1'
+          toolchain: '1.95.0'
           components: rustfmt
 
       - name: Cargo cache

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.93.1"
+          toolchain: "1.95.0"
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.93.1"
+          toolchain: "1.95.0"
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@2096c74c99c2f065b14e98d9738b44dd2018c2b7 # cargo-audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.93.1"
+rust-version = "1.95.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/api/src/handlers/debug.rs
+++ b/crates/api/src/handlers/debug.rs
@@ -35,10 +35,10 @@ const DEFAULT_SPILL_DIR: &str = "data/spill";
 const SPILL_DIR_ENV: &str = "TV_SPILL_DIR";
 
 fn resolve_logs_dir() -> PathBuf {
-    if let Ok(custom) = std::env::var(LOGS_DIR_ENV) {
-        if !custom.trim().is_empty() {
-            return PathBuf::from(custom);
-        }
+    if let Ok(custom) = std::env::var(LOGS_DIR_ENV)
+        && !custom.trim().is_empty()
+    {
+        return PathBuf::from(custom);
     }
     PathBuf::from(DEFAULT_LOGS_DIR)
 }
@@ -68,10 +68,10 @@ pub async fn logs_jsonl_latest() -> impl IntoResponse {
 }
 
 fn resolve_spill_dir() -> PathBuf {
-    if let Ok(custom) = std::env::var(SPILL_DIR_ENV) {
-        if !custom.trim().is_empty() {
-            return PathBuf::from(custom);
-        }
+    if let Ok(custom) = std::env::var(SPILL_DIR_ENV)
+        && !custom.trim().is_empty()
+    {
+        return PathBuf::from(custom);
     }
     PathBuf::from(DEFAULT_SPILL_DIR)
 }

--- a/crates/api/src/handlers/instruments.rs
+++ b/crates/api/src/handlers/instruments.rs
@@ -548,8 +548,7 @@ mod tests {
         // The unwrap_or_else fallback on the diagnostic endpoint handles
         // serialization errors. We verify the fallback format directly since
         // serde_json::to_value on a well-formed DiagnosticReport never fails.
-        let err =
-            serde_json::Error::io(std::io::Error::new(std::io::ErrorKind::Other, "simulated"));
+        let err = serde_json::Error::io(std::io::Error::other("simulated"));
         let fallback = serde_json::json!({"error": format!("serialization failed: {err}")});
         assert!(fallback.is_object());
         assert!(
@@ -564,8 +563,7 @@ mod tests {
 
     #[test]
     fn test_diagnostic_serialization_fallback_produces_error_json() {
-        let err =
-            serde_json::Error::io(std::io::Error::new(std::io::ErrorKind::Other, "test error"));
+        let err = serde_json::Error::io(std::io::Error::other("test error"));
         let result = diagnostic_serialization_fallback(err);
         assert!(result.is_object());
         let error_msg = result.get("error").unwrap().as_str().unwrap();

--- a/crates/api/src/handlers/market_data.rs
+++ b/crates/api/src/handlers/market_data.rs
@@ -224,7 +224,7 @@ pub async fn get_stock_movers(State(state): State<SharedAppState>) -> impl IntoR
             .partial_cmp(&b.change_pct)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    most_active.sort_by(|a, b| b.volume.cmp(&a.volume));
+    most_active.sort_by_key(|e| std::cmp::Reverse(e.volume));
 
     Json(StockMoversResponse {
         available: !gainers.is_empty() || !losers.is_empty() || !most_active.is_empty(),

--- a/crates/api/src/handlers/movers_v2.rs
+++ b/crates/api/src/handlers/movers_v2.rs
@@ -155,7 +155,7 @@ fn project_price(
     top: usize,
     only_category: Option<MoverCategory>,
 ) -> BucketResponse {
-    let include = |cat: MoverCategory| only_category.map_or(true, |filter| filter == cat);
+    let include = |cat: MoverCategory| only_category.is_none_or(|filter| filter == cat);
     BucketResponse {
         tracked: bucket.tracked,
         gainers: include(MoverCategory::Gainers).then(|| trim(&bucket.gainers, top)),
@@ -173,7 +173,7 @@ fn project_derivative(
     top: usize,
     only_category: Option<MoverCategory>,
 ) -> BucketResponse {
-    let include = |cat: MoverCategory| only_category.map_or(true, |filter| filter == cat);
+    let include = |cat: MoverCategory| only_category.is_none_or(|filter| filter == cat);
     BucketResponse {
         tracked: bucket.tracked,
         gainers: include(MoverCategory::Gainers).then(|| trim(&bucket.gainers, top)),
@@ -227,18 +227,18 @@ pub async fn get_movers_v2(
     };
 
     // ---- Bucket/category compatibility (405) ----
-    if let (Some(b), Some(c)) = (bucket_filter, category_filter) {
-        if !c.is_applicable_to(b) {
-            let body = ErrorBody {
-                error: format!(
-                    "category `{}` is not applicable to bucket `{}`",
-                    c.as_str(),
-                    b.as_str()
-                ),
-                valid: None,
-            };
-            return (StatusCode::METHOD_NOT_ALLOWED, Json(body)).into_response();
-        }
+    if let (Some(b), Some(c)) = (bucket_filter, category_filter)
+        && !c.is_applicable_to(b)
+    {
+        let body = ErrorBody {
+            error: format!(
+                "category `{}` is not applicable to bucket `{}`",
+                c.as_str(),
+                b.as_str()
+            ),
+            valid: None,
+        };
+        return (StatusCode::METHOD_NOT_ALLOWED, Json(body)).into_response();
     }
 
     // ---- Validate `top` ----
@@ -278,7 +278,7 @@ pub async fn get_movers_v2(
 
     // ---- Project per bucket filter ----
     let mut buckets = std::collections::BTreeMap::new();
-    let include_bucket = |b: MoverBucket| bucket_filter.map_or(true, |filter| filter == b);
+    let include_bucket = |b: MoverBucket| bucket_filter.is_none_or(|filter| filter == b);
 
     if include_bucket(MoverBucket::Indices) {
         buckets.insert(

--- a/crates/api/src/handlers/movers_v2.rs
+++ b/crates/api/src/handlers/movers_v2.rs
@@ -502,7 +502,7 @@ mod tests {
 
     fn mk_state() -> SharedAppState {
         use std::sync::{Arc, RwLock};
-        let state = SharedAppState::new(
+        SharedAppState::new(
             tickvault_common::config::QuestDbConfig {
                 host: "127.0.0.1".to_string(),
                 http_port: 1,
@@ -531,8 +531,7 @@ mod tests {
             Arc::new(RwLock::new(None)),
             Arc::new(RwLock::new(None)),
             Arc::new(crate::state::SystemHealthStatus::new()),
-        );
-        state
+        )
     }
 
     async fn call(uri: &str, state: SharedAppState) -> (axum::http::StatusCode, String) {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -18,6 +18,8 @@
 // Phase 0.2: no dropped Result/JoinHandle/must-use values (silent error swallowing).
 #![cfg_attr(not(test), deny(unused_must_use))]
 #![cfg_attr(not(test), warn(clippy::let_underscore_must_use))]
+#![cfg_attr(test, allow(clippy::assertions_on_constants))]
+#![cfg_attr(test, allow(clippy::field_reassign_with_default))]
 #![allow(missing_docs)]
 
 pub mod handlers;
@@ -289,7 +291,6 @@ mod tests {
     // build_router: smoke test — router builds without panic
     // -------------------------------------------------------------------
 
-    #[test]
     /// 2026-04-25 (PR #357): direct smoke test for `build_router_with_auth`,
     /// the production code path that takes a pre-resolved `ApiAuthConfig`
     /// (typically constructed from an SSM-fetched `SecretString` in

--- a/crates/api/src/middleware.rs
+++ b/crates/api/src/middleware.rs
@@ -139,7 +139,7 @@ impl ApiAuthConfig {
 
     /// **TEST-ONLY constructor.** Loads the API token from the
     /// `TV_API_TOKEN` environment variable. Retained for the existing unit
-    /// + integration test suite so tests can inject ad-hoc tokens without
+    /// and integration test suite so tests can inject ad-hoc tokens without
     /// spinning up real AWS SSM. **Production callers in
     /// `crates/app/src/main.rs` MUST NOT use this** — they go through
     /// [`Self::from_token`] with an SSM-fetched `SecretString` per

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -10,6 +10,8 @@
 // Phase 0.2: no dropped Result/JoinHandle/must-use values (silent error swallowing).
 #![cfg_attr(not(test), deny(unused_must_use))]
 #![cfg_attr(not(test), warn(clippy::let_underscore_must_use))]
+#![cfg_attr(test, allow(clippy::assertions_on_constants))]
+#![cfg_attr(test, allow(clippy::field_reassign_with_default))]
 
 pub mod boot_helpers;
 pub mod greeks_pipeline;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -6245,6 +6245,9 @@ fn build_inline_greeks_enricher(
 // All pure helper function tests are in boot_helpers.rs (lib.rs target).
 // Only integration-level tests that require main.rs-specific code remain here.
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
+// APPROVED: helper fns below the tests block are part of the boot path; reordering would add churn
+#[allow(clippy::assertions_on_constants)]
 mod tests {
     use super::*;
     use tickvault_app::boot_helpers::{

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2432,7 +2432,7 @@ async fn main() -> Result<()> {
             let depth_selections: Vec<
                 tickvault_core::instrument::depth_strike_selector::DepthStrikeSelection,
             > = if let Some(universe) = depth_universe {
-                let ul_refs: Vec<&str> = depth_underlyings.iter().copied().collect();
+                let ul_refs: Vec<&str> = depth_underlyings.to_vec();
                 tickvault_core::instrument::depth_strike_selector::select_depth_instruments(
                     universe,
                     &ul_refs,
@@ -3279,7 +3279,6 @@ async fn main() -> Result<()> {
                 tickvault_core::instrument::preopen_price_buffer::new_shared_stock_ltps();
             {
                 let stock_ltps_updater = std::sync::Arc::clone(&live_stock_ltps);
-                let stock_ltps_universe = stock_ltps_universe;
                 let mut stock_rx = tick_broadcast_sender.subscribe();
                 tokio::spawn(async move {
                     loop {
@@ -4987,8 +4986,6 @@ fn spawn_historical_candle_fetch(
     let bg_dhan_config = config.dhan.clone();
     let bg_historical_config = config.historical.clone();
     let bg_questdb_config = config.questdb.clone();
-    let bg_data_collection_start = config.trading.data_collection_start.clone();
-    let bg_data_collection_end = config.trading.data_collection_end.clone();
     let bg_token_handle = token_manager.token_handle();
     let bg_notifier = std::sync::Arc::clone(notifier);
 
@@ -5178,14 +5175,13 @@ fn spawn_historical_candle_fetch(
                 today_ist_naive,
             )
             .await
-            .map(|n| {
+            .inspect(|&n| {
                 info!(
                     today_ist = %today_ist_naive,
                     today_candles = n,
                     "historical fetch returned zero — checking DB presence to \
                      classify as idempotent re-run vs outage"
                 );
-                n
             })
         } else {
             None

--- a/crates/app/tests/observability_chain_e2e.rs
+++ b/crates/app/tests/observability_chain_e2e.rs
@@ -46,7 +46,6 @@ use tickvault_core::notification::summary_writer::{
 };
 use tracing_subscriber::Layer;
 use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 fn fresh_tmp_dir(label: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(

--- a/crates/app/tests/post_market_pool_halt_guard.rs
+++ b/crates/app/tests/post_market_pool_halt_guard.rs
@@ -61,7 +61,6 @@ fn pool_watchdog_match_block(src: &str) -> &str {
     let start = src
         .find(needle)
         .expect("spawn_pool_watchdog_task must contain `let verdict = pool.poll_watchdog();`");
-    let after = &src[start..];
     // The `match verdict {` block ends at the next top-level closing
     // brace pair followed by `Healthy => { ... }` — but the cleanest
     // bound is just to take the next ~6,000 bytes which comfortably

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -44,6 +44,7 @@ loom = { workspace = true, optional = true }
 
 [features]
 loom = ["dep:loom"]
+dhat = []
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/core/src/auth/token_cache.rs
+++ b/crates/core/src/auth/token_cache.rs
@@ -126,14 +126,14 @@ pub fn save_token_cache(token: &TokenState, client_id: &SecretString) {
 
     if let Err(err) = write_result {
         warn!(?err, "failed to write token cache temp file");
-        let _ = std::fs::remove_file(&tmp_path);
+        drop(std::fs::remove_file(&tmp_path));
         return;
     }
 
     // Atomic rename
     if let Err(err) = std::fs::rename(&tmp_path, TOKEN_CACHE_FILE_PATH) {
         warn!(?err, "failed to rename token cache file");
-        let _ = std::fs::remove_file(&tmp_path);
+        drop(std::fs::remove_file(&tmp_path));
         return;
     }
 
@@ -326,7 +326,7 @@ pub fn load_token_cache_fast() -> Option<FastCacheResult> {
 
 /// Deletes the token cache file (best-effort, no error on failure).
 pub fn delete_cache_file() {
-    let _ = std::fs::remove_file(TOKEN_CACHE_FILE_PATH);
+    drop(std::fs::remove_file(TOKEN_CACHE_FILE_PATH));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/auth/token_cache.rs
+++ b/crates/core/src/auth/token_cache.rs
@@ -393,6 +393,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::print_stderr)]
+    // APPROVED: test logs SKIP reason to stderr for cross-platform diagnostics
     fn test_save_and_load_roundtrip() {
         use chrono::{Duration, Utc};
 

--- a/crates/core/src/historical/candle_fetcher.rs
+++ b/crates/core/src/historical/candle_fetcher.rs
@@ -3571,7 +3571,7 @@ mod tests {
         // wrapping_shl with attempt >= 64 wraps — confirm no panic
         let result = compute_dh904_backoff_secs(100);
         // With wrapping_shl, 1u64.wrapping_shl(100) wraps to 1u64.wrapping_shl(100 % 64)
-        assert!(result > 0 || result == 0); // Just confirm no panic
+        let _ = result; // Just confirm no panic; result is u64 so always >= 0
     }
 
     // =======================================================================

--- a/crates/core/src/historical/cross_verify.rs
+++ b/crates/core/src/historical/cross_verify.rs
@@ -3288,6 +3288,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     // Helper to build DiffSummaryParams concisely in tests
+    #[allow(clippy::too_many_arguments)]
+    // APPROVED: test helper mirrors DiffSummaryParams 1-to-1 for readable assertions
     fn diff_params(
         d_open: f64,
         d_high: f64,

--- a/crates/core/src/instrument/daily_scheduler.rs
+++ b/crates/core/src/instrument/daily_scheduler.rs
@@ -144,7 +144,7 @@ pub fn spawn_daily_refresh_task(
         if !config.enabled {
             // GAP-CFG-01: scheduler disabled — park until shutdown
             info!("daily instrument refresh scheduler disabled");
-            let _ = shutdown_rx.changed().await;
+            drop(shutdown_rx.changed().await);
             return;
         }
 

--- a/crates/core/src/instrument/depth_strike_selector.rs
+++ b/crates/core/src/instrument/depth_strike_selector.rs
@@ -606,7 +606,7 @@ mod tests {
         let has_ce = selection
             .all_security_ids
             .iter()
-            .any(|&id| id >= 10000 && id < 20000);
+            .any(|&id| (10000..20000).contains(&id));
         let has_pe = selection.all_security_ids.iter().any(|&id| id >= 20000);
         assert!(has_ce, "must have CE security IDs");
         assert!(has_pe, "must have PE security IDs");

--- a/crates/core/src/instrument/instrument_loader.rs
+++ b/crates/core/src/instrument/instrument_loader.rs
@@ -1234,9 +1234,8 @@ mod tests {
     fn test_is_within_build_window_exact_second_boundary() {
         // Window from 12:00:00 to 12:00:01 — 1 second window
         // Very unlikely current time is in this exact second
-        let result = is_within_build_window("12:00:00", "12:00:01");
+        let _ = is_within_build_window("12:00:00", "12:00:01");
         // Just verify it returns a bool without panicking
-        assert!(result || !result);
     }
 
     #[test]
@@ -1315,7 +1314,7 @@ mod tests {
         let date_str = now_ist_date_string();
         let year: u32 = date_str[0..4].parse().unwrap();
         assert!(
-            year >= 2025 && year <= 2030,
+            (2025..=2030).contains(&year),
             "year should be reasonable, got {year}"
         );
     }

--- a/crates/core/src/instrument/live_tick_atm_resolver.rs
+++ b/crates/core/src/instrument/live_tick_atm_resolver.rs
@@ -242,10 +242,11 @@ async fn build_snapshot_for_stocks(
     let map = spot_prices.read().await;
     let mut out: HashMap<String, f64> = HashMap::with_capacity(stocks.len());
     for stock in stocks {
-        if let Some(entry) = map.get(stock) {
-            if entry.price > 0.0 && entry.price.is_finite() {
-                out.insert(stock.clone(), entry.price);
-            }
+        if let Some(entry) = map.get(stock)
+            && entry.price > 0.0
+            && entry.price.is_finite()
+        {
+            out.insert(stock.clone(), entry.price);
         }
     }
     out

--- a/crates/core/src/instrument/phase2_scheduler.rs
+++ b/crates/core/src/instrument/phase2_scheduler.rs
@@ -385,10 +385,10 @@ pub fn next_phase2_trigger(
 
     if now_ist_time < trigger {
         // Before 09:12 — sleep until the trigger.
-        let secs_until = match (trigger - now_ist_time).num_seconds().try_into() {
-            Ok(s) => s,
-            Err(_) => 0,
-        };
+        let secs_until = (trigger - now_ist_time)
+            .num_seconds()
+            .try_into()
+            .unwrap_or_default();
         return NextTrigger::SleepUntil {
             duration: Duration::from_secs(secs_until),
         };

--- a/crates/core/src/instrument/preopen_price_buffer.rs
+++ b/crates/core/src/instrument/preopen_price_buffer.rs
@@ -252,9 +252,8 @@ pub fn is_within_preopen_window() -> bool {
         return false;
     };
     let now_ist = offset.from_utc_datetime(&Utc::now().naive_utc());
-    let sec_of_day = (now_ist.time().hour() * 3600
-        + now_ist.time().minute() * 60
-        + now_ist.time().second()) as u32;
+    let sec_of_day =
+        now_ist.time().hour() * 3600 + now_ist.time().minute() * 60 + now_ist.time().second();
     minute_index_for_ist_seconds(sec_of_day).is_some()
 }
 

--- a/crates/core/src/instrument/preopen_price_buffer.rs
+++ b/crates/core/src/instrument/preopen_price_buffer.rs
@@ -493,8 +493,7 @@ mod tests {
             .unwrap()
             .and_hms_opt(hour, minute, second)
             .unwrap();
-        let ist_utc = ist_naive.and_utc().timestamp() - i64::from(IST_UTC_OFFSET_SECONDS);
-        ist_utc
+        ist_naive.and_utc().timestamp() - i64::from(IST_UTC_OFFSET_SECONDS)
     }
 
     #[test]
@@ -669,7 +668,7 @@ mod tests {
         record_preopen_tick(&buffer, "RELIANCE", ts, 2847.5).await;
         let snap = snapshot(&buffer).await;
         assert!(
-            snap.get("RELIANCE").is_none(),
+            !snap.contains_key("RELIANCE"),
             "no bucket should have been created for a 09:15 tick"
         );
     }
@@ -712,7 +711,7 @@ mod tests {
         record_preopen_tick(&buffer, "RELIANCE", ts, 2847.5).await;
         let snap = snapshot(&buffer).await;
         assert!(
-            snap.get("RELIANCE").is_none(),
+            !snap.contains_key("RELIANCE"),
             "08:59:59 IST is outside the widened 09:00-09:12 window"
         );
     }
@@ -757,8 +756,8 @@ mod tests {
             Some(&"BANKNIFTY".to_string())
         );
         // Wrong segment must not match even with same id.
-        assert!(lookup.get(&(13, ExchangeSegment::NseEquity)).is_none());
-        assert!(lookup.get(&(25, ExchangeSegment::NseEquity)).is_none());
+        assert!(!lookup.contains_key(&(13, ExchangeSegment::NseEquity)));
+        assert!(!lookup.contains_key(&(25, ExchangeSegment::NseEquity)));
     }
 
     #[test]

--- a/crates/core/src/instrument/subscription_planner.rs
+++ b/crates/core/src/instrument/subscription_planner.rs
@@ -435,12 +435,11 @@ pub fn build_subscription_plan(
                         // Binary search: find strike closest to spot price.
                         let idx = chain.calls.partition_point(|e| e.strike_price < price);
                         let candidates = [idx.saturating_sub(1), idx.min(call_count - 1)];
-                        let best = candidates.iter().copied().min_by(|&a, &b| {
+                        candidates.iter().copied().min_by(|&a, &b| {
                             let da = (chain.calls[a].strike_price - price).abs();
                             let db = (chain.calls[b].strike_price - price).abs();
                             da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
-                        });
-                        best
+                        })
                     }
                     _ => {
                         // No pre-market price available — skip this stock's options.
@@ -497,12 +496,11 @@ pub fn build_subscription_plan(
                     Some(price) if price > 0.0 && price.is_finite() => {
                         let idx = chain.puts.partition_point(|e| e.strike_price < price);
                         let candidates = [idx.saturating_sub(1), idx.min(put_count - 1)];
-                        let best = candidates.iter().copied().min_by(|&a, &b| {
+                        candidates.iter().copied().min_by(|&a, &b| {
                             let da = (chain.puts[a].strike_price - price).abs();
                             let db = (chain.puts[b].strike_price - price).abs();
                             da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
-                        });
-                        best
+                        })
                     }
                     _ => None, // No pre-market price — skipped (same as calls)
                 }

--- a/crates/core/src/instrument/universe_builder.rs
+++ b/crates/core/src/instrument/universe_builder.rs
@@ -493,23 +493,22 @@ fn build_derivatives_and_chains(
         // silently overwrite the other. Warn loudly so the operator can
         // investigate before the collision causes a downstream bug
         // (wrong subscription, wrong Greeks, wrong delta-detector pass).
-        if let Some(prev) = derivative_contracts.insert(row.security_id, contract.clone()) {
-            if prev.exchange_segment != contract.exchange_segment
-                || prev.underlying_symbol != contract.underlying_symbol
-            {
-                tracing::warn!(
-                    security_id = row.security_id,
-                    prev_segment = ?prev.exchange_segment,
-                    new_segment = ?contract.exchange_segment,
-                    prev_underlying = %prev.underlying_symbol,
-                    new_underlying = %contract.underlying_symbol,
-                    "I-P1-11: FnoUniverse.derivative_contracts cross-key collision — \
-                     two distinct contracts share the same security_id. One will be \
-                     dropped; delta_detector lookups on this id are ambiguous until \
-                     the FnoUniverse map is refactored to (id, segment) key."
-                );
-                metrics::counter!("tv_fno_universe_derivative_collisions_total").increment(1);
-            }
+        if let Some(prev) = derivative_contracts.insert(row.security_id, contract.clone())
+            && (prev.exchange_segment != contract.exchange_segment
+                || prev.underlying_symbol != contract.underlying_symbol)
+        {
+            tracing::warn!(
+                security_id = row.security_id,
+                prev_segment = ?prev.exchange_segment,
+                new_segment = ?contract.exchange_segment,
+                prev_underlying = %prev.underlying_symbol,
+                new_underlying = %contract.underlying_symbol,
+                "I-P1-11: FnoUniverse.derivative_contracts cross-key collision — \
+                 two distinct contracts share the same security_id. One will be \
+                 dropped; delta_detector lookups on this id are ambiguous until \
+                 the FnoUniverse map is refactored to (id, segment) key."
+            );
+            metrics::counter!("tv_fno_universe_derivative_collisions_total").increment(1);
         }
 
         // Add to instrument_info

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,8 @@
 // Phase 0.2: no dropped Result/JoinHandle/must-use values (silent error swallowing).
 #![cfg_attr(not(test), deny(unused_must_use))]
 #![cfg_attr(not(test), warn(clippy::let_underscore_must_use))]
+#![cfg_attr(test, allow(clippy::assertions_on_constants))]
+#![cfg_attr(test, allow(clippy::field_reassign_with_default))]
 #![allow(missing_docs)] // TODO: enforce after adding docs to all public items
 
 //! Core engine: instrument universe, authentication, WebSocket management,

--- a/crates/core/src/network/ip_monitor.rs
+++ b/crates/core/src/network/ip_monitor.rs
@@ -175,7 +175,7 @@ pub fn spawn_ip_monitor(
                         "GAP-NET-01: CRITICAL — IP MISMATCH DETECTED. \
                          Dhan API calls will be rejected from wrong IP. Trading should halt."
                     );
-                    let _ = tx.send(true);
+                    _ = tx.send(true);
                 }
                 IpCheckResult::CheckFailed { reason } => {
                     warn!(

--- a/crates/core/src/option_chain/types.rs
+++ b/crates/core/src/option_chain/types.rs
@@ -440,7 +440,7 @@ mod tests {
             gamma: 0.001,
             vega: 8.0,
         };
-        let g2 = g.clone();
+        let g2 = g;
         assert_eq!(g.delta, g2.delta);
         assert_eq!(g.theta, g2.theta);
         assert_eq!(g.gamma, g2.gamma);

--- a/crates/core/src/pipeline/option_movers.rs
+++ b/crates/core/src/pipeline/option_movers.rs
@@ -310,7 +310,7 @@ impl OptionMoversTracker {
                 .filter(|e| e.oi >= MIN_OI_THRESHOLD)
                 .cloned()
                 .collect();
-            v.sort_unstable_by(|a, b| b.oi.cmp(&a.oi));
+            v.sort_unstable_by_key(|e| std::cmp::Reverse(e.oi));
             v.truncate(TOP_N);
             v
         };
@@ -350,7 +350,7 @@ impl OptionMoversTracker {
         // 4. Top Volume — sort by volume descending
         let top_volume = {
             let mut v = entries.clone();
-            v.sort_unstable_by(|a, b| b.volume.cmp(&a.volume));
+            v.sort_unstable_by_key(|e| std::cmp::Reverse(e.volume));
             v.truncate(TOP_N);
             v
         };

--- a/crates/core/src/pipeline/tick_processor.rs
+++ b/crates/core/src/pipeline/tick_processor.rs
@@ -69,6 +69,7 @@ const INDEX_PREV_CLOSE_CACHE_TMP: &str = "data/instrument-cache/index-prev-close
 /// - NIFTY 50: Dhan SID 13, segment IDX_I
 /// - BANK NIFTY: Dhan SID 25, segment IDX_I
 /// - SENSEX: Dhan SID 51, segment IDX_I
+///
 /// Verified via existing test `tests::test_header_parse` which uses
 /// SID 13 for NIFTY, and by the live universe seeded from the
 /// instrument master at boot.
@@ -222,7 +223,7 @@ fn current_received_at_nanos() -> i64 {
 /// wall-clock goes BACKWARD by more than `CLOCK_SKEW_BACKWARD_THRESHOLD_NANOS`
 /// versus the largest value seen so far, it logs ERROR + increments
 /// `tv_clock_skew_detections_total` so the operator sees it in Grafana
-/// + Telegram. The tick is still evaluated against the window (we do
+/// and Telegram. The tick is still evaluated against the window (we do
 /// NOT reject it on the basis of skew alone — that would drop
 /// legitimate ticks during a one-off correction).
 ///
@@ -236,7 +237,7 @@ fn is_wall_clock_within_persist_window(received_at_nanos: i64) -> bool {
     if received_at_nanos > prev_max {
         // Rising edge: update max (relaxed CAS — lost races only mean
         // we miss an update, which is fine for a monitoring counter).
-        let _ = MAX_WALL_CLOCK_SEEN_NANOS.compare_exchange(
+        _ = MAX_WALL_CLOCK_SEEN_NANOS.compare_exchange(
             prev_max,
             received_at_nanos,
             Ordering::Relaxed,
@@ -344,7 +345,7 @@ fn persist_stock_movers_snapshot(
                 let prev_close = f32_clean(entry.prev_close);
                 let ltp = f32_clean(entry.last_traded_price);
                 let change_pct = f32_clean(entry.change_pct);
-                let _ = writer.append_stock_mover(
+                drop(writer.append_stock_mover(
                     ts_nanos,
                     category,
                     (i as i32).saturating_add(1),
@@ -355,7 +356,7 @@ fn persist_stock_movers_snapshot(
                     prev_close,
                     change_pct,
                     i64::from(entry.volume),
-                );
+                ));
             }
         };
 
@@ -367,7 +368,7 @@ fn persist_stock_movers_snapshot(
     persist_entries(writer, &snapshot.index_most_active, "INDEX_MOST_ACTIVE");
 
     // Best-effort flush
-    let _ = writer.flush();
+    drop(writer.flush());
 }
 
 /// Persists an option movers snapshot to QuestDB (cold path, best-effort).
@@ -431,7 +432,7 @@ fn persist_option_movers_snapshot(
                 const SPOT_PRICE_NOT_AVAILABLE: f64 = 0.0;
                 let spot_price = SPOT_PRICE_NOT_AVAILABLE;
 
-                let _ = writer.append_option_mover(
+                drop(writer.append_option_mover(
                     ts_nanos,
                     category,
                     (i as i32).saturating_add(1),
@@ -451,7 +452,7 @@ fn persist_option_movers_snapshot(
                     f32_clean(entry.oi_change_pct),
                     i64::from(entry.volume),
                     entry.value,
-                );
+                ));
             }
         };
 
@@ -488,7 +489,7 @@ fn persist_option_movers_snapshot(
     split_persist(writer, &snapshot.price_gainers, "PRICE_GAINER");
     split_persist(writer, &snapshot.price_losers, "PRICE_LOSER");
 
-    let _ = writer.flush();
+    drop(writer.flush());
 }
 
 // ---------------------------------------------------------------------------
@@ -1297,7 +1298,7 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                     let cache_path = INDEX_PREV_CLOSE_CACHE_PATH;
                     let tmp_path = INDEX_PREV_CLOSE_CACHE_TMP;
                     if let Ok(json) = serde_json::to_string(&index_prev_close_cache) {
-                        let _ = std::fs::create_dir_all(cache_dir);
+                        drop(std::fs::create_dir_all(cache_dir));
                         match std::fs::write(tmp_path, &json)
                             .and_then(|()| std::fs::rename(tmp_path, cache_path))
                         {
@@ -1594,7 +1595,7 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                 if !is_within_persist_window(c.timestamp_secs) {
                     continue;
                 }
-                let _ = cw.append_candle(
+                drop(cw.append_candle(
                     c.security_id,
                     c.exchange_segment_code,
                     c.timestamp_secs,
@@ -1609,7 +1610,7 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                     c.gamma,
                     c.theta,
                     c.vega,
-                );
+                ));
             }
             cw.flush_on_shutdown();
         }

--- a/crates/core/src/pipeline/top_movers.rs
+++ b/crates/core/src/pipeline/top_movers.rs
@@ -2217,7 +2217,7 @@ mod tests {
             change_pct: -3.75,
             volume: 99999,
         };
-        let json = serde_json::to_value(&entry).unwrap();
+        let json = serde_json::to_value(entry).unwrap();
         assert_eq!(json["security_id"], 12345);
         assert_eq!(json["exchange_segment_code"], 1);
         assert_eq!(json["volume"], 99999);
@@ -2869,7 +2869,7 @@ mod tests {
             last_traded_price: 162.15,
             prev_close: 290.30,
             change_pct: -44.14,
-            volume: 12_202_3_330,
+            volume: 122_023_330,
             open_interest: 8_017_880,
             prev_open_interest: 4_673_565,
             oi_change_pct: 71.56,

--- a/crates/core/src/pipeline/top_movers.rs
+++ b/crates/core/src/pipeline/top_movers.rs
@@ -278,7 +278,7 @@ impl TopMoversTracker {
                 .collect();
 
             // Most active: sort by volume descending
-            entries.sort_unstable_by(|a, b| b.volume.cmp(&a.volume));
+            entries.sort_unstable_by_key(|e| std::cmp::Reverse(e.volume));
             let most_active: Vec<MoverEntry> = entries.iter().take(top_n).copied().collect();
 
             (gainers, losers, most_active)
@@ -1445,7 +1445,9 @@ fn trim_price_bucket(bucket: &mut PriceBucket) {
     bucket.losers.truncate(MOVERS_V2_TOP_N);
 
     // Most active: volume desc.
-    bucket.most_active.sort_by(|a, b| b.volume.cmp(&a.volume));
+    bucket
+        .most_active
+        .sort_by_key(|e| std::cmp::Reverse(e.volume));
     bucket.most_active.truncate(MOVERS_V2_TOP_N);
 }
 
@@ -1466,12 +1468,14 @@ fn trim_derivative_bucket(bucket: &mut DerivativeBucket) {
     bucket.losers.retain(|e| e.change_pct < 0.0);
     bucket.losers.truncate(MOVERS_V2_TOP_N);
 
-    bucket.most_active.sort_by(|a, b| b.volume.cmp(&a.volume));
+    bucket
+        .most_active
+        .sort_by_key(|e| std::cmp::Reverse(e.volume));
     bucket.most_active.truncate(MOVERS_V2_TOP_N);
 
     bucket
         .top_oi
-        .sort_by(|a, b| b.open_interest.cmp(&a.open_interest));
+        .sort_by_key(|e| std::cmp::Reverse(e.open_interest));
     bucket.top_oi.truncate(MOVERS_V2_TOP_N);
 
     bucket.top_value.sort_by(|a, b| {

--- a/crates/core/src/scheduler/mod.rs
+++ b/crates/core/src/scheduler/mod.rs
@@ -488,6 +488,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[allow(clippy::clone_on_copy)]
+    // APPROVED: this test exists to verify Clone trait is wired alongside Copy
     fn test_schedule_phase_copy_clone_eq() {
         let phase = SchedulePhase::MarketOpen;
         let copied = phase; // Copy

--- a/crates/core/src/websocket/connection.rs
+++ b/crates/core/src/websocket/connection.rs
@@ -902,7 +902,7 @@ impl WebSocketConnection {
                     // Close the socket regardless of send outcome.
                     {
                         let mut sink = write.lock().await;
-                        let _ = time::timeout(Duration::from_secs(1), sink.close()).await; // APPROVED: graceful-shutdown inner close timeout — 1s is the session 7 A5 spec.
+                        drop(time::timeout(Duration::from_secs(1), sink.close()).await); // APPROVED: graceful-shutdown inner close timeout — 1s is the session 7 A5 spec.
                     }
                     return Ok(());
                 }

--- a/crates/core/src/websocket/depth_connection.rs
+++ b/crates/core/src/websocket/depth_connection.rs
@@ -264,14 +264,14 @@ pub async fn run_twenty_depth_connection(
                 // If we reached a clean close AFTER at least one prior
                 // failure, we successfully recovered (connect + run +
                 // clean server-side close). Fire the reconnect event.
-                if failures_before_attempt > 0 {
-                    if let Some(ref n) = notifier {
-                        n.notify(
-                            crate::notification::events::NotificationEvent::DepthTwentyReconnected {
-                                underlying: underlying_label.clone(), // O(1) EXEMPT: cold path, once per reconnect
-                            },
-                        );
-                    }
+                if failures_before_attempt > 0
+                    && let Some(ref n) = notifier
+                {
+                    n.notify(
+                        crate::notification::events::NotificationEvent::DepthTwentyReconnected {
+                            underlying: underlying_label.clone(), // O(1) EXEMPT: cold path, once per reconnect
+                        },
+                    );
                 }
                 // Reset counter only on successful connection (failures accumulate for backoff)
                 reconnect_counter.store(0, Ordering::Relaxed);
@@ -581,7 +581,7 @@ async fn connect_and_run_depth(
                     first_frame_received = true;
                     m_active.set(1.0);
                     if let Some(signal) = connected_signal.take() {
-                        let _ = signal.send(());
+                        _ = signal.send(());
                     }
                 }
                 m_frames.increment(1);
@@ -823,15 +823,15 @@ pub async fn run_two_hundred_depth_connection(
             Ok(()) => {
                 info!(security_id, label = %label, "{prefix}: connection closed normally");
                 // Recovery from prior failure streak — fire Telegram.
-                if failures_before_attempt > 0 {
-                    if let Some(ref n) = notifier {
-                        n.notify(
-                            crate::notification::events::NotificationEvent::DepthTwoHundredReconnected {
-                                contract: label.clone(), // O(1) EXEMPT: cold path, once per reconnect
-                                security_id,
-                            },
-                        );
-                    }
+                if failures_before_attempt > 0
+                    && let Some(ref n) = notifier
+                {
+                    n.notify(
+                        crate::notification::events::NotificationEvent::DepthTwoHundredReconnected {
+                            contract: label.clone(), // O(1) EXEMPT: cold path, once per reconnect
+                            security_id,
+                        },
+                    );
                 }
                 // Reset counter only on successful connection (failures accumulate for backoff)
                 reconnect_counter.store(0, Ordering::Relaxed);
@@ -1138,7 +1138,7 @@ async fn connect_and_run_200_depth(
                     first_frame_received = true;
                     m_active.set(1.0);
                     if let Some(signal) = connected_signal.take() {
-                        let _ = signal.send(());
+                        _ = signal.send(());
                     }
                 }
                 m_frames.increment(1);

--- a/crates/core/src/websocket/order_update_connection.rs
+++ b/crates/core/src/websocket/order_update_connection.rs
@@ -170,8 +170,7 @@ pub async fn run_order_update_connection(
 // ---------------------------------------------------------------------------
 
 /// Single connection lifecycle: connect → login → read loop.
-#[allow(clippy::too_many_arguments)] // APPROVED: STAGE-C added wal_spill param
-#[allow(clippy::too_many_arguments)] // APPROVED: STAGE-C + O2 authenticated signal
+#[allow(clippy::too_many_arguments)] // APPROVED: STAGE-C wal_spill + O2 authenticated signal
 async fn connect_and_listen(
     url: &str,
     client_id: &str,
@@ -221,14 +220,14 @@ async fn connect_and_listen(
     // reconnect. A reconnect is defined as "connect() succeeded AND we
     // had >=1 prior consecutive failure". First boot (failures=0) does
     // not qualify — `OrderUpdateConnected` covers that already.
-    if failures_before_attempt > 0 {
-        if let Some(n) = notifier {
-            n.notify(
-                crate::notification::events::NotificationEvent::OrderUpdateReconnected {
-                    consecutive_failures: failures_before_attempt,
-                },
-            );
-        }
+    if failures_before_attempt > 0
+        && let Some(n) = notifier
+    {
+        n.notify(
+            crate::notification::events::NotificationEvent::OrderUpdateReconnected {
+                consecutive_failures: failures_before_attempt,
+            },
+        );
     }
 
     let m_active = metrics::gauge!("tv_order_update_ws_active");

--- a/crates/core/tests/gap_enforcement.rs
+++ b/crates/core/tests/gap_enforcement.rs
@@ -26,6 +26,8 @@
 //! GAP-SEC-01 tests live in crates/api/tests/auth_middleware.rs.
 //! AUTH-GAP-01/02 tests live in the auth module's unit tests (require secrecy crate).
 
+#![allow(clippy::assertions_on_constants)]
+
 // ===========================================================================
 // I-P0-05: S3 Backup — exhaustive
 // ===========================================================================

--- a/crates/core/tests/mid_session_profile_watchdog_guard.rs
+++ b/crates/core/tests/mid_session_profile_watchdog_guard.rs
@@ -9,6 +9,8 @@
 //!
 //! These tests scan the source so the wiring cannot regress silently.
 
+#![allow(clippy::assertions_on_constants)]
+
 use std::fs;
 use std::path::PathBuf;
 

--- a/crates/core/tests/phase2_wiring_integration.rs
+++ b/crates/core/tests/phase2_wiring_integration.rs
@@ -15,6 +15,8 @@
 //! the public API of `tickvault-core` — same surface a real consumer
 //! sees.
 
+#![allow(clippy::field_reassign_with_default)]
+
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/crates/core/tests/ws_telegram_visibility_guard.rs
+++ b/crates/core/tests/ws_telegram_visibility_guard.rs
@@ -24,6 +24,8 @@
 //! 5. Subscription replay on reconnect is preserved (main feed
 //!    `cached_subscription_messages.iter()` in `connect_and_subscribe`).
 
+#![allow(clippy::assertions_on_constants)]
+
 use std::fs;
 use std::path::PathBuf;
 

--- a/crates/storage/src/candle_persistence.rs
+++ b/crates/storage/src/candle_persistence.rs
@@ -2437,9 +2437,9 @@ mod tests {
             exchange_segment_code: 2, // NSE_FNO
             timestamp_secs: 1_740_556_500,
             open: 24567.25,
-            high: 24600.50,
+            high: 24600.5,
             low: 24510.75,
-            close: 24580.00,
+            close: 24580.0,
             volume: 1_234_567,
             tick_count: 4_200,
             iv: f64::NAN,
@@ -4421,6 +4421,7 @@ mod tests {
         // Write records using BufWriter.
         let file = std::fs::OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .open(&spill_path)
             .unwrap();
@@ -5884,8 +5885,7 @@ mod tests {
 
         // Connect then immediately break the sender
         let port = spawn_tcp_drain_server();
-        if let Ok(s) = questdb::ingress::Sender::from_conf(&format!("tcp::addr=127.0.0.1:{port};"))
-        {
+        if let Ok(s) = questdb::ingress::Sender::from_conf(format!("tcp::addr=127.0.0.1:{port};")) {
             writer.buffer = s.new_buffer();
             writer.sender = Some(s);
         }
@@ -5995,7 +5995,7 @@ mod tests {
         let spill_path = tmp_dir.join("candles-corrupt.bin");
 
         // Write a partial record (less than CANDLE_SPILL_RECORD_SIZE bytes)
-        std::fs::write(&spill_path, &[0u8; 10]).unwrap();
+        std::fs::write(&spill_path, [0u8; 10]).unwrap();
         writer.spill_path = Some(spill_path.clone());
         writer.candles_spilled_total = 1;
 
@@ -6042,7 +6042,7 @@ mod tests {
                 vega: f64::NAN,
             };
             let record = serialize_candle(&c);
-            std::fs::write(&spill_path, &record).unwrap();
+            std::fs::write(&spill_path, record).unwrap();
         }
 
         writer.spill_path = Some(spill_path.clone());
@@ -6088,7 +6088,7 @@ mod tests {
                 vega: f64::NAN,
             };
             let record = serialize_candle(&c);
-            std::fs::write(&spill_path, &record).unwrap();
+            std::fs::write(&spill_path, record).unwrap();
         }
 
         writer.spill_path = Some(spill_path.clone());
@@ -6096,8 +6096,7 @@ mod tests {
 
         // Connect a sender that we'll disconnect after building rows
         let port = spawn_tcp_drain_server();
-        if let Ok(s) = questdb::ingress::Sender::from_conf(&format!("tcp::addr=127.0.0.1:{port};"))
-        {
+        if let Ok(s) = questdb::ingress::Sender::from_conf(format!("tcp::addr=127.0.0.1:{port};")) {
             writer.buffer = s.new_buffer();
             writer.sender = Some(s);
         }
@@ -6190,7 +6189,7 @@ mod tests {
                 vega: f64::NAN,
             };
             let record = serialize_candle(&c);
-            std::fs::write(&stale_path, &record).unwrap();
+            std::fs::write(&stale_path, record).unwrap();
         }
 
         // Make sure the active spill path is different
@@ -6230,7 +6229,7 @@ mod tests {
         let stale_path = real_spill_dir.join("candles-19700102.bin");
 
         // Write partial/corrupt data
-        std::fs::write(&stale_path, &[0xFFu8; 10]).unwrap();
+        std::fs::write(&stale_path, [0xFFu8; 10]).unwrap();
         writer.spill_path = None;
 
         let recovered = writer.recover_stale_spill_files();
@@ -6311,9 +6310,7 @@ mod tests {
             pg_port: port,
         };
         let mut writer = LiveCandleWriter::new(&config).ok()?;
-        if writer.sender.is_none() {
-            return None;
-        }
+        writer.sender.as_ref()?;
         writer.next_reconnect_allowed =
             std::time::Instant::now() + std::time::Duration::from_secs(3600);
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -6495,7 +6492,7 @@ mod tests {
         let path = std::path::PathBuf::from(format!("{}/candles-bufwriter-test.bin", spill_dir));
         let candle = make_cov_buffered_candle(33000);
         let record = serialize_candle(&candle);
-        std::fs::write(&path, &record).unwrap();
+        std::fs::write(&path, record).unwrap();
 
         writer.spill_path = Some(path.clone());
         writer.candles_spilled_total = 1;
@@ -6532,7 +6529,7 @@ mod tests {
         let _ = std::fs::create_dir_all(spill_dir);
         let path = std::path::PathBuf::from(format!("{}/candles-read-err-test.bin", spill_dir));
         // Write corrupt (short) data — should trigger read error
-        std::fs::write(&path, &[0xAB; 30]).unwrap();
+        std::fs::write(&path, [0xAB; 30]).unwrap();
 
         writer.spill_path = Some(path.clone());
         writer.candles_spilled_total = 1;
@@ -6565,7 +6562,7 @@ mod tests {
         let path = std::path::PathBuf::from(format!("{}/candles-build-err-test.bin", spill_dir));
         let candle = make_cov_buffered_candle(34000);
         let record = serialize_candle(&candle);
-        std::fs::write(&path, &record).unwrap();
+        std::fs::write(&path, record).unwrap();
 
         writer.spill_path = Some(path.clone());
         writer.candles_spilled_total = 1;
@@ -6656,7 +6653,7 @@ mod tests {
         // Use a unique filename with test-specific prefix to avoid conflicts
         let stale = std::path::PathBuf::from(format!("{}/candles-19800101.bin", spill_dir));
         // Write corrupt short data — triggers stale spill read error (line 787)
-        std::fs::write(&stale, &[0xAB; 30]).unwrap();
+        std::fs::write(&stale, [0xAB; 30]).unwrap();
 
         let recovered = writer.recover_stale_spill_files();
         let _ = recovered;

--- a/crates/storage/src/greeks_persistence.rs
+++ b/crates/storage/src/greeks_persistence.rs
@@ -1518,7 +1518,7 @@ mod tests {
             ts_nanos: sample_ts_nanos(),
         };
         assert!(build_option_greeks_live_row(&mut buffer, &row).is_ok());
-        assert!(buffer.len() > 0);
+        assert!(!buffer.is_empty());
     }
 
     #[test]
@@ -1538,7 +1538,7 @@ mod tests {
             ts_nanos: sample_ts_nanos(),
         };
         assert!(build_pcr_snapshot_live_row(&mut buffer, &row).is_ok());
-        assert!(buffer.len() > 0);
+        assert!(!buffer.is_empty());
     }
 
     // --- Async HTTP tests for ensure_greeks_tables + execute_ddl ---
@@ -1711,7 +1711,7 @@ mod tests {
             ts_nanos: sample_ts_nanos(),
         };
         assert!(build_dhan_raw_row(&mut buffer, &row).is_ok());
-        assert!(buffer.len() > 0);
+        assert!(!buffer.is_empty());
     }
 
     #[test]
@@ -1751,7 +1751,7 @@ mod tests {
             ts_nanos: sample_ts_nanos(),
         };
         assert!(build_option_greeks_row(&mut buffer, &row).is_ok());
-        assert!(buffer.len() > 0);
+        assert!(!buffer.is_empty());
     }
 
     #[test]
@@ -1770,7 +1770,7 @@ mod tests {
             ts_nanos: sample_ts_nanos(),
         };
         assert!(build_pcr_snapshot_row(&mut buffer, &row).is_ok());
-        assert!(buffer.len() > 0);
+        assert!(!buffer.is_empty());
     }
 
     #[test]
@@ -1802,7 +1802,7 @@ mod tests {
             ts_nanos: sample_ts_nanos(),
         };
         assert!(build_verification_row(&mut buffer, &row).is_ok());
-        assert!(buffer.len() > 0);
+        assert!(!buffer.is_empty());
     }
 
     #[test]

--- a/crates/storage/src/indicator_snapshot_persistence.rs
+++ b/crates/storage/src/indicator_snapshot_persistence.rs
@@ -512,22 +512,22 @@ impl IndicatorSnapshotWriter {
         // Connected. FIRST drain the rescue ring (oldest rows first), so
         // on a bursty restart the oldest missed snapshots reach QuestDB
         // before the in-flight batch.
-        if !self.rescue_ring.is_empty() {
-            if let Err(err) = self.drain_rescue_ring_to_sender() {
-                // Ring drain failed (flush error during drain). Keep the
-                // sender set to None so the next flush retries reconnect
-                // + drain. Rows are still in the ring.
-                self.sender = None;
-                self.buffer.clear();
-                self.pending_count = 0;
-                warn!(
-                    ?err,
-                    ring_depth = self.rescue_ring.len(),
-                    "indicator snapshot rescue ring drain failed — will retry \
-                     on next flush attempt"
-                );
-                return Ok(());
-            }
+        if !self.rescue_ring.is_empty()
+            && let Err(err) = self.drain_rescue_ring_to_sender()
+        {
+            // Ring drain failed (flush error during drain). Keep the
+            // sender set to None so the next flush retries reconnect
+            // + drain. Rows are still in the ring.
+            self.sender = None;
+            self.buffer.clear();
+            self.pending_count = 0;
+            warn!(
+                ?err,
+                ring_depth = self.rescue_ring.len(),
+                "indicator snapshot rescue ring drain failed — will retry \
+                 on next flush attempt"
+            );
+            return Ok(());
         }
 
         // Now flush the in-flight ILP batch.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -7,6 +7,7 @@
 // Phase 0.2: no dropped Result/JoinHandle/must-use values (silent error swallowing).
 #![cfg_attr(not(test), deny(unused_must_use))]
 #![cfg_attr(not(test), warn(clippy::let_underscore_must_use))]
+#![cfg_attr(test, allow(clippy::assertions_on_constants))]
 #![allow(missing_docs)] // TODO: enforce after adding docs to all public items
 
 //! Data persistence layer — QuestDB for time-series, Valkey for caching.
@@ -52,6 +53,7 @@ pub mod tick_persistence_testing {
 /// The two recovery tests
 ///   - `tick_persistence::tests::test_recover_skips_current_active_spill`
 ///   - `candle_persistence::tests::test_live_candle_recover_stale_spill_files`
+///
 /// both call `recover_stale_spill_files()`, which drains EVERY matching
 /// `{ticks,candles}-*.bin` file under the global spill directory. When
 /// cargo runs these tests in parallel inside the same binary, they race

--- a/crates/storage/src/movers_persistence.rs
+++ b/crates/storage/src/movers_persistence.rs
@@ -347,25 +347,10 @@ impl StockMoversWriter {
             Instant::now() + Duration::from_secs(MOVERS_RECONNECT_THROTTLE_SECS);
     }
 
-    /// Appends a single stock mover entry to the ILP buffer.
-    ///
-    /// # Arguments
-    /// * `ts_nanos` — snapshot timestamp (IST epoch nanoseconds)
-    /// * `category` — "GAINER", "LOSER", or "MOST_ACTIVE"
-    /// * `rank` — 1-based rank within category
-    /// * `security_id` — Dhan security ID
-    /// * `segment` — exchange segment string ("NSE_EQ", "NSE_FNO", etc.)
-    /// * `symbol` — human-readable symbol name
-    /// * `ltp` — last traded price
-    /// * `prev_close` — previous day close price
-    /// * `change_pct` — percentage change
-    /// * `volume` — day volume
-    // TEST-EXEMPT: ILP buffer append — requires live QuestDB, tested via ensure_movers_tables integration
-    #[allow(clippy::too_many_arguments)]
-    // APPROVED: 10 params — each maps to a QuestDB column, no abstraction reduces this
     /// Writes a `BufferedStockMover` into an ILP `Buffer`. Single source
     /// of truth for column order + rounding policy — both live append
     /// and rescue drain call this helper. DB-2.
+    // TEST-EXEMPT: ILP buffer append — requires live QuestDB, tested via ensure_movers_tables integration
     fn append_stock_row_to_buffer(buffer: &mut Buffer, row: &BufferedStockMover) -> Result<()> {
         let change_abs = ((row.ltp - row.prev_close) * 100.0).round() / 100.0;
         let ts = TimestampNanos::new(row.ts_nanos);
@@ -397,6 +382,21 @@ impl StockMoversWriter {
         Ok(())
     }
 
+    /// Appends a single stock mover entry to the ILP buffer.
+    ///
+    /// # Arguments
+    /// * `ts_nanos` — snapshot timestamp (IST epoch nanoseconds)
+    /// * `category` — "GAINER", "LOSER", or "MOST_ACTIVE"
+    /// * `rank` — 1-based rank within category
+    /// * `security_id` — Dhan security ID
+    /// * `segment` — exchange segment string ("NSE_EQ", "NSE_FNO", etc.)
+    /// * `symbol` — human-readable symbol name
+    /// * `ltp` — last traded price
+    /// * `prev_close` — previous day close price
+    /// * `change_pct` — percentage change
+    /// * `volume` — day volume
+    #[allow(clippy::too_many_arguments)]
+    // APPROVED: 10 params — each maps to a QuestDB column, no abstraction reduces this
     pub fn append_stock_mover(
         &mut self,
         ts_nanos: i64,
@@ -657,17 +657,9 @@ impl OptionMoversWriter {
             Instant::now() + Duration::from_secs(MOVERS_RECONNECT_THROTTLE_SECS);
     }
 
-    /// Appends a single option mover entry to the ILP buffer.
-    ///
-    /// # Arguments
-    /// * `ts_nanos` — snapshot timestamp (IST epoch nanoseconds)
-    /// * `category` — "HIGHEST_OI", "OI_GAINER", "OI_LOSER", "TOP_VOLUME", "TOP_VALUE", "PRICE_GAINER", "PRICE_LOSER"
-    /// * `rank` — 1-based rank within category
-    // TEST-EXEMPT: ILP buffer append — requires live QuestDB, tested via ensure_movers_tables integration
-    #[allow(clippy::too_many_arguments)]
-    // APPROVED: 17 params — each maps to a QuestDB column, no abstraction reduces this
     /// Writes a `BufferedOptionMover` into an ILP `Buffer`. Single source
     /// of truth for column order + rounding. DB-2.
+    // TEST-EXEMPT: ILP buffer append — requires live QuestDB, tested via ensure_movers_tables integration
     fn append_option_row_to_buffer(buffer: &mut Buffer, row: &BufferedOptionMover) -> Result<()> {
         let ts = TimestampNanos::new(row.ts_nanos);
         buffer
@@ -714,6 +706,14 @@ impl OptionMoversWriter {
         Ok(())
     }
 
+    /// Appends a single option mover entry to the ILP buffer.
+    ///
+    /// # Arguments
+    /// * `ts_nanos` — snapshot timestamp (IST epoch nanoseconds)
+    /// * `category` — "HIGHEST_OI", "OI_GAINER", "OI_LOSER", "TOP_VOLUME", "TOP_VALUE", "PRICE_GAINER", "PRICE_LOSER"
+    /// * `rank` — 1-based rank within category
+    #[allow(clippy::too_many_arguments)]
+    // APPROVED: 17 params — each maps to a QuestDB column, no abstraction reduces this
     pub fn append_option_mover(
         &mut self,
         ts_nanos: i64,
@@ -807,7 +807,7 @@ impl OptionMoversWriter {
     ///
     /// DB-2/DB-6/DB-7: rescue-ring drain-on-reconnect + pop-on-success
     /// + retain-on-failure. See `StockMoversWriter::flush` for the
-    /// identical contract.
+    ///   identical contract.
     pub fn flush(&mut self) -> Result<()> {
         if self.pending_count == 0 && self.rescue_ring.is_empty() {
             return Ok(());

--- a/crates/storage/src/movers_persistence.rs
+++ b/crates/storage/src/movers_persistence.rs
@@ -2157,7 +2157,7 @@ mod tests {
             ltp: 162.15,
             prev_close: 290.30,
             change_pct: -44.14,
-            volume: 12_202_3_330,
+            volume: 122_023_330,
             value: 19_786_775_434.5,
             oi: 8_017_880,
             prev_oi: 4_673_565,
@@ -2182,7 +2182,7 @@ mod tests {
             ltp: 1_368.10,
             prev_close: 1_265.30,
             change_pct: 8.12,
-            volume: 65_515_73,
+            volume: 6_551_573,
             value: 8_963_200_000.0,
             oi: 0,
             prev_oi: 0,
@@ -2255,7 +2255,7 @@ mod tests {
             .expect("price row should append cleanly");
         // Buffer should now contain two line-protocol rows. len_bytes > 0.
         assert!(
-            buffer.len() > 0,
+            !buffer.is_empty(),
             "buffer must have content after two appends"
         );
     }

--- a/crates/storage/src/phase2_subscription_marker.rs
+++ b/crates/storage/src/phase2_subscription_marker.rs
@@ -130,8 +130,7 @@ pub fn decide_recovery(
     is_trading_day: bool,
 ) -> RecoveryDecision {
     let in_market_hours = is_trading_day
-        && now_sec_of_day_ist >= PHASE2_TRIGGER_SECS_IST
-        && now_sec_of_day_ist < MARKET_CLOSE_SECS_IST;
+        && (PHASE2_TRIGGER_SECS_IST..MARKET_CLOSE_SECS_IST).contains(&now_sec_of_day_ist);
     let pre_trigger_trading_day = is_trading_day && now_sec_of_day_ist < PHASE2_TRIGGER_SECS_IST;
 
     // Case A — valid today-dated snapshot wins every time. The

--- a/crates/storage/src/tick_persistence.rs
+++ b/crates/storage/src/tick_persistence.rs
@@ -6630,7 +6630,7 @@ mod tests {
             last_trade_quantity: 75,
             exchange_timestamp: 1_740_556_500,
             received_at_nanos: 1_740_556_500_123_456_789,
-            average_traded_price: 24495.50,
+            average_traded_price: 24495.5,
             volume: 50000,
             total_sell_quantity: 12000,
             total_buy_quantity: 13000,
@@ -7170,6 +7170,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[allow(clippy::print_stderr)]
+    // APPROVED: verbose proof test prints human-readable narrative to stderr
     fn test_verbose_proof_zero_tick_loss_guarantee() {
         use std::sync::atomic::Ordering;
 
@@ -7322,7 +7324,7 @@ mod tests {
             last_trade_quantity: 75,
             exchange_timestamp: 1_740_556_500,
             received_at_nanos: 1_740_556_500_123_456_789,
-            average_traded_price: 24495.50,
+            average_traded_price: 24495.5,
             volume: 50000,
             total_sell_quantity: 12000,
             total_buy_quantity: 13000,
@@ -7754,9 +7756,9 @@ mod tests {
         // If it exists with no matching files, should also return 0.
         let recovered = writer.recover_stale_spill_files();
 
-        // Can only guarantee >= 0 without controlling filesystem state,
-        // but the method must not panic.
-        assert!(recovered == 0 || recovered > 0, "must not panic");
+        // Can only guarantee that the method returns without panicking;
+        // recovered is usize so the value itself is always >= 0.
+        let _ = recovered;
     }
 
     // -----------------------------------------------------------------------
@@ -10403,7 +10405,7 @@ mod tests {
     #[test]
     fn test_f32_to_f64_clean_pi_constant() {
         let result = f32_to_f64_clean(std::f32::consts::PI);
-        assert!((result - 3.1415927_f64).abs() < 0.0001);
+        assert!((result - f64::from(std::f32::consts::PI)).abs() < 0.0001);
     }
 
     #[test]
@@ -11873,7 +11875,7 @@ mod tests {
         let spill_path = tmp_dir.join("ticks-corrupt.bin");
 
         // Write partial data (less than TICK_SPILL_RECORD_SIZE)
-        std::fs::write(&spill_path, &[0xAAu8; 20]).unwrap();
+        std::fs::write(&spill_path, [0xAAu8; 20]).unwrap();
         writer.spill_path = Some(spill_path.clone());
         writer.ticks_spilled_total = 1;
 
@@ -11948,7 +11950,7 @@ mod tests {
         {
             let tick = make_test_tick(5000, 28000.0);
             let record = serialize_tick(&tick);
-            std::fs::write(&stale_path, &record).unwrap();
+            std::fs::write(&stale_path, record).unwrap();
         }
 
         writer.spill_path = None; // no active spill
@@ -12009,7 +12011,7 @@ mod tests {
         let stale_path = real_spill_dir.join("ticks-19700102.bin");
 
         // Write partial/corrupt data
-        std::fs::write(&stale_path, &[0xBBu8; 10]).unwrap();
+        std::fs::write(&stale_path, [0xBBu8; 10]).unwrap();
         writer.spill_path = None;
 
         let recovered = writer.recover_stale_spill_files();
@@ -12528,9 +12530,7 @@ mod tests {
             pg_port: port,
         };
         let mut writer = TickPersistenceWriter::new(&config).ok()?;
-        if writer.sender.is_none() {
-            return None;
-        }
+        writer.sender.as_ref()?;
         // Prevent reconnect during test
         writer.next_reconnect_allowed =
             std::time::Instant::now() + std::time::Duration::from_secs(3600);
@@ -12558,9 +12558,7 @@ mod tests {
             pg_port: port,
         };
         let mut writer = DepthPersistenceWriter::new(&config).ok()?;
-        if writer.sender.is_none() {
-            return None;
-        }
+        writer.sender.as_ref()?;
         writer.next_reconnect_allowed =
             std::time::Instant::now() + std::time::Duration::from_secs(3600);
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -12750,7 +12748,7 @@ mod tests {
         let corrupt_path =
             std::path::PathBuf::from(format!("{}/ticks-corrupt-test.bin", spill_dir));
         // Write only 50 bytes — less than TICK_SPILL_RECORD_SIZE (112)
-        std::fs::write(&corrupt_path, &[0xAB; 50]).unwrap();
+        std::fs::write(&corrupt_path, [0xAB; 50]).unwrap();
 
         writer.spill_path = Some(corrupt_path.clone());
         writer.ticks_spilled_total = 1;
@@ -12780,7 +12778,7 @@ mod tests {
         let path = std::path::PathBuf::from(format!("{}/ticks-build-err-test.bin", spill_dir));
         let tick = make_test_tick(6000, 24800.0);
         let record = serialize_tick(&tick);
-        std::fs::write(&path, &record).unwrap();
+        std::fs::write(&path, record).unwrap();
 
         writer.spill_path = Some(path.clone());
         writer.ticks_spilled_total = 1;
@@ -12888,7 +12886,7 @@ mod tests {
         let stale_path = format!("{}/ticks-19800501.bin", spill_dir);
         let tick = make_test_tick(8000, 25000.0);
         let record = serialize_tick(&tick);
-        std::fs::write(&stale_path, &record).unwrap();
+        std::fs::write(&stale_path, record).unwrap();
 
         // Poison the buffer to trigger build_tick_row error (line 572)
         let _ = writer.buffer.table("ticks");
@@ -13108,7 +13106,7 @@ mod tests {
         let corrupt_path =
             std::path::PathBuf::from(format!("{}/depth-corrupt-test.bin", spill_dir));
         // Write short data to trigger UnexpectedEof read error (line 1314)
-        std::fs::write(&corrupt_path, &[0xCD; 50]).unwrap();
+        std::fs::write(&corrupt_path, [0xCD; 50]).unwrap();
 
         writer.spill_path = Some(corrupt_path.clone());
         writer.depth_spilled_total = 1;
@@ -13141,7 +13139,7 @@ mod tests {
             depth,
         };
         let record = serialize_depth(&snapshot);
-        std::fs::write(&path, &record).unwrap();
+        std::fs::write(&path, record).unwrap();
 
         writer.spill_path = Some(path.clone());
         writer.depth_spilled_total = 1;

--- a/crates/storage/src/valkey_cache.rs
+++ b/crates/storage/src/valkey_cache.rs
@@ -1629,7 +1629,7 @@ mod tests {
         for hour in 0..24_u8 {
             let ttl = compute_instrument_ttl_secs(epoch, hour);
             assert!(
-                ttl >= 60 && ttl <= 86_400,
+                (60..=86_400).contains(&ttl),
                 "TTL for target hour {hour} must be in [60, 86400], got {ttl}"
             );
         }

--- a/crates/storage/tests/chaos_zero_tick_loss.rs
+++ b/crates/storage/tests/chaos_zero_tick_loss.rs
@@ -135,10 +135,10 @@ fn read_metric(metric: &str) -> f64 {
             continue;
         };
         // Match either bare metric name or name with label set.
-        if name == metric || name.starts_with(&format!("{metric}{{")) {
-            if let Ok(v) = value.trim().parse::<f64>() {
-                return v;
-            }
+        if (name == metric || name.starts_with(&format!("{metric}{{")))
+            && let Ok(v) = value.trim().parse::<f64>()
+        {
+            return v;
         }
     }
     0.0

--- a/crates/storage/tests/dedup_segment_meta_guard.rs
+++ b/crates/storage/tests/dedup_segment_meta_guard.rs
@@ -159,7 +159,7 @@ fn self_test_collect_finds_ticks_dedup_key() {
     let decls = collect_dedup_key_declarations();
     let names: Vec<&str> = decls.iter().map(|(_, _, n, _)| n.as_str()).collect();
     assert!(
-        names.iter().any(|n| *n == "DEDUP_KEY_TICKS"),
+        names.contains(&"DEDUP_KEY_TICKS"),
         "DEDUP_KEY_TICKS must be discovered by the scanner. Names: {:?}",
         names
     );

--- a/crates/storage/tests/dedup_uniqueness_proptest.rs
+++ b/crates/storage/tests/dedup_uniqueness_proptest.rs
@@ -76,7 +76,7 @@ proptest! {
         new_vol in any::<u32>(),
         new_oi in any::<u32>(),
     ) {
-        let mut changed = base.clone();
+        let mut changed = base;
         changed.last_traded_price = new_price;
         changed.volume = new_vol;
         changed.open_interest = new_oi;
@@ -92,7 +92,7 @@ proptest! {
         new_sid in any::<u32>(),
     ) {
         prop_assume!(new_sid != base.security_id);
-        let mut changed = base.clone();
+        let mut changed = base;
         changed.security_id = new_sid;
         prop_assert_ne!(dedup_tuple(&base), dedup_tuple(&changed));
     }
@@ -107,7 +107,7 @@ proptest! {
         new_seg in any::<u8>(),
     ) {
         prop_assume!(new_seg != base.exchange_segment_code);
-        let mut changed = base.clone();
+        let mut changed = base;
         changed.exchange_segment_code = new_seg;
         prop_assert_ne!(dedup_tuple(&base), dedup_tuple(&changed));
     }
@@ -119,7 +119,7 @@ proptest! {
         new_ts in any::<u32>(),
     ) {
         prop_assume!(new_ts != base.exchange_timestamp);
-        let mut changed = base.clone();
+        let mut changed = base;
         changed.exchange_timestamp = new_ts;
         prop_assert_ne!(dedup_tuple(&base), dedup_tuple(&changed));
     }

--- a/crates/storage/tests/grafana_dashboard_snapshot_filter_guard.rs
+++ b/crates/storage/tests/grafana_dashboard_snapshot_filter_guard.rs
@@ -661,10 +661,10 @@ fn scan_dir_for_counter_names(dir: &Path, out: &mut BTreeSet<String>) {
         let path = entry.path();
         if path.is_dir() {
             scan_dir_for_counter_names(&path, out);
-        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                extract_counter_names_from_source(&content, out);
-            }
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs")
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            extract_counter_names_from_source(&content, out);
         }
     }
 }

--- a/crates/trading/benches/obi.rs
+++ b/crates/trading/benches/obi.rs
@@ -16,7 +16,7 @@ fn make_levels(base_price: f64, step: f64, base_qty: u32) -> Vec<DeepDepthLevel>
         .map(|i| DeepDepthLevel {
             price: base_price + step * i as f64,
             quantity: base_qty.saturating_sub(i * (base_qty / 25)),
-            orders: (20 - i) as u32,
+            orders: 20 - i,
         })
         .collect()
 }

--- a/crates/trading/src/greeks/aggregator.rs
+++ b/crates/trading/src/greeks/aggregator.rs
@@ -194,11 +194,11 @@ impl GreeksAggregator {
 
         match segment {
             // Index or equity tick → update underlying LTP cache
-            Some(ExchangeSegment::IdxI | ExchangeSegment::NseEquity) => {
-                if tick.last_traded_price > 0.0 && tick.last_traded_price.is_finite() {
-                    self.underlying_ltp
-                        .insert(tick.security_id, tick.last_traded_price);
-                }
+            Some(ExchangeSegment::IdxI | ExchangeSegment::NseEquity)
+                if tick.last_traded_price > 0.0 && tick.last_traded_price.is_finite() =>
+            {
+                self.underlying_ltp
+                    .insert(tick.security_id, tick.last_traded_price);
             }
             // F&O tick → update option state
             Some(ExchangeSegment::NseFno) => {

--- a/crates/trading/src/greeks/black_scholes.rs
+++ b/crates/trading/src/greeks/black_scholes.rs
@@ -1463,7 +1463,7 @@ mod tests {
         let g = compute_greeks(OptionSide::Call, S, K, T, R, Q, price);
         assert!(g.is_some());
         assert!(
-            g.as_ref().map_or(false, |g| g.rho > 0.0),
+            g.as_ref().is_some_and(|g| g.rho > 0.0),
             "Call rho should be positive"
         );
     }
@@ -1474,7 +1474,7 @@ mod tests {
         let g = compute_greeks(OptionSide::Put, S, K, T, R, Q, price);
         assert!(g.is_some());
         assert!(
-            g.as_ref().map_or(false, |g| g.rho < 0.0),
+            g.as_ref().is_some_and(|g| g.rho < 0.0),
             "Put rho should be negative"
         );
     }
@@ -1486,7 +1486,7 @@ mod tests {
         let g = compute_greeks(OptionSide::Call, S, K, T, R, Q, price);
         assert!(g.is_some());
         // Vanna can be positive or negative — just check it's computed and finite.
-        assert!(g.as_ref().map_or(false, |g| g.vanna.is_finite()));
+        assert!(g.as_ref().is_some_and(|g| g.vanna.is_finite()));
     }
 
     #[test]
@@ -1495,7 +1495,7 @@ mod tests {
         let price = bs_call_price(S, K, T, R, Q, SIGMA);
         let g = compute_greeks(OptionSide::Call, S, K, T, R, Q, price);
         assert!(g.is_some());
-        assert!(g.as_ref().map_or(false, |g| g.volga.is_finite()));
+        assert!(g.as_ref().is_some_and(|g| g.volga.is_finite()));
     }
 
     #[test]
@@ -1504,7 +1504,7 @@ mod tests {
         let price = bs_call_price(S, K, T, R, Q, SIGMA);
         let g = compute_greeks(OptionSide::Call, S, K, T, R, Q, price);
         assert!(g.is_some());
-        assert!(g.as_ref().map_or(false, |g| g.speed.is_finite()));
+        assert!(g.as_ref().is_some_and(|g| g.speed.is_finite()));
     }
 
     #[test]
@@ -1930,6 +1930,8 @@ mod tests {
     /// Fine-tune: scan spot/T to find exact params matching Dhan with Cody CDF.
     /// Prints optimal parameters and asserts all 4 Greeks match within 1%.
     #[test]
+    #[allow(clippy::print_stderr)]
+    // APPROVED: calibration test prints diagnostic numerics for human review
     fn test_dhan_screenshot_fine_tune_params_24mar2026() {
         let strike = 22950.0;
         let iv = 0.1829;

--- a/crates/trading/src/greeks/buildup.rs
+++ b/crates/trading/src/greeks/buildup.rs
@@ -152,14 +152,14 @@ mod tests {
     fn test_nifty_23000_ce_short_covering() {
         // From screenshot: CE 23000 → LTP 296.50 (was higher prev), OI down
         // OI: 72,90,595 → current OI lower → Short Covering if price up
-        let result = classify_buildup(72_90_595, 80_00_000, 296.50, 280.0);
+        let result = classify_buildup(7_290_595, 8_000_000, 296.50, 280.0);
         assert_eq!(result, Some(BuildupType::ShortCovering));
     }
 
     #[test]
     fn test_nifty_23000_pe_short_buildup() {
         // PE 23000 → OI increasing, price decreasing → Short Buildup
-        let result = classify_buildup(9_62_065, 8_00_000, 173.75, 250.0);
+        let result = classify_buildup(962_065, 800_000, 173.75, 250.0);
         assert_eq!(result, Some(BuildupType::ShortBuildup));
     }
 

--- a/crates/trading/src/greeks/calibration.rs
+++ b/crates/trading/src/greeks/calibration.rs
@@ -466,6 +466,8 @@ mod tests {
 
     /// Helper: runs calibration for a specific `days_to_expiry` value and returns
     /// the best result along with a per-combo error table.
+    #[allow(clippy::type_complexity)]
+    // APPROVED: tuple maps 1-to-1 to Dhan calibration sample columns; refactor would obscure intent
     fn calibrate_with_day_count(
         base_samples: &[(OptionSide, f64, f64, f64, f64, f64, f64, f64, f64)],
         days_to_expiry: i64,
@@ -991,6 +993,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::print_stderr)]
+    // APPROVED: calibration proof test prints grid-search diagnostics for human review
     fn test_proof_find_dhan_exact_parameters() {
         // Grid search: r × q × dc × fractional_time
         let rates = [0.0, 0.05, 0.06, 0.065, 0.068, 0.07, 0.075, 0.08, 0.10, 0.12];

--- a/crates/trading/src/greeks/inline_computer.rs
+++ b/crates/trading/src/greeks/inline_computer.rs
@@ -385,9 +385,9 @@ mod tests {
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
         // IDX_I tick updates underlying LTP cache.
-        let mut tick = make_tick(13, 0, 23114.50); // IDX_I = 0
+        let mut tick = make_tick(13, 0, 23114.5); // IDX_I = 0
         computer.enrich(&mut tick);
-        assert_eq!(computer.underlying_ltp.get(&13), Some(&23114.50_f32));
+        assert_eq!(computer.underlying_ltp.get(&13), Some(&23114.5_f32));
     }
 
     #[test]
@@ -396,7 +396,7 @@ mod tests {
         let today = NaiveDate::from_ymd_opt(2026, 3, 26).unwrap();
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
-        let mut tick = make_tick(13, 0, 23114.50);
+        let mut tick = make_tick(13, 0, 23114.5);
         computer.enrich(&mut tick);
         // Greeks should remain NAN for non-F&O ticks.
         assert!(tick.iv.is_nan());
@@ -422,7 +422,7 @@ mod tests {
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
         // First: send underlying tick to populate LTP cache.
-        let mut idx_tick = make_tick(13, 0, 23114.50);
+        let mut idx_tick = make_tick(13, 0, 23114.5);
         computer.enrich(&mut idx_tick);
 
         // Then: send option tick → should compute Greeks.
@@ -464,7 +464,7 @@ mod tests {
         let today = NaiveDate::from_ymd_opt(2026, 3, 26).unwrap();
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
-        let mut idx_tick = make_tick(13, 0, 23114.50);
+        let mut idx_tick = make_tick(13, 0, 23114.5);
         computer.enrich(&mut idx_tick);
 
         let mut put_tick = make_tick(50002, 2, 200.0);
@@ -489,7 +489,7 @@ mod tests {
         let today = NaiveDate::from_ymd_opt(2026, 3, 26).unwrap();
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
-        let mut idx_tick = make_tick(13, 0, 23114.50);
+        let mut idx_tick = make_tick(13, 0, 23114.5);
         computer.enrich(&mut idx_tick);
 
         // Future tick → no option_type → no Greeks.
@@ -505,7 +505,7 @@ mod tests {
         let today = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
-        let mut idx_tick = make_tick(13, 0, 23114.50);
+        let mut idx_tick = make_tick(13, 0, 23114.5);
         computer.enrich(&mut idx_tick);
 
         let mut opt_tick = make_tick(50001, 2, 250.0);
@@ -522,7 +522,7 @@ mod tests {
         let today = NaiveDate::from_ymd_opt(2026, 3, 26).unwrap();
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
-        let mut idx_tick = make_tick(13, 0, 23114.50);
+        let mut idx_tick = make_tick(13, 0, 23114.5);
         computer.enrich(&mut idx_tick);
 
         // Zero LTP option → skip.
@@ -548,7 +548,7 @@ mod tests {
         let today = NaiveDate::from_ymd_opt(2026, 3, 26).unwrap();
         let mut computer = InlineGreeksComputer::new(registry, 0.065, 0.012, 365.0, today);
 
-        let mut idx_tick = make_tick(13, 0, 23114.50);
+        let mut idx_tick = make_tick(13, 0, 23114.5);
         computer.enrich(&mut idx_tick);
 
         // First option tick: resolves metadata.

--- a/crates/trading/src/greeks/inline_computer.rs
+++ b/crates/trading/src/greeks/inline_computer.rs
@@ -251,11 +251,9 @@ impl GreeksEnricher for InlineGreeksComputer {
             // Index / equity: update underlying LTP cache, no Greeks.
             Some(
                 ExchangeSegment::IdxI | ExchangeSegment::NseEquity | ExchangeSegment::BseEquity,
-            ) => {
-                if tick.last_traded_price > 0.0 && tick.last_traded_price.is_finite() {
-                    self.underlying_ltp
-                        .insert(tick.security_id, tick.last_traded_price);
-                }
+            ) if tick.last_traded_price > 0.0 && tick.last_traded_price.is_finite() => {
+                self.underlying_ltp
+                    .insert(tick.security_id, tick.last_traded_price);
             }
             // F&O: compute Greeks for options.
             Some(ExchangeSegment::NseFno | ExchangeSegment::BseFno) => {

--- a/crates/trading/src/greeks/pcr.rs
+++ b/crates/trading/src/greeks/pcr.rs
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn test_pcr_basic() {
-        let pcr = compute_pcr(72_90_595, 28_12_485).unwrap();
+        let pcr = compute_pcr(7_290_595, 2_812_485).unwrap();
         assert!(pcr > 2.0, "High put OI → high PCR: {pcr}");
     }
 
@@ -86,7 +86,7 @@ mod tests {
     fn test_pcr_nifty_example() {
         // From screenshot: PCR = 0.78 (approximate)
         // Typical NIFTY weekly: ~40L puts, ~50L calls
-        let pcr = compute_pcr(40_00_000, 51_28_205).unwrap();
+        let pcr = compute_pcr(4_000_000, 5_128_205).unwrap();
         assert!(pcr > 0.7 && pcr < 0.9, "NIFTY-like PCR: {pcr}");
     }
 

--- a/crates/trading/src/lib.rs
+++ b/crates/trading/src/lib.rs
@@ -7,6 +7,8 @@
 // Phase 0.2: no dropped Result/JoinHandle/must-use values (silent error swallowing).
 #![cfg_attr(not(test), deny(unused_must_use))]
 #![cfg_attr(not(test), warn(clippy::let_underscore_must_use))]
+#![cfg_attr(test, allow(clippy::assertions_on_constants))]
+#![cfg_attr(test, allow(clippy::field_reassign_with_default))]
 #![allow(missing_docs)] // TODO: enforce after adding docs to all public items
 
 //! Trading engine: O(1) indicators, FSM strategies, OMS, Greeks, and risk controls.

--- a/crates/trading/src/oms/api_client.rs
+++ b/crates/trading/src/oms/api_client.rs
@@ -4900,7 +4900,7 @@ mod tests {
         let (url, h) = start_mock_server(429, "{}").await;
         let client = make_test_client(&url);
         let result = client.activate_kill_switch("jwt").await;
-        assert!(matches!(result, Err(OmsError::DhanRateLimited { .. })));
+        assert!(matches!(result, Err(OmsError::DhanRateLimited)));
         h.abort();
     }
 
@@ -4923,7 +4923,7 @@ mod tests {
             trailing_jump: 0.0,
         };
         let result = client.place_super_order("jwt", &req).await;
-        assert!(matches!(result, Err(OmsError::DhanRateLimited { .. })));
+        assert!(matches!(result, Err(OmsError::DhanRateLimited)));
         h.abort();
     }
 
@@ -4950,7 +4950,7 @@ mod tests {
             quantity1: None,
         };
         let result = client.create_forever_order("jwt", &req).await;
-        assert!(matches!(result, Err(OmsError::DhanRateLimited { .. })));
+        assert!(matches!(result, Err(OmsError::DhanRateLimited)));
         h.abort();
     }
 
@@ -4959,7 +4959,7 @@ mod tests {
         let (url, h) = start_mock_server(429, "{}").await;
         let client = make_test_client(&url);
         let result = client.get_all_conditional_triggers("jwt").await;
-        assert!(matches!(result, Err(OmsError::DhanRateLimited { .. })));
+        assert!(matches!(result, Err(OmsError::DhanRateLimited)));
         h.abort();
     }
 }

--- a/crates/trading/src/risk/engine.rs
+++ b/crates/trading/src/risk/engine.rs
@@ -924,35 +924,35 @@ mod tests {
         let mut engine = make_engine();
         engine.update_market_price(1001, f64::NAN);
         // NaN should NOT be stored
-        assert!(engine.market_prices.get(&1001).is_none());
+        assert!(!engine.market_prices.contains_key(&1001));
     }
 
     #[test]
     fn test_infinity_price_rejected() {
         let mut engine = make_engine();
         engine.update_market_price(1001, f64::INFINITY);
-        assert!(engine.market_prices.get(&1001).is_none());
+        assert!(!engine.market_prices.contains_key(&1001));
     }
 
     #[test]
     fn test_negative_infinity_price_rejected() {
         let mut engine = make_engine();
         engine.update_market_price(1001, f64::NEG_INFINITY);
-        assert!(engine.market_prices.get(&1001).is_none());
+        assert!(!engine.market_prices.contains_key(&1001));
     }
 
     #[test]
     fn test_zero_price_rejected() {
         let mut engine = make_engine();
         engine.update_market_price(1001, 0.0);
-        assert!(engine.market_prices.get(&1001).is_none());
+        assert!(!engine.market_prices.contains_key(&1001));
     }
 
     #[test]
     fn test_negative_price_rejected() {
         let mut engine = make_engine();
         engine.update_market_price(1001, -1.0);
-        assert!(engine.market_prices.get(&1001).is_none());
+        assert!(!engine.market_prices.contains_key(&1001));
     }
 
     #[test]

--- a/crates/trading/src/risk/tick_gap_tracker.rs
+++ b/crates/trading/src/risk/tick_gap_tracker.rs
@@ -1043,7 +1043,7 @@ mod tests {
         }
         // Gap exactly at (alert + error) / 2 — should be Warning not Error
         let mid_gap = (TICK_GAP_ALERT_THRESHOLD_SECS + TICK_GAP_ERROR_THRESHOLD_SECS) / 2;
-        if mid_gap >= TICK_GAP_ALERT_THRESHOLD_SECS && mid_gap < TICK_GAP_ERROR_THRESHOLD_SECS {
+        if (TICK_GAP_ALERT_THRESHOLD_SECS..TICK_GAP_ERROR_THRESHOLD_SECS).contains(&mid_gap) {
             let gap_ts = base_ts + TICK_GAP_MIN_TICKS_BEFORE_ACTIVE + mid_gap;
             let result = tracker.record_tick(1001, gap_ts);
             assert!(
@@ -1063,7 +1063,7 @@ mod tests {
         let gap_ts = base_ts + TICK_GAP_MIN_TICKS_BEFORE_ACTIVE + TICK_GAP_ERROR_THRESHOLD_SECS - 1;
         let result = tracker.record_tick(1001, gap_ts);
         // If error - 1 >= alert, it should be Warning
-        if TICK_GAP_ERROR_THRESHOLD_SECS - 1 >= TICK_GAP_ALERT_THRESHOLD_SECS {
+        if TICK_GAP_ERROR_THRESHOLD_SECS > TICK_GAP_ALERT_THRESHOLD_SECS {
             assert!(matches!(result, TickGapResult::Warning { .. }));
         }
     }

--- a/crates/trading/src/risk/tick_gap_tracker.rs
+++ b/crates/trading/src/risk/tick_gap_tracker.rs
@@ -251,7 +251,7 @@ impl TickGapTracker {
         // Include up to 3 worst security_ids for debugging.
         // O(1) EXEMPT: begin — cold path, called once every 30s (not per tick)
         self.pending_warn_gaps
-            .sort_unstable_by(|a, b| b.1.cmp(&a.1));
+            .sort_unstable_by_key(|&(_, gap)| std::cmp::Reverse(gap));
         let worst_3: Vec<_> = self.pending_warn_gaps.iter().take(3).collect();
         let sample_str: String = worst_3
             .iter()

--- a/crates/trading/src/risk/types.rs
+++ b/crates/trading/src/risk/types.rs
@@ -139,6 +139,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::clone_on_copy)]
+    // APPROVED: this test exists to verify Clone trait is wired alongside Copy
     fn risk_breach_clone_and_copy() {
         let breach = RiskBreach::ManualHalt;
         let cloned = breach.clone();
@@ -263,6 +265,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::clone_on_copy)]
+    // APPROVED: this test exists to verify Clone trait is wired alongside Copy
     fn position_info_clone_and_copy() {
         let pos = PositionInfo {
             net_lots: 10,

--- a/crates/trading/tests/obi_e2e.rs
+++ b/crates/trading/tests/obi_e2e.rs
@@ -19,7 +19,7 @@ fn make_realistic_book(base_price: f64, step: f64, base_qty: u32) -> Vec<DeepDep
         .map(|i| DeepDepthLevel {
             price: base_price + step * i as f64,
             quantity: base_qty.saturating_sub(i * (base_qty / 25)),
-            orders: (20 - i) as u32,
+            orders: 20 - i,
         })
         .collect()
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "tickvault-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2024"
-rust-version = "1.93.1"
+rust-version = "1.95.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,5 +8,5 @@
 # =============================================================================
 
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src", "llvm-tools-preview"]


### PR DESCRIPTION
## Summary

Bumps the Rust toolchain across the workspace from **1.93.1 → 1.95.0** and fixes every new clippy lint surfaced by the upgrade. Three commits, scoped by concern:

1. `chore(toolchain): bump Rust 1.93.1 to 1.95.0` — version pins in `Cargo.toml`, `rust-toolchain.toml`, `fuzz/Cargo.toml`, and 7 workflow files.
2. `fix(clippy): address Rust 1.95.0 lib lints across workspace` — production-code lints (25 files).
3. `fix(clippy): address Rust 1.95.0 test-target lints across workspace` — test-only lints (44 files).

No business logic changed. Fixes are clippy-driven only; `#[allow(...)]` was used sparingly with `// APPROVED:` rationale where mechanical rewrites would be misleading (e.g. tests that intentionally exercise `Clone` on `Copy` types, or human-readable `eprintln!` proof tests).

### Lint categories fixed

| Lint | Approach |
|------|----------|
| `manual_range_contains` / `manual_range_inclusive` | rewrote as `(a..b).contains(&x)` |
| `unnecessary_sort_by` | switched to `sort_unstable_by_key(|e| Reverse(...))` |
| `collapsible_if` | merged into `if … && let Some(_) = … {` |
| `let_underscore_must_use` (prod) | `drop(expr)` for fire-and-forget cleanup; `_ = expr;` for `Copy` results |
| `assertions_on_constants` (tests) | crate-level `#![cfg_attr(test, allow(...))]` in each `lib.rs` |
| `field_reassign_with_default` (tests) | crate-level `#![cfg_attr(test, allow(...))]` |
| `print_stderr` (verbose proof tests) | per-fn `#[allow(clippy::print_stderr)]` with `// APPROVED:` |
| `excessive_precision` | dropped trailing zero on f32 literals |
| `inconsistent_digit_grouping` | regrouped to thousands |
| `needless_borrows_for_generic_args` | dropped `&` from `std::fs::write(path, &record)` etc. |
| `unnecessary_map_or` | switched to `is_some_and` / `is_none_or` |
| `clone_on_copy` | removed clone or kept with `// APPROVED:` for trait-coverage tests |
| `items_after_test_module` (main.rs) | `#[allow]` w/ rationale |
| `too_many_arguments` (test helper) | `#[allow]` w/ rationale |
| `type_complexity` (calibration helper) | `#[allow]` w/ rationale |
| `double_comparisons`, `int_plus_one`, etc. | mechanical rewrite |
| `eq_op` on tautologies | replaced with `let _ = …` |
| `unexpected_cfgs` | added `dhat = []` to `crates/core/Cargo.toml` `[features]` |

### Known compatibility notes

- The workspace lib.rs in storage / core / trading / api / app now adds:
  ```rust
  #![cfg_attr(test, allow(clippy::assertions_on_constants))]
  #![cfg_attr(test, allow(clippy::field_reassign_with_default))]
  ```
  These only apply during test compilation; production builds are unaffected.
- A new `dhat` feature was added to `crates/core/Cargo.toml` so the existing `#![cfg(feature = "dhat")]` test gate is recognized by `check-cfg` (no semantic change).

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace --lib` — **7,261 passed, 0 failed, 3 ignored**
- [ ] CI: confirm `cargo test --workspace` (integration + chaos) passes on PR build

https://claude.ai/code/session_01DaxEZHT8Mx34Mp8MMdePk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaxEZHT8Mx34Mp8MMdePk4)_