### PR TITLE
feat(automation): auto-up Docker on local SessionStart when all 4 services OFFLINE

### DIFF
--- a/crates/common/tests/claude_session_bootstrap_guard.rs
+++ b/crates/common/tests/claude_session_bootstrap_guard.rs
@@ -517,6 +517,79 @@ fn health_slash_command_exists_and_wires_all_layers() {
     }
 }
 
+// -----------------------------------------------------------------------
+// PR #384 — auto-up Docker on local profile when all 4 services OFFLINE.
+// Closes "Honest gap #1": operator should not have to manually run
+// `make docker-up` after every laptop reboot. Strict guards keep this
+// safe (local-only, all-OFFLINE-only, CI-skipped, opt-out via env var,
+// fire-and-forget). The 5 ratchets below pin every safety guard so a
+// future regression cannot silently fire `docker compose up -d` from a
+// CI runner or an AWS profile.
+// -----------------------------------------------------------------------
+
+#[test]
+fn bootstrap_auto_up_only_fires_on_local_profile() {
+    let src = read("scripts/claude-session-bootstrap.sh");
+    assert!(
+        src.contains(r#"PROFILE" = "local""#),
+        "auto-up must guard on PROFILE=local — never touch AWS or mac-dev"
+    );
+}
+
+#[test]
+fn bootstrap_auto_up_skipped_in_ci() {
+    let src = read("scripts/claude-session-bootstrap.sh");
+    for env_var in ["${CI:-}", "${GITHUB_ACTIONS:-}", "${GITLAB_CI:-}"] {
+        assert!(
+            src.contains(env_var),
+            "auto-up must skip when {env_var} is set — CI runners must \
+             never spin up Docker via the SessionStart hook"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_auto_up_supports_operator_opt_out() {
+    let src = read("scripts/claude-session-bootstrap.sh");
+    assert!(
+        src.contains("TICKVAULT_NO_AUTO_UP"),
+        "auto-up must honor TICKVAULT_NO_AUTO_UP=1 escape hatch — operator \
+         debugging a partially-up stack must be able to disable auto-start"
+    );
+}
+
+#[test]
+fn bootstrap_auto_up_requires_every_service_offline() {
+    let src = read("scripts/claude-session-bootstrap.sh");
+    // A partially-up stack means the operator is mid-debug — never
+    // disturb. Auto-up only fires when EVERY probed local service is
+    // OFFLINE (a fresh laptop boot scenario).
+    for status_var in ["PROM_S", "QDB_S", "GRAF_S", "API_S"] {
+        assert!(
+            src.contains(&format!(r#""${status_var}" = "OFFLINE""#)),
+            "auto-up must require {status_var}=OFFLINE — partial-up state \
+             must NOT trigger docker compose up"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_auto_up_is_fire_and_forget() {
+    let src = read("scripts/claude-session-bootstrap.sh");
+    assert!(
+        src.contains("nohup docker compose"),
+        "auto-up must use nohup so SessionStart never blocks on Docker"
+    );
+    assert!(
+        src.contains("disown"),
+        "auto-up must disown the background docker compose process"
+    );
+    assert!(
+        src.contains("deploy/docker/docker-compose.yml"),
+        "auto-up must reference the canonical compose file path"
+    );
+}
+
 #[test]
 fn active_profile_is_one_of_the_known_profiles() {
     let cfg = read("config/claude-mcp-endpoints.toml");

--- a/scripts/claude-session-bootstrap.sh
+++ b/scripts/claude-session-bootstrap.sh
@@ -173,4 +173,31 @@ if [ -n "$AUTO_SWITCHED_FROM" ]; then
 else
     echo "bootstrap: profile=$PROFILE  prom=$PROM_S  qdb=$QDB_S  graf=$GRAF_S  api=$API_S" >&2
 fi
+
+# PR #384: auto-up Docker on local profile when every probed service is OFFLINE.
+# Closes "Honest gap #1" — operator should not have to run `make docker-up`
+# after every laptop reboot. Strict guards keep this safe:
+#   1. Only fires on profile=local (never touches AWS).
+#   2. Only fires when prom + qdb + graf + api are ALL OFFLINE
+#      (any service up → assume operator is mid-debug and don't disturb).
+#   3. Only fires if `docker` is on PATH and the compose file exists.
+#   4. Skipped in CI (CI=true / GITHUB_ACTIONS=true / GITLAB_CI=true).
+#   5. Operator opt-out via TICKVAULT_NO_AUTO_UP=1.
+#   6. Fire-and-forget: never blocks SessionStart — `nohup ... &` + `disown`.
+#   7. Idempotent: `docker compose up -d` is a no-op if already running.
+COMPOSE_FILE="$CWD/deploy/docker/docker-compose.yml"
+if [ "$PROFILE" = "local" ] \
+    && [ "${TICKVAULT_NO_AUTO_UP:-0}" != "1" ] \
+    && [ -z "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ] && [ -z "${GITLAB_CI:-}" ] \
+    && [ "$PROM_S" = "OFFLINE" ] && [ "$QDB_S" = "OFFLINE" ] \
+    && [ "$GRAF_S" = "OFFLINE" ] && [ "$API_S" = "OFFLINE" ] \
+    && command -v docker >/dev/null 2>&1 \
+    && [ -f "$COMPOSE_FILE" ]; then
+    AUTO_UP_LOG="$CWD/data/logs/auto-up.$(date +%Y-%m-%d-%H%M).log"
+    mkdir -p "$(dirname "$AUTO_UP_LOG")" 2>/dev/null || true
+    echo "bootstrap: all 4 local services OFFLINE — firing 'docker compose up -d' in background (log: $AUTO_UP_LOG; opt out via TICKVAULT_NO_AUTO_UP=1)" >&2
+    nohup docker compose -f "$COMPOSE_FILE" up -d </dev/null > "$AUTO_UP_LOG" 2>&1 &
+    disown || true
+fi
+
 exit 0


### PR DESCRIPTION
## Closes "Honest gap #1" — auto-up Docker on local profile

Every session resume currently shows the operator:

```
bootstrap: profile=local  prom=OFFLINE  qdb=OFFLINE  graf=OFFLINE  api=OFFLINE
```

forcing them to run `make docker-up` after every laptop reboot before any tooling works (logs, Grafana, the tickvault-logs MCP, etc). This PR closes that gap by auto-firing `docker compose up -d` in the background on `SessionStart`, with strict guards so it never disturbs production or CI.

## Behaviour

`scripts/claude-session-bootstrap.sh` now fires `docker compose up -d` if and only if EVERY guard is satisfied:

| # | Guard | Why |
|---|-------|-----|
| 1 | `PROFILE = "local"` | Never AWS or `mac-dev` — those use real infra |
| 2 | All 4 of `prom`/`qdb`/`graf`/`api` are OFFLINE | Partial-up = operator mid-debug, leave alone |
| 3 | `CI` / `GITHUB_ACTIONS` / `GITLAB_CI` are unset | CI runners must never spin up Docker |
| 4 | `TICKVAULT_NO_AUTO_UP != "1"` | One-env-var operator escape hatch |
| 5 | `docker` on PATH + `deploy/docker/docker-compose.yml` exists | No-op if compose file absent |
| 6 | `nohup` + `disown` | SessionStart never blocks |
| 7 | `docker compose up -d` is idempotent | No-op if already running |

Side-effect is explicit: operator sees one line in stderr and a per-day log file at `data/logs/auto-up.YYYY-MM-DD-HHMM.log`.

## Ratchet tests (5 new)

Appended to `crates/common/tests/claude_session_bootstrap_guard.rs`:

- `bootstrap_auto_up_only_fires_on_local_profile`
- `bootstrap_auto_up_skipped_in_ci`
- `bootstrap_auto_up_supports_operator_opt_out`
- `bootstrap_auto_up_requires_every_service_offline`
- `bootstrap_auto_up_is_fire_and_forget`

A future regression that drops any guard fails the build immediately.

## Smoke tests (local)

| Scenario | Result |
|---|---|
| `bash -n scripts/claude-session-bootstrap.sh` | Clean syntax |
| `CI=true bash scripts/claude-session-bootstrap.sh` | No auto-up line emitted (CI guard active) |
| `cargo test -p tickvault-common --test claude_session_bootstrap_guard` | 33/33 ok (was 28) |
| `cargo fmt --check` | Clean |
| `cargo clippy -p tickvault-common --tests -- -D warnings` | Clean |

## Out of scope (deferred — infra-blocked)

| Honest gap | Blocker | Unblocking condition |
|---|---|---|
| #2 — AWS log-surface parity | EC2 not yet provisioned | Operator brings up `c7i.xlarge` per `aws-budget.md`; Terraform module ready |
| #3 — 24h fuzz "clean" run | GHA free tier blocks 24h jobs | Operator confirms paid tier OR self-hosts runner |
| #4 — `chaos_healthy_ops_burst_100k_frames_zero_drops` flake | Test asserts safety-floor invariant `tv_ws_frame_spill_drop_critical == 0`; CI tolerance weakens detection | Investigate writer-thread scheduling on slow runners — separate PR |

---

_Generated by [Claude Code](https://claude.ai/code/session_017hJQxjT3EiNnqFC9za7SFC)_