### PR TITLE
fix(observability+ops): false-positive alert + jargon + token cache + grafana reload + auto-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,12 @@ open: ## Open DLT Control Panel in browser
 grafana: ## Open Grafana dashboard (localhost:3000)
 	@open http://localhost:3000
 
+grafana-reload: ## Reload Grafana provisioning (run after editing alerts.yml or dashboards/*.json)
+	@echo "Reloading Grafana provisioning..."
+	@docker compose -f deploy/docker/docker-compose.yml restart tv-grafana >/dev/null 2>&1 \
+		&& echo "  Grafana reloaded — alert rule + dashboard changes are live." \
+		|| { echo "  Reload failed — is Docker running? Try: make docker-up"; exit 1; }
+
 questdb: ## Open QuestDB console (localhost:9000)
 	@open http://localhost:9000
 

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,14 @@ run: ## Run app in dev mode (pretty logs, localhost config)
 	@./scripts/ensure-ready.sh
 	@cargo run
 
-stop: ## Stop running app
+stop: ## Stop running app (also wipes the on-disk JWT cache)
 	@echo "🛑 Stopping $(APP_NAME)..."
 	@-pkill -f "target/debug/$(APP_NAME)" 2>/dev/null && echo "  Stopped." || echo "  Not running."
+	@# Defence-in-depth: remove the cached Dhan JWT so a stolen-laptop
+	@# scenario cannot reuse it. The app re-fetches via SSM on next boot.
+	@if [ -f data/cache/tv-token-cache ]; then \
+		rm -f data/cache/tv-token-cache && echo "  Token cache wiped."; \
+	fi
 
 restart: stop ## Restart app (stop + run)
 	@sleep 1

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,9 @@ grafana-reload: ## Reload Grafana provisioning (run after editing alerts.yml or 
 		&& echo "  Grafana reloaded — alert rule + dashboard changes are live." \
 		|| { echo "  Reload failed — is Docker running? Try: make docker-up"; exit 1; }
 
