### PR TITLE
ci(commit-lint): skip Dependabot-authored commits to unblock #384 + #385

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,18 @@ jobs:
           # matches the behaviour of commitlint/husky configs everywhere.
           for sha in $(git log --no-merges --format=%H "$base..$head"); do
             subject=$(git log -1 --format=%s "$sha")
+            author_email=$(git log -1 --format=%ae "$sha")
+            # Skip commits authored by Dependabot. Dependabot uses its own
+            # `deps(<group>)(deps): bump ...` format with two scopes that no
+            # human-authored project follows. We trust the bot's signature
+            # and squash-merge with a project-conformant title at merge time
+            # (see scripts/merge-dependabot-pr.sh and the README for the
+            # squash-title format the bot's PR description provides).
+            if [[ "$author_email" == "49699333+dependabot[bot]@users.noreply.github.com" ]] \
+                || [[ "$author_email" == "support@dependabot.com" ]]; then
+              echo "::notice::Skipping commit-lint for Dependabot commit $sha (subject: $subject)"
+              continue
+            fi
             if ! [[ "$subject" =~ $pattern ]]; then
               echo "::error::Commit $sha does not follow conventional format: $subject"
               failed=1


### PR DESCRIPTION
## Unblocks Dependabot PRs #384 + #385

Both currently-open Dependabot PRs have all 11 required checks GREEN except **Commit Lint**, which fails because Dependabot's commit format violates two rules in the project regex:

```
deps(actions)(deps): bump actions/upload-artifact from 7.0.0 to 7.0.1
^^^^             ^^^^
type "deps"      double scope
not in allowlist not allowed by regex
```

Project regex: `^(feat|fix|refactor|test|docs|chore|perf|security|ci|build|style)(\([a-z0-9_/,-]+\))?: .+`

## Fix

Skip commits authored by Dependabot's bot identity in the commit-lint loop.

| Author email | Form | Why |
|---|---|---|
| `49699333+dependabot[bot]@users.noreply.github.com` | Current bot identity | Dependabot's standard noreply address |
| `support@dependabot.com` | Legacy | Still used on some older Dependabot actions versions |

A `::notice::` log line is printed for every skipped commit so the audit trail stays visible. **Human-authored commits remain subject to the full regex** — no relaxation.

## Why this is the right fix

| Alternative | Why rejected |
|---|---|
| Add `deps` to the type allowlist | Doesn't fix the double-scope issue; touches every project commit's allowed type list for one bot |
| Allow double scopes `(\(...\))*` | Loosens human commit format universally for one bot |
| Squash-merge with custom title (no CI fix) | Branch protection requires Commit Lint green before merge fires; cannot bypass per CLAUDE.md (no `--admin`) |

## Squash-merge flow preserved

Dependabot PRs squash-merge with a project-conformant title supplied via `commit_title` parameter at merge time — the merged commit on `main` still follows `chore(deps): bump ...` format. Only the per-commit lint on the PR branch is exempted.

## Test plan

- [x] YAML parses (`yamllint .github/workflows/ci.yml` clean — no shape changes)
- [ ] After merge: re-run Commit Lint on PR #384 / #385 — expect green
- [ ] After merge: PRs #384 + #385 auto-merge fires (already armed)

## Out of scope

The chaos test flake fix (`chaos_questdb_lifecycle::questdb_round_trip_preserves_every_tick`) and the AWS / fuzz gaps remain queued — separate PRs after this lands.

---

_Generated by [Claude Code](https://claude.ai/code/session_017hJQxjT3EiNnqFC9za7SFC)_