### PR TITLE
docs(observability): unstale Phase 7.2 — Triage MCP server is shipped

### DIFF
--- a/.claude/rules/project/observability-architecture.md
+++ b/.claude/rules/project/observability-architecture.md
@@ -214,8 +214,16 @@ summary file and drives the above flow.
       incl. clear-spill), `.claude/triage/claude-loop-prompt.md`,
       `error-triage.sh` shell hook, 3 auto-fix scripts, triage_rules_guard
       meta-test, `make triage-dry-run/triage-execute`
-- [x] **Phase 7.1** — `/loop` runbook prompt (claude-loop-prompt.md);
-      Phase 7.2 MCP server still pending
+- [x] **Phase 7.1** — `/loop` runbook prompt
+      (`.claude/triage/claude-loop-prompt.md`).
+- [x] **Phase 7.2** — Triage MCP server shipped:
+      `scripts/mcp-servers/tickvault-logs/server.py` exposes the full
+      triage flow over stdio MCP — `_signature_hash` (FNV-1a of
+      code+target+first-160), `tool_triage_log_tail`,
+      `tool_find_runbook_for_code`, `tool_list_novel_signatures`,
+      `tool_tail_errors`, `tool_summary_snapshot`, `tool_signature_history`.
+      Auto-loaded via `.mcp.json` `tickvault-logs` entry; tools surface
+      as `mcp__tickvault-logs__*` in any Claude Code session.
 - [~] **Phase 8.1** — Common auto-fix scripts (restart-depth, refresh-
       instruments, clear-spill — all three scaffolded, refresh-instruments
       fully functional today); Phase 8.2 Lambda bridge deferred until


### PR DESCRIPTION
## Summary

Follow-up to #374. The Completion status block still claimed "Phase 7.2 MCP server still pending" — but the `tickvault-logs` MCP server at `scripts/mcp-servers/tickvault-logs/server.py` already implements the full triage flow.

## Why the #374 guard didn't catch this

The original line read:

```
- [x] **Phase 7.1** — `/loop` runbook prompt (claude-loop-prompt.md);
      Phase 7.2 MCP server still pending
```

The guard test scans `[x]` lines for backtick-quoted repo paths and verifies they exist on disk. This line is on a **Phase 7.1** bullet that mentions 7.2 in prose — not a separate `[x] Phase 7.2` line — so the guard correctly didn't flag it (no missing path was cited; the line just had a stale prose claim).

## Citations the doc now includes

| Triage flow function | Implementation |
|---|---|
| `_signature_hash` (FNV-1a of code+target+first-160 chars) | `scripts/mcp-servers/tickvault-logs/server.py:213` |
| `tool_triage_log_tail` | `:368` |
| `tool_find_runbook_for_code` | `:450` |
| `tool_list_novel_signatures` | (in same file) |
| `tool_tail_errors` / `tool_summary_snapshot` / `tool_signature_history` | (in same file) |
| Auto-loaded via `.mcp.json` `tickvault-logs` entry | tools surface as `mcp__tickvault-logs__*` |

## Verification

```
$ cargo test -p tickvault-common --test observability_completion_status_guard
running 5 tests
test result: ok. 5 passed; 0 failed
```

## Note for future sessions

When adding a `[x] Phase X.Y — ... shipped` line, **always include at least one backtick-quoted repo path** so the drift guard from #374 can verify it. Otherwise prose claims on shipped phases can still drift undetected.

## Test plan

- [ ] CI Build & Verify passes
- [ ] CI Test (common) passes
- [ ] Reviewer verifies `mcp__tickvault-logs__find_runbook_for_code` is callable from a fresh Claude Code session

https://claude.ai/code/session_01T8R5awCiqUsSYyxZndtxzS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8R5awCiqUsSYyxZndtxzS)_