### PR TITLE
fix(observability): kill stale-from-prior-run false-positive on tv-error-logs alert

### DIFF
--- a/crates/storage/tests/error_log_alert_guard.rs
+++ b/crates/storage/tests/error_log_alert_guard.rs
@@ -1,0 +1,139 @@
+//! Ratchet for the `tv-error-logs` Grafana alert rule.
+//!
+//! Background: the alert defined in
+//! `deploy/docker/grafana/provisioning/alerting/alerts.yml` uses a Loki
+//! query `count_over_time(... [2m])` to count ERROR/FATAL log lines and
+//! pages when the count > 0 sustained for `for:` duration.
+//!
+//! On 2026-04-26 20:28 IST a clean fresh boot at 20:27:44 (zero ERROR
+//! lines from the live process — verified via empty JSONL sink and
+//! empty `errors.summary.md`) nevertheless triggered the alert because
+//! ERROR lines from a PRIOR (now-exited) `tickvault` process were still
+//! inside Loki's 2-minute count window. With `for: 1m`, that single
+//! stale-window paged the operator.
+//!
+//! Mechanical fix: `for:` was raised to `3m`. Because the count window
+//! is `[2m]`, residual ERROR lines from a prior process age out of the
+//! count within 2 minutes — strictly less than the 3-minute sustain
+//! requirement. Therefore stale-from-prior-run logs cannot trigger the
+//! alert. Genuine sustained errors still page.
+//!
+//! This guard pins the rule mechanically so a future edit cannot
+//! silently revert `for:` below the count window.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ALERTS_YAML: &str = "deploy/docker/grafana/provisioning/alerting/alerts.yml";
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn load_alerts_yaml() -> String {
+    let path = workspace_root().join(ALERTS_YAML);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Extract the YAML stanza for the `tv-error-logs` rule.
+///
+/// We slice from `uid: tv-error-logs` to the next blank-line-then-`- uid:`
+/// boundary so each assertion only inspects this rule, not adjacent ones.
+fn tv_error_logs_stanza(text: &str) -> &str {
+    let start = text
+        .find("uid: tv-error-logs")
+        .expect("tv-error-logs rule missing — Telegram early-warning signal removed");
+    let tail = &text[start..];
+    let end = tail
+        .find("\n      - uid:")
+        .or_else(|| tail.find("\n  # ---"))
+        .or_else(|| tail.find("\n  - orgId:"))
+        .unwrap_or(tail.len());
+    &tail[..end]
+}
+
+#[test]
+fn tv_error_logs_alert_rule_exists() {
+    let text = load_alerts_yaml();
+    assert!(
+        text.contains("uid: tv-error-logs"),
+        "tv-error-logs alert rule deleted — operator loses the ERROR/FATAL Telegram signal"
+    );
+    assert!(
+        text.contains("title: \"Application ERROR Logs Detected\""),
+        "tv-error-logs title changed — Telegram dedup may break"
+    );
+}
+
+#[test]
+fn tv_error_logs_uses_loki_json_level_match_not_substring() {
+    // The spirit-correct match is `| json | level=~"ERROR|FATAL"` because
+    // a raw substring regex would also match nested fields whose VALUE is
+    // the literal token `"level":"ERROR"` (e.g. a serialized error payload).
+    let stanza = load_alerts_yaml();
+    let stanza = tv_error_logs_stanza(&stanza);
+    assert!(
+        stanza.contains("| json | level=~"),
+        "tv-error-logs no longer uses parsed-level Loki match — fragile substring \
+         regex risks false positives on log content. Restore the `| json | level=~` form."
+    );
+    assert!(
+        stanza.contains("ERROR|FATAL"),
+        "tv-error-logs no longer matches both ERROR and FATAL — coverage gap"
+    );
+}
+
+#[test]
+fn tv_error_logs_for_duration_exceeds_count_window() {
+    // Rationale: count window is `[2m]`. `for:` MUST be greater than the
+    // count window so that ERROR lines from a PRIOR (now-exited) process
+    // age out of the count BEFORE the alert can fire. Otherwise a clean
+    // fresh boot pages on stale residual logs.
+    //
+    // Locking the value to exactly `for: 3m` (what shipped on the
+    // 2026-04-26 false-positive fix). If a future edit needs to change
+    // it, the new value must still be strictly greater than the [Nm]
+    // count window — update both this test AND the comment in the rule.
+    let stanza = load_alerts_yaml();
+    let stanza = tv_error_logs_stanza(&stanza);
+    assert!(
+        stanza.contains("count_over_time({job=\\\"tv-docker\\\", container=\\\"tickvault\\\"} | json | level=~\\\"ERROR|FATAL\\\" [2m])"),
+        "tv-error-logs Loki count window changed away from `[2m]`. \
+         If you raised it, also raise `for:` to remain strictly greater. \
+         The invariant is `for: > count_window`."
+    );
+    assert!(
+        stanza.contains("for: 3m"),
+        "tv-error-logs `for:` MUST be `3m` (greater than the 2m count window). \
+         Reverting to `for: 1m` reopens the 2026-04-26 20:28 IST false-positive \
+         where stale logs from a prior process triggered a page on a clean boot. \
+         If you genuinely need a different value, it must still be strictly \
+         greater than the count window AND this test must be updated in the same PR."
+    );
+    // Belt-and-suspenders: explicitly reject the regressed values.
+    assert!(
+        !stanza.contains("for: 0m"),
+        "tv-error-logs `for: 0m` reintroduced — every transient ERROR pages. \
+         Revert to `for: 3m`."
+    );
+    assert!(
+        !stanza.contains("for: 1m"),
+        "tv-error-logs `for: 1m` reintroduced — stale-from-prior-run logs can \
+         page on a clean fresh boot. See 2026-04-26 incident note in the rule \
+         comment. Revert to `for: 3m`."
+    );
+}
+
+#[test]
+fn tv_error_logs_severity_remains_critical() {
+    let stanza = load_alerts_yaml();
+    let stanza = tv_error_logs_stanza(&stanza);
+    assert!(
+        stanza.contains("severity: critical"),
+        "tv-error-logs severity downgraded — ERROR/FATAL Telegram routing depends on this label"
+    );
+}

--- a/deploy/docker/grafana/provisioning/alerting/alerts.yml
+++ b/deploy/docker/grafana/provisioning/alerting/alerts.yml
@@ -392,17 +392,28 @@ groups:
     rules:
       - uid: tv-error-logs
         title: "Application ERROR Logs Detected"
-        # Two changes vs the previous version:
+        # Three changes vs the previous version:
         #   1. Use Loki's parsed `level` label (`| json | level=~"ERROR|FATAL"`)
         #      instead of a raw substring match on the JSON line. The old
         #      `|~ "\"level\":\"(ERROR|FATAL)\""` regex was correct in spirit
         #      but fragile against any future field whose value contains the
         #      literal token `"level":"ERROR"` (e.g. a serialized error
         #      object). Parsing the JSON makes the match unambiguous.
-        #   2. `for: 1m` (was 0m). Single transient ERRORs (e.g. a one-off
-        #      flush that retries successfully) don't deserve a page; a
-        #      sustained 1-minute presence does. WARN-level retries (auth
-        #      transient backoff, etc.) are NOT matched — only true ERROR/FATAL.
+        #   2. WARN-level retries (auth transient backoff, etc.) are NOT
+        #      matched — only true ERROR/FATAL.
+        #   3. `for: 3m` (was 1m, originally 0m). Rationale: the count window
+        #      is `[2m]`, so ERROR lines from a PRIOR (now-exited) tickvault
+        #      process age out of the count within 2 minutes. Requiring the
+        #      condition to hold for 3 consecutive minutes makes it
+        #      mechanically impossible for stale-from-prior-run logs to page
+        #      after a fresh boot. Genuine sustained errors still alert —
+        #      they just need to be present for 3 minutes (already implied
+        #      by "sustained" semantics). Operator-observed false positive
+        #      on 2026-04-26 20:28 IST: clean boot at 20:27:44, alert fired
+        #      at 20:28 from a prior run's residual ERROR lines still in the
+        #      2m Loki window. JSONL sink + summary_writer were both empty
+        #      for the live process — confirming this was a stale-window
+        #      artifact, not a real error.
         condition: C
         data:
           - refId: A
@@ -429,10 +440,10 @@ groups:
                 - evaluator: { type: gt, params: [0] }
         noDataState: OK
         execErrState: Alerting
-        for: 1m
+        for: 3m
         annotations:
           summary: "ERROR/FATAL logs detected in tickvault"
-          description: "Application produced ERROR or FATAL logs sustained for 1+ minute (window: last 2 minutes). WARN-level transient retries are excluded. Check Grafana Logs dashboard for details."
+          description: "Application produced ERROR or FATAL logs sustained for 3+ minutes (window: last 2 minutes). WARN-level transient retries are excluded. Stale logs from a prior process cannot trigger this alert — the count window is shorter than the for-duration. Check Grafana Logs dashboard for details."
         labels:
           severity: critical
 


### PR DESCRIPTION
## Symptom

Operator received a `🔴 FIRING — Application ERROR Logs Detected` Telegram at 2026-04-26 20:28 IST despite a clean fresh boot at 20:27:44.

Evidence the live process was clean:
- `data/logs/errors.jsonl.*` → empty (0 events scanned by `mcp__tickvault-logs__tail_errors`)
- `data/logs/errors.summary.md` → did not exist yet
- Stdout dump 20:27:44 → 20:28:02 contained zero lines at level ERROR or FATAL

## Root cause

The `tv-error-logs` Loki query `count_over_time({...} | json | level=~"ERROR|FATAL" [2m])` looks back **2 minutes**. With `for: 1m`, ERROR lines emitted by the **PRIOR** (now-exited) `tickvault` process were still inside that 2m window when the alert evaluated at ~20:28, so the rule fired even though the live process was clean.

## Fix

| Knob | Before | After | Why |
|---|---|---|---|
| `for:` | `1m` | `3m` | Strictly greater than the `[2m]` count window. Stale ERROR lines from a prior process age out of the count within 2 min — less than the 3-min sustain requirement — so they cannot trigger the alert on a fresh boot. |
| Query | unchanged | unchanged | Still uses parsed-level `\| json \| level=~"ERROR\|FATAL"` form (PR #380 fix). |
| Severity | `critical` | `critical` | Genuine sustained errors still page; nothing is muted. |
| Description | "sustained for 1+ minute" | "sustained for 3+ minutes" + note that stale logs cannot trigger | Operator-facing accuracy. |

## Ratchet

New `crates/storage/tests/error_log_alert_guard.rs` (4 tests) pins the rule mechanically:

1. `tv_error_logs_alert_rule_exists` — rule + title still present
2. `tv_error_logs_uses_loki_json_level_match_not_substring` — parsed-level form (not fragile substring)
3. `tv_error_logs_for_duration_exceeds_count_window` — locks `for: 3m`, explicitly rejects regression to `for: 0m` or `for: 1m`, enforces invariant `for: > count_window`
4. `tv_error_logs_severity_remains_critical`

A future revert to `for: 1m` or `for: 0m` now fails the build.

## Test plan

- [x] `cargo test -p tickvault-storage --test error_log_alert_guard` → 4/4 ok
- [x] `cargo fmt --check` → clean
- [x] `cargo clippy -p tickvault-storage --tests -- -D warnings` → clean
- [ ] After deploy: trigger a real ERROR (e.g. force a flush failure) → confirm alert still fires within ~3 min
- [ ] After deploy: restart tickvault during market hours → confirm no false-positive page on the fresh boot

## Out of scope (NOT done in this PR)

- Did not change the Loki query, the count window, the severity, or any other alert
- Did not touch any code, dependencies, or hot path
- Did not modify any other observability config

Per CLAUDE.md "match the scope of your actions to what was actually requested" and observability-architecture.md "Do not change the canonical paths" — this PR is the smallest possible delta that closes the false-positive while keeping every guarantee already pinned by the existing 21 mechanical ratchets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Loj7EozqptuNws6zXebKYe)_