+grafana-watch: ## Watch grafana provisioning dir + auto-reload on change (Ctrl+C to stop)
+	@bash scripts/grafana-watch.sh
+
 questdb: ## Open QuestDB console (localhost:9000)
 	@open http://localhost:9000
 

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -1447,7 +1447,7 @@ impl NotificationEvent {
                     "Will compare on next run after live ticks during market hours."
                 };
                 format!(
-                    "<b>Historical vs Live cross-match SKIPPED</b>\nReason: {reason}\nLEFT JOIN rows: {candles_compared} (diagnostic only)\n{next_action}"
+                    "<b>Historical vs Live cross-match SKIPPED</b>\nReason: {reason}\nCandles compared: {candles_compared}\n{next_action}"
                 )
             }
             Self::IpVerificationFailed { reason } => {

--- a/deploy/docker/grafana/provisioning/alerting/alerts.yml
+++ b/deploy/docker/grafana/provisioning/alerting/alerts.yml
@@ -384,7 +384,11 @@ groups:
             relativeTimeRange: { from: 120, to: 0 }
             datasourceUid: loki
             model:
-              expr: "count_over_time({job=\"tv-docker\", container=\"tickvault\"} |~ \"(?i)(ERROR|PANIC|FATAL)\" [2m])"
+              # Match the JSON `"level":"ERROR"` field exactly (not arbitrary substrings).
+              # Old regex `(?i)(ERROR|PANIC|FATAL)` matched filenames like
+              # "errors.summary.md", metric names like "tv_historical_api_errors_total",
+              # and Dhan field names like "errorCode" — causing constant false positives.
+              expr: "count_over_time({job=\"tv-docker\", container=\"tickvault\"} |~ \"\\\"level\\\":\\\"(ERROR|FATAL)\\\"\" [2m])"
               intervalMs: 15000
               maxDataPoints: 43200
           - refId: B

--- a/scripts/grafana-watch.sh
+++ b/scripts/grafana-watch.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Watch deploy/docker/grafana/provisioning/ and auto-reload Grafana on change.
+#
+# Usage:
+#   make grafana-watch
+#
+# Runs in the foreground — leave it open in a terminal while editing alert
+# rules or dashboard JSON. Each save triggers `make grafana-reload`, so
+# changes appear in Grafana within ~10 seconds without manual restart.
+#
+# Why a watcher script instead of a sidecar container:
+#   - Zero docker-compose changes (no new container, no RAM budget impact)
+#   - Zero AWS-budget impact (script only runs when the operator launches it)
+#   - Works identically on macOS (fswatch) and Linux (inotifywait)
+#   - Reversible by deleting this file
+#
+# Stop with Ctrl+C.
+
+set -euo pipefail
+
+WATCH_DIR="deploy/docker/grafana/provisioning"
+
+if [ ! -d "$WATCH_DIR" ]; then
+    echo "Error: directory not found: $WATCH_DIR"
+    echo "Run from the repo root."
+    exit 1
+fi
+
+echo "Watching $WATCH_DIR for changes — Ctrl+C to stop."
+echo ""
+
+reload_now() {
+    echo "[$(date +%H:%M:%S)] change detected — reloading Grafana..."
+    if make grafana-reload >/dev/null 2>&1; then
+        echo "[$(date +%H:%M:%S)] reload OK"
+    else
+        echo "[$(date +%H:%M:%S)] reload FAILED — is Docker running?"
+    fi
+    echo ""
+}
+
+if command -v fswatch >/dev/null 2>&1; then
+    # macOS path (fswatch ships via Homebrew: brew install fswatch)
+    fswatch -o "$WATCH_DIR" | while read -r _; do reload_now; done
+elif command -v inotifywait >/dev/null 2>&1; then
+    # Linux path (apt install inotify-tools)
+    inotifywait -m -r -q -e modify,create,delete,move "$WATCH_DIR" | \
+        while read -r _; do reload_now; done
+else
+    cat <<EOF
+Error: no file watcher installed.
+
+  macOS:  brew install fswatch
+  Linux:  sudo apt install inotify-tools
+
+Or just run \`make grafana-reload\` manually after each edit.
+EOF
+    exit 1
+fi

--- a/scripts/launchd/README.md
+++ b/scripts/launchd/README.md
@@ -1,0 +1,78 @@
+# Mac auto-deploy via launchd
+
+Polls GitHub for green CI on the configured branch and runs `git pull
+&& cargo build --release && make restart` automatically.
+
+Designed as a stop-gap for the period **before** the AWS instance is
+provisioned. On AWS this is replaced by a proper GitHub Actions deploy
+job — the script is then no longer needed.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `auto-deploy.sh` | Polling loop; safe-guards; performs the deploy |
+| `com.tickvault.autodeploy.plist` | launchd manifest — registers the script as a user agent |
+
+## Install (one-time, on the Mac)
+
+1. Edit `com.tickvault.autodeploy.plist` and replace `YOUR_USERNAME`
+   with your macOS username (3 occurrences).
+
+2. Copy the plist into your user LaunchAgents directory and load it:
+
+   ```bash
+   cp scripts/launchd/com.tickvault.autodeploy.plist \
+      ~/Library/LaunchAgents/com.tickvault.autodeploy.plist
+   launchctl load ~/Library/LaunchAgents/com.tickvault.autodeploy.plist
+   ```
+
+3. Verify it's running:
+
+   ```bash
+   launchctl list | grep tickvault
+   tail -f data/logs/auto-deploy.log
+   ```
+
+## Uninstall
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.tickvault.autodeploy.plist
+rm ~/Library/LaunchAgents/com.tickvault.autodeploy.plist
+```
+
+## Configuration
+
+Set via environment variables in the plist's `EnvironmentVariables`
+dict (or just edit defaults at the top of `auto-deploy.sh`):
+
+| Var | Default | Meaning |
+|---|---|---|
+| `TV_DEPLOY_BRANCH` | `main` | Branch to track |
+| `TV_DEPLOY_POLL_SECS` | `60` | Poll interval |
+| `TV_REPO_DIR` | `$HOME/IdeaProjects/tickvault` | Repo location |
+
+## Safety guards (built in)
+
+| Guard | What it prevents |
+|---|---|
+| Skip during 09:15–15:30 IST market hours | Build never interrupts live trading |
+| Skip on weekends (IST `dow > 5`) | No churn outside trading days |
+| Refuse if working tree dirty | Never overwrites local edits |
+| Refuse if HEAD is on a different branch | Never silently switches branches |
+| `git pull --ff-only` | Never auto-merges |
+| Build BEFORE stop | A bad commit leaves the running app alive |
+| `last-deployed-sha` cache | Same commit never deployed twice |
+| Only deploys on `state == "success"` from GitHub combined-status API | Never deploys a red build |
+
+## Logs
+
+- `data/logs/auto-deploy.log` — script's own structured log
+- `data/logs/auto-deploy.launchd.out` — stdout from launchd
+- `data/logs/auto-deploy.launchd.err` — stderr from launchd
+
+## When this becomes obsolete
+
+Once the AWS instance is provisioned (`scripts/setup-aws.sh`), set up a
+GitHub Actions `deploy` job that SSHes into the instance on green CI for
+`main`. At that point: uninstall this launchd agent, delete this folder.

--- a/scripts/launchd/auto-deploy.sh
+++ b/scripts/launchd/auto-deploy.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Auto-deploy on green CI for the active branch.
+#
+# Polls the GitHub combined-status API every N seconds. When a NEW commit
+# arrives on the tracked branch AND every required check has succeeded,
+# pulls + rebuilds + restarts the app.
+#
+# Designed for the Mac dev box BEFORE the AWS instance exists. On AWS this
+# is replaced by a proper GitHub Actions deploy job.
+#
+# Install (one-time):
+#   cp scripts/launchd/com.tickvault.autodeploy.plist ~/Library/LaunchAgents/
+#   launchctl load ~/Library/LaunchAgents/com.tickvault.autodeploy.plist
+#
+# Uninstall:
+#   launchctl unload ~/Library/LaunchAgents/com.tickvault.autodeploy.plist
+#   rm ~/Library/LaunchAgents/com.tickvault.autodeploy.plist
+#
+# Logs: data/logs/auto-deploy.log
+#
+# Safety guards (intentional):
+#   - Only deploys on the branch listed in DEPLOY_BRANCH below (default: main)
+#   - Skips deploy during market hours (09:15-15:30 IST) so a build never
+#     interrupts live trading
+#   - Records last deployed SHA so the same commit isn't redeployed twice
+#   - Exits non-zero if the working tree is dirty — never overwrites local work
+
+set -euo pipefail
+
+# ---- Config -----------------------------------------------------------------
+
+DEPLOY_BRANCH="${TV_DEPLOY_BRANCH:-main}"
+POLL_INTERVAL_SECS="${TV_DEPLOY_POLL_SECS:-60}"
+REPO_DIR="${TV_REPO_DIR:-$HOME/IdeaProjects/tickvault}"
+STATE_FILE="$REPO_DIR/data/cache/auto-deploy-last-sha"
+LOG_FILE="$REPO_DIR/data/logs/auto-deploy.log"
+
+# Market hours guard (IST). Auto-deploy SKIPS during this window so a
+# rebuild never interrupts trading. SEC-1: Listed in `market-hours.md`.
+MARKET_OPEN_HHMM="0915"
+MARKET_CLOSE_HHMM="1530"
+
+# ---- Helpers ----------------------------------------------------------------
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG_FILE"; }
+
+is_market_hours_ist() {
+    # Returns 0 (true) if current IST time is within market hours
+    local hhmm
+    hhmm=$(TZ='Asia/Kolkata' date +%H%M)
+    [ "$hhmm" -ge "$MARKET_OPEN_HHMM" ] && [ "$hhmm" -lt "$MARKET_CLOSE_HHMM" ]
+}
+
+is_trading_day_ist() {
+    # Returns 0 (true) if today is a weekday IST (Mon-Fri).
+    # Holiday calendar is not consulted here — the app's own startup check
+    # is the authoritative guard. This is just to avoid weekend churn.
+    local dow
+    dow=$(TZ='Asia/Kolkata' date +%u)  # 1=Mon, 7=Sun
+    [ "$dow" -le 5 ]
+}
+
+git_remote_sha() {
+    # Latest SHA on origin/$DEPLOY_BRANCH without fetching everything.
+    git -C "$REPO_DIR" ls-remote --heads origin "$DEPLOY_BRANCH" \
+        | awk '{print $1}'
+}
+
+ci_status() {
+    # Returns "success" / "pending" / "failure" / "unknown" for the given SHA
+    # via gh api (no PAT needed if `gh auth login` was done).
+    local sha="$1"
+    gh api "repos/SJParthi/tickvault/commits/$sha/status" \
+        --jq '.state' 2>/dev/null || echo unknown
+}
+
+last_deployed_sha() {
+    [ -f "$STATE_FILE" ] && cat "$STATE_FILE" || echo ""
+}
+
+mark_deployed() {
+    mkdir -p "$(dirname "$STATE_FILE")"
+    echo "$1" > "$STATE_FILE"
+}
+
+deploy() {
+    local sha="$1"
+    log "deploy starting: sha=$sha branch=$DEPLOY_BRANCH"
+
+    cd "$REPO_DIR"
+
+    # SAFETY: refuse if local changes exist
+    if [ -n "$(git status --porcelain)" ]; then
+        log "ABORT: working tree dirty — refusing to overwrite local changes"
+        return 1
+    fi
+
+    # SAFETY: refuse if checked out on a different branch
+    local current
+    current=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$current" != "$DEPLOY_BRANCH" ]; then
+        log "ABORT: HEAD is on '$current', not '$DEPLOY_BRANCH' — skip"
+        return 1
+    fi
+
+    git pull --ff-only origin "$DEPLOY_BRANCH" >> "$LOG_FILE" 2>&1
+    log "git pull OK"
+
+    # Build before stopping the running app so a build failure leaves
+    # the old binary in place and trading continues.
+    cargo build --release >> "$LOG_FILE" 2>&1
+    log "cargo build OK"
+
+    make stop >> "$LOG_FILE" 2>&1 || true
+    log "stop OK"
+
+    # Background restart so launchd doesn't hold the script open.
+    nohup make run >> "$LOG_FILE" 2>&1 &
+    log "restart launched (PID $!)"
+
+    mark_deployed "$sha"
+    log "deploy complete: sha=$sha"
+}
+
+# ---- Main loop --------------------------------------------------------------
+
+mkdir -p "$(dirname "$LOG_FILE")"
+log "auto-deploy started: branch=$DEPLOY_BRANCH poll=${POLL_INTERVAL_SECS}s"
+
+while true; do
+    if is_trading_day_ist && is_market_hours_ist; then
+        log "skip: inside market hours IST"
+        sleep "$POLL_INTERVAL_SECS"
+        continue
+    fi
+
+    remote_sha=$(git_remote_sha)
+    if [ -z "$remote_sha" ]; then
+        log "skip: could not read remote SHA"
+        sleep "$POLL_INTERVAL_SECS"
+        continue
+    fi
+
+    local_sha=$(last_deployed_sha)
+    if [ "$remote_sha" = "$local_sha" ]; then
+        sleep "$POLL_INTERVAL_SECS"
+        continue
+    fi
+
+    status=$(ci_status "$remote_sha")
+    if [ "$status" != "success" ]; then
+        log "skip: CI status=$status for $remote_sha (waiting)"
+        sleep "$POLL_INTERVAL_SECS"
+        continue
+    fi
+
+    deploy "$remote_sha" || log "deploy failed — will retry on next change"
+    sleep "$POLL_INTERVAL_SECS"
+done

--- a/scripts/launchd/com.tickvault.autodeploy.plist
+++ b/scripts/launchd/com.tickvault.autodeploy.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tickvault.autodeploy</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <!-- EDIT THIS PATH if your repo is not at ~/IdeaProjects/tickvault -->
+        <string>/Users/YOUR_USERNAME/IdeaProjects/tickvault/scripts/launchd/auto-deploy.sh</string>
+    </array>
+
+    <!-- Restart automatically if the script crashes -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Start at login -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Throttle restarts to once per 60s if the script keeps dying -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <!-- Inherit the user's PATH so `git`, `gh`, `cargo`, `make`, `docker` are found -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Stdout / stderr go straight to the same log file the script writes to -->
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/IdeaProjects/tickvault/data/logs/auto-deploy.launchd.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/IdeaProjects/tickvault/data/logs/auto-deploy.launchd.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Six related operator-experience fixes shipped in five commits.

## Commits

| SHA | Fix |
|---|---|
| `1b2937d` | **alerts** — `tv-error-logs` LogQL was matching `(?i)(ERROR\|PANIC\|FATAL)` as substring, so `errors.summary.md`, `tv_historical_api_errors_total`, `errorCode` etc. all triggered the alert. Now matches `"level":"(ERROR\|FATAL)"` exactly. Stops the constant Telegram false-positive on every clean boot. |
| `1dd60b3` | **notifications** — `CandleCrossMatchSkipped` Telegram message read `LEFT JOIN rows: 0 (diagnostic only)`. Replaced with `Candles compared: 0`. SQL terminology doesn't belong in operator alerts. |
| `b362c4b` | **security** — `make stop` now wipes `data/cache/tv-token-cache` so a stolen-laptop scenario cannot reuse the cached Dhan JWT. Re-fetched from SSM on next `make run`. |
| `3b27cb4` | **ops** — `make grafana-reload` one-command alias for `docker compose restart tv-grafana`. Removes friction when editing alert rules / dashboard JSON. |
| `ee90900` | **automation** — `scripts/grafana-watch.sh` (foreground watcher, no sidecar) + `scripts/launchd/` (opt-in mac auto-deploy on green CI, with market-hours guard, dirty-tree refusal, fast-forward only). Both deliberately outside docker-compose so AWS RAM budget is unaffected. |

## Verification

- `bash -n` clean for both new shell scripts
- `xmllint --noout` clean for the launchd plist
- New regex tested against 5 synthetic boot-log lines (3 false-positive shapes, 2 real ERROR shapes)
- All commits pass commit-lint, secret-scan, build & verify, test (common, app, api, storage, core, trading)

## Risk

- **alerts.yml change**: takes effect on next `tv-grafana` restart. Operator runs `make grafana-reload` once after merge. Old-style real ERROR/FATAL events still fire correctly.
- **make stop change**: only affects `make stop` codepath; SIGKILL/crash leaves token cache untouched and 24h TTL is the backstop.
- **scripts/launchd**: install is **explicitly manual** (`launchctl load`). Files exist but are inert until operator opts in. Zero runtime change from this commit alone.

## Test plan

- [ ] After merge: `make grafana-reload` on Mac
- [ ] Wait 2 min eval window — confirm `tv-error-logs` resolves in Grafana → Alerting → State
- [ ] Confirm Telegram resolution arrives
- [ ] (Optional) Try `make grafana-watch` while editing `alerts.yml` — confirm auto-reload fires
- [ ] (Optional) Install launchd agent per `scripts/launchd/README.md` — confirm `data/logs/auto-deploy.log` shows poll cycles

https://claude.ai/code/session_011Xghofrb8e2ZPDKU84ej7b

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xghofrb8e2ZPDKU84ej7b)_