### PR TITLE
docs: align stale rust-version references with pinned 1.95.0

### DIFF
--- a/.claude/rules/project/cargo-and-docker.md
+++ b/.claude/rules/project/cargo-and-docker.md
@@ -13,7 +13,7 @@ paths:
 - `cargo update` is BANNED — Bible updates only.
 - Workspace deps in root Cargo.toml, crates use `{ workspace = true }`
 - Adding deps: check Bible first. Not found? Propose to Parthiban with justification.
-- `edition = "2024"`, `rust-version = "1.93.1"` in every crate
+- `edition = "2024"`, `rust-version = "1.95.0"` in every crate
 
 ## Docker
 - Same docker-compose.yml and Dockerfile on Mac and AWS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Every file, function, config decision must pass all three. No exceptions.
 ## PROJECT
 
 - **Purpose:** O(1) latency live F&O trading system for Indian markets (NSE)
-- **Language:** Rust 2024 Edition (stable 1.93.1)
+- **Language:** Rust 2024 Edition (stable 1.95.0)
 - **Repo:** `https://github.com/SJParthi/tickvault` (single source of truth)
 - **Runtime:** Docker everywhere. Mac (dev) → AWS c7i.2xlarge Mumbai (prod). Same containers, same code, always real AWS SSM.
 - **Owner:** Parthiban (architect). Claude Code (builder).
@@ -186,7 +186,7 @@ Branch protection ON: Build & Verify, Security & Audit, Commit Lint, Secret Scan
 
 - Workspace deps in root Cargo.toml, crates use `{ workspace = true }`
 - Exact versions ONLY in workspace `Cargo.toml`. `^`, `~`, `*`, `>=` are BANNED. `cargo update` is BANNED. New dep additions need Parthiban approval.
-- `edition = "2024"`, `rust-version = "1.93.1"` in every crate
+- `edition = "2024"`, `rust-version = "1.95.0"` in every crate
 - Release profile: `overflow-checks = true`, `lto = "thin"`, `codegen-units = 1`, `panic = "abort"`, `strip = "symbols"`
 
 ## KEY DEPENDENCIES (pinned versions)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ tickvault/
 
 ## Quick Start
 
-**Prerequisites:** Rust 1.93.1, Docker, Docker Compose
+**Prerequisites:** Rust 1.95.0, Docker, Docker Compose
 
 ```bash
 git clone https://github.com/SJParthi/tickvault.git

--- a/docs/PROJECT-SCOPE.md
+++ b/docs/PROJECT-SCOPE.md
@@ -11,7 +11,7 @@
 | Property | Value |
 |----------|-------|
 | **Purpose** | O(1) latency live F&O trading system for Indian markets (NSE) |
-| **Language** | Rust 2024 Edition (stable 1.93.1) |
+| **Language** | Rust 2024 Edition (stable 1.95.0) |
 | **Architecture** | 6-crate workspace, Docker-first, AWS c7i.2xlarge Mumbai (prod) |
 | **Phase** | Phase 1 — Live Trading System |
 | **Codebase** | ~84,000 lines of Rust across 147 files |

--- a/docs/phases/phase-1-live-trading.md
+++ b/docs/phases/phase-1-live-trading.md
@@ -1392,7 +1392,7 @@ Response: Array of OHLCV candles with timestamps.
 
 | Property | Value |
 |----------|-------|
-| Language | Rust 2024 Edition (1.93.1) |
+| Language | Rust 2024 Edition (1.95.0) |
 | Runtime | Docker containers (Mac dev → AWS prod) |
 | Tick parse latency | <10ns (zerocopy) |
 | End-to-end latency | <92μs (tick → QuestDB) |

--- a/docs/standards/security-audit-2026-03-07.md
+++ b/docs/standards/security-audit-2026-03-07.md
@@ -281,7 +281,7 @@ api:
 - Bible last reconciled 2026-02-26 but dependencies have drifted since
 
 ### LOW: Fuzz Crate Edition Duplication
-- `fuzz/Cargo.toml` duplicates `edition = "2024"` and `rust-version = "1.93.1"` instead of workspace inheritance (acceptable since excluded from workspace)
+- `fuzz/Cargo.toml` duplicates `edition = "2024"` and `rust-version = "1.95.0"` instead of workspace inheritance (acceptable since excluded from workspace)
 
 ### LOW: DashMap in Dependencies
 - `dashmap` appears in root Cargo.toml but is imported nowhere — dead dependency


### PR DESCRIPTION
## Summary

You asked to pin the workspace to Rust **1.95.1**. Verification showed:

- `https://static.rust-lang.org/dist/rust-1.95.1-x86_64-unknown-linux-gnu.tar.gz.sha256` returns **404** — 1.95.1 has not been released.
- The latest stable as of 2026-04-25 is **1.95.0** (released 2026-04-14).
- The workspace, `fuzz/Cargo.toml`, `rust-toolchain.toml`, and 7 GitHub Actions workflows were already pinned to 1.95.0.
- Six documentation files still mentioned the older 1.93.1 — those are corrected here.

## What changed

| File | Before | After |
|---|---|---|
| `README.md` | Rust 1.93.1 | Rust 1.95.0 |
| `CLAUDE.md` (project header) | stable 1.93.1 | stable 1.95.0 |
| `CLAUDE.md` (Cargo section) | `rust-version = "1.93.1"` in every crate | `rust-version = "1.95.0"` in every crate |
| `docs/PROJECT-SCOPE.md` | stable 1.93.1 | stable 1.95.0 |
| `docs/phases/phase-1-live-trading.md` | Rust 2024 Edition (1.93.1) | Rust 2024 Edition (1.95.0) |
| `.claude/rules/project/cargo-and-docker.md` | `rust-version = "1.93.1"` | `rust-version = "1.95.0"` |
| `docs/standards/security-audit-2026-03-07.md` | quotes "1.93.1" in fuzz reference | quotes "1.95.0" |

## State of the workspace after this PR

| Location | Pinned |
|---|---|
| `rust-toolchain.toml` channel | `1.95.0` |
| Workspace root `Cargo.toml` `rust-version` | `1.95.0` |
| All 6 crate `Cargo.toml` (`rust-version.workspace = true`) | inherits `1.95.0` |
| `fuzz/Cargo.toml` (excluded from workspace, intentional) | `1.95.0` |
| 7 GitHub Actions workflows (ci, mutation, chaos-nightly, security-audit, dep-freshness-nightly, full-test-nightly, deploy-aws) | `1.95.0` |
| All 6 doc files updated in this PR | `1.95.0` |

Grep proof:
```
$ grep -rn "1\.93\.1" --include="*.toml" --include="*.yml" --include="*.md" .
(none)
$ grep -rn "1\.94\." --include="*.toml" --include="*.yml" --include="*.md" .
(none)
$ grep -rn "1\.95\." --include="*.toml" --include="*.yml" --include="*.md" .
# 25 hits, every single one is "1.95.0"
```

## Verification

- `cargo --version` → `cargo 1.95.0 (f2d3ce0bd 2026-03-21)` ✅
- `rustc --version` → `rustc 1.95.0 (59807616e 2026-04-14)` ✅
- `cargo check --workspace --all-targets` → **exit 0**, 5m 06s wall-clock (all 6 crates: common, core, trading, storage, api, app) ✅

## Test plan

- [ ] CI Build & Verify on 1.95.0 passes (fmt, clippy, test, doc, typos, pattern guards)
- [ ] CI Security & Audit on 1.95.0 passes (cargo deny + cargo audit)
- [ ] Re-pin to 1.95.1 in a follow-up PR once it actually ships on `static.rust-lang.org`

## What this PR does NOT do

You asked for many additional guarantees in the same message — 100% coverage / 100% security / zero tick loss / "WS never disconnects" / full local+AWS automation / activate every subagent. Those are ongoing programs that span dozens of PRs (see CLAUDE.md Phases 0–12, the 21 ratchets in `observability-architecture.md`, the gap-enforcement matrix, etc.). I'm intentionally not bundling them here — this PR is scoped to the version-pin sweep so it can be reviewed and merged in minutes rather than getting blocked on unrelated work. Open follow-up issues for any of those programs and we'll attack them one at a time with concrete proofs (tests, ratchets, gauges) — not adjective lists.

https://claude.ai/code/session_01T8R5awCiqUsSYyxZndtxzS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8R5awCiqUsSYyxZndtxzS)_