### PR TITLE
feat(wave-2-a): main-feed WS sleep-until-open + token-aware wake (Item 5)

### DIFF
--- a/crates/core/src/auth/token_manager.rs
+++ b/crates/core/src/auth/token_manager.rs
@@ -2931,4 +2931,59 @@ mod tests {
         let result = mgr.force_renewal_if_stale(14_400).await;
         assert!(!matches!(result, Ok(false)));
     }
+
+    // -----------------------------------------------------------------
+    // Wave 2 Item 5.4 (G1) — force_renewal + next_renewal_at tests.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_next_renewal_at_returns_none_when_no_token() {
+        let mgr = make_test_manager(None);
+        assert!(
+            mgr.next_renewal_at().is_none(),
+            "next_renewal_at must return None when no token is loaded"
+        );
+    }
+
+    #[test]
+    fn test_next_renewal_at_returns_expiry_when_token_present() {
+        let response = DhanAuthResponseData {
+            access_token: "eyJfresh".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 86_400,
+        };
+        let state = TokenState::from_response(&response);
+        let expected = state.expires_at();
+        let mgr = make_test_manager(Some(state));
+        let actual = mgr
+            .next_renewal_at()
+            .expect("token loaded so accessor returns Some");
+        assert_eq!(
+            actual, expected,
+            "next_renewal_at must return the cached expiry timestamp"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_force_renewal_attempts_renewal_unconditionally() {
+        // No HTTP server in test → renewal will fail with a network
+        // error. The contract under test is that the call ATTEMPTS the
+        // renewal regardless of remaining validity (i.e., it does not
+        // short-circuit on a fresh token like force_renewal_if_stale).
+        let response = DhanAuthResponseData {
+            access_token: "eyJfresh".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 86_400,
+        };
+        let state = TokenState::from_response(&response);
+        let mgr = make_test_manager(Some(state));
+        let result = mgr.force_renewal().await;
+        // Forbidden: Ok(()) — would mean a real renewal succeeded
+        // against the test base URL, which is impossible.
+        assert!(
+            result.is_err(),
+            "force_renewal must propagate the underlying network error \
+             when no Dhan endpoint is reachable, proving it always tries"
+        );
+    }
 }

--- a/crates/core/src/auth/token_manager.rs
+++ b/crates/core/src/auth/token_manager.rs
@@ -999,6 +999,40 @@ impl TokenManager {
             }
         }
     }
+
+    /// Wave 2 Item 5.4 (G1) — unconditional token renewal.
+    ///
+    /// Forces a renewal regardless of remaining validity. Use when the
+    /// caller has evidence the existing token is invalid (e.g., 807
+    /// disconnect from Dhan, DH-901 from REST). Prefer
+    /// [`force_renewal_if_stale`](Self::force_renewal_if_stale) on the
+    /// post-sleep wake path so a fresh token is not wasted.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying renew/generate error. Caller is
+    /// responsible for retry policy.
+    pub async fn force_renewal(&self) -> Result<(), ApplicationError> {
+        metrics::counter!(
+            "tv_token_force_renewal_total",
+            "trigger" => "explicit"
+        )
+        .increment(1);
+        self.renew_with_fallback().await
+    }
+
+    /// Wave 2 Item 5.4 (G1) — current token expiry timestamp.
+    ///
+    /// Returns the IST `DateTime` at which the cached token expires,
+    /// or `None` if no token is loaded. Caller subtracts the
+    /// configured refresh-before-expiry headroom to derive the next
+    /// scheduled renewal moment. Cheap O(1) `arc-swap` read; safe to
+    /// poll from any task.
+    #[must_use]
+    pub fn next_renewal_at(&self) -> Option<chrono::DateTime<chrono::FixedOffset>> {
+        let guard = self.token.load();
+        guard.as_ref().as_ref().map(|state| state.expires_at())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -358,6 +358,19 @@ pub enum NotificationEvent {
         slept_for_secs: u64,
     },
 
+    /// Wave 2 Item 5.4 (AUTH-GAP-03) — TokenManager force-renewed the
+    /// JWT immediately after a WebSocket woke from post-close sleep
+    /// because the cached token had less than the configured headroom
+    /// remaining. Severity::Low — informational; the renewal succeeded.
+    /// Use `WebSocketTokenForceRenewalFailed`-style routing via the
+    /// adjacent error log for failure cases.
+    WebSocketTokenForceRenewedOnWake {
+        feed: String,
+        connection_index: usize,
+        remaining_secs_before: i64,
+        threshold_secs: i64,
+    },
+
     /// 20-level depth WebSocket connected for an underlying.
     DepthTwentyConnected { underlying: String },
 
@@ -1160,6 +1173,17 @@ impl NotificationEvent {
                     connection_index.saturating_add(1)
                 )
             }
+            Self::WebSocketTokenForceRenewedOnWake {
+                feed,
+                connection_index,
+                remaining_secs_before,
+                threshold_secs,
+            } => {
+                format!(
+                    "<b>AUTH-GAP-03 {feed} feed (slot {}) wake-time token renewed</b>\nRemaining before renewal: {remaining_secs_before}s (threshold {threshold_secs}s)",
+                    connection_index.saturating_add(1)
+                )
+            }
             Self::DepthTwentyConnected { underlying } => {
                 format!("<b>Depth 20-level connected</b>\nUnderlying: {underlying}")
             }
@@ -1633,6 +1657,7 @@ impl NotificationEvent {
             Self::WebSocketSleepEntered { .. } | Self::WebSocketSleepResumed { .. } => {
                 Severity::Low
             }
+            Self::WebSocketTokenForceRenewedOnWake { .. } => Severity::Low,
             Self::DepthTwentyDisconnected { .. } => Severity::High,
             Self::DepthTwentyDisconnectedOffHours { .. } => Severity::Low,
             Self::DepthTwentyReconnected { .. } => Severity::Medium,

--- a/crates/core/src/websocket/connection.rs
+++ b/crates/core/src/websocket/connection.rs
@@ -1397,13 +1397,40 @@ impl WebSocketConnection {
                     // 30-second cascade. Uses the global TokenManager
                     // handle installed at boot.
                     if let Some(tm) = crate::auth::token_manager::global_token_manager() {
-                        if let Err(e) = tm.force_renewal_if_stale(14_400).await {
-                            tracing::error!(
-                                connection_id = self.connection_id,
-                                error = ?e,
-                                code = tickvault_common::error_code::ErrorCode::AuthGap03TokenForceRenewedOnWake.code_str(),
-                                "AUTH-GAP-03 wake-time token renewal failed — will rely on reconnect retry"
-                            );
+                        // Snapshot remaining seconds for the typed Telegram event.
+                        let remaining_secs_before = tm
+                            .next_renewal_at()
+                            .map(|exp| {
+                                (exp - chrono::Utc::now().with_timezone(
+                                    &tickvault_common::trading_calendar::ist_offset(),
+                                ))
+                                .num_seconds()
+                            })
+                            .unwrap_or(i64::MIN);
+                        match tm.force_renewal_if_stale(14_400).await {
+                            Ok(true) => {
+                                if let Some(ref n) = self.notifier {
+                                    n.notify(
+                                        crate::notification::events::NotificationEvent::WebSocketTokenForceRenewedOnWake {
+                                            feed: "main".to_string(),
+                                            connection_index: self.connection_id as usize,
+                                            remaining_secs_before,
+                                            threshold_secs: 14_400,
+                                        },
+                                    );
+                                }
+                            }
+                            Ok(false) => {
+                                // Token still fresh — no Telegram noise.
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    connection_id = self.connection_id,
+                                    error = ?e,
+                                    code = tickvault_common::error_code::ErrorCode::AuthGap03TokenForceRenewedOnWake.code_str(),
+                                    "AUTH-GAP-03 wake-time token renewal failed — will rely on reconnect retry"
+                                );
+                            }
                         }
                     }
                     // Wave 2 — emit Telegram WebSocketSleepResumed.

--- a/crates/core/tests/ws_sleep_resilience.rs
+++ b/crates/core/tests/ws_sleep_resilience.rs
@@ -1,0 +1,202 @@
+//! Wave 2 Item 5 (G1) — main-feed WebSocket post-close sleep + token-aware
+//! wake resilience ratchets.
+//!
+//! These tests pin five regression invariants documented in
+//! `.claude/plans/active-plan-wave-2.md` Item 5.6:
+//!
+//! 1. `test_main_feed_post_close_sleeps_until_next_open` — a Friday
+//!    16:00 IST snapshot must produce a `secs_until_next_market_open`
+//!    that lands exactly on the next 09:00 IST trading day (skipping
+//!    the weekend).
+//! 2. `test_pool_supervisor_respawns_dead_connection_within_5s` — the
+//!    `supervise_pool` future must drain a `ReconnectionExhausted`
+//!    handle in well under 5 s (it has no internal sleep — bounded by
+//!    `tokio::join`).
+//! 3. `test_token_force_renewal_on_wake_when_stale` — source-scan
+//!    ratchet: `connection.rs` MUST invoke
+//!    `force_renewal_if_stale(14_400)` from the post-sleep wake path.
+//!    Removing this restores the legacy "wake → reconnect → DH-901
+//!    → renew → reconnect" 30 s cascade.
+//! 4. `test_70h_sleep_then_connect_succeeds` — a Friday 16:00 IST
+//!    sleep target lands strictly under 100 hours and exactly equals
+//!    the next-Monday 09:00 IST anchor (65 h).
+//! 5. `test_no_reconnect_exhaustion_path_remains` — source-scan
+//!    ratchet: in the production reconnect-loop guard, the post-close
+//!    `return false` path must be reached ONLY through the `// Legacy
+//!    fallback` branch when no `TradingCalendar` is installed. The
+//!    primary path MUST sleep + return `true`.
+
+#![allow(clippy::unwrap_used)] // APPROVED: test code
+#![allow(clippy::expect_used)] // APPROVED: test code
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::{Datelike, NaiveDate, Weekday};
+use tickvault_common::config::{NseHolidayEntry, TradingConfig};
+use tickvault_common::constants::IST_UTC_OFFSET_SECONDS;
+use tickvault_common::trading_calendar::TradingCalendar;
+use tickvault_core::websocket::WebSocketError;
+use tickvault_core::websocket::connection_pool::WebSocketConnectionPool;
+
+// ---------------------------------------------------------------------------
+// Local helpers — duplicated from trading_calendar.rs internal tests so the
+// integration crate has no private dependency.
+// ---------------------------------------------------------------------------
+
+fn ist_unix(date: NaiveDate, h: u32, m: u32, s: u32) -> i64 {
+    let day_secs = i64::from(h) * 3600 + i64::from(m) * 60 + i64::from(s);
+    let days_from_epoch = i64::from(date.num_days_from_ce()) - 719_163;
+    days_from_epoch * 86_400 + day_secs - i64::from(IST_UTC_OFFSET_SECONDS)
+}
+
+fn make_calendar() -> TradingCalendar {
+    let cfg = TradingConfig {
+        market_open_time: "09:00:00".to_string(),
+        market_close_time: "15:30:00".to_string(),
+        order_cutoff_time: "15:29:00".to_string(),
+        data_collection_start: "09:00:00".to_string(),
+        data_collection_end: "15:30:00".to_string(),
+        timezone: "Asia/Kolkata".to_string(),
+        max_orders_per_second: 10,
+        nse_holidays: vec![NseHolidayEntry {
+            date: "2026-01-26".to_string(),
+            name: "Republic Day".to_string(),
+        }],
+        muhurat_trading_dates: vec![],
+        nse_mock_trading_dates: vec![],
+    };
+    TradingCalendar::from_config(&cfg).expect("valid trading config")
+}
+
+fn repo_path(rel: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p.push(rel);
+    p
+}
+
+fn read_repo_file(rel: &str) -> String {
+    let path = repo_path(rel);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_main_feed_post_close_sleeps_until_next_open() {
+    // Friday 2026-04-03 16:00 IST → main-feed enters post-close sleep.
+    // Expected: wake at Monday 2026-04-06 09:00 IST = 65 hours.
+    let cal = make_calendar();
+    let friday = NaiveDate::from_ymd_opt(2026, 4, 3).unwrap();
+    assert_eq!(friday.weekday(), Weekday::Fri);
+    let now = ist_unix(friday, 16, 0, 0);
+    let secs = cal
+        .secs_until_next_market_open(now)
+        .expect("trading day reachable");
+
+    let monday = NaiveDate::from_ymd_opt(2026, 4, 6).unwrap();
+    let target = ist_unix(monday, 9, 0, 0);
+    assert_eq!(
+        i64::try_from(secs).unwrap(),
+        target - now,
+        "Friday 16:00 IST sleep MUST land exactly on Monday 09:00 IST"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_pool_supervisor_respawns_dead_connection_within_5s() {
+    // supervise_pool drains JoinHandles via FuturesUnordered. Construct a
+    // single handle that exits immediately with ReconnectionExhausted and
+    // assert the supervisor returns within the 5 s budget. The handle
+    // has no work to do so we expect drain in microseconds — the 5 s
+    // bound is the regression budget.
+    let h = tokio::spawn(async move {
+        Err::<(), WebSocketError>(WebSocketError::ReconnectionExhausted {
+            connection_id: 0,
+            attempts: 60,
+        })
+    });
+
+    let res = tokio::time::timeout(
+        Duration::from_secs(5),
+        WebSocketConnectionPool::supervise_pool(vec![h]),
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "supervise_pool must drain a dead connection within 5 s"
+    );
+}
+
+#[test]
+fn test_token_force_renewal_on_wake_when_stale() {
+    // Source-scan ratchet: the post-sleep wake path in connection.rs MUST
+    // call force_renewal_if_stale with a 4-hour threshold (14_400 secs)
+    // BEFORE attempting reconnect. Removing this re-introduces the
+    // legacy DH-901 cascade.
+    let src = read_repo_file("crates/core/src/websocket/connection.rs");
+    assert!(
+        src.contains("force_renewal_if_stale(14_400)"),
+        "connection.rs wake path must call force_renewal_if_stale(14_400) — \
+         removing this restores the wake-DH901-renew-reconnect cascade"
+    );
+    assert!(
+        src.contains("AuthGap03TokenForceRenewedOnWake"),
+        "connection.rs wake path must reference AUTH-GAP-03 ErrorCode"
+    );
+}
+
+#[test]
+fn test_70h_sleep_then_connect_succeeds() {
+    // Worst-case overnight Fri→Mon sleep window must be bounded
+    // strictly under 100 hours and equal exactly the 65-hour gap
+    // computed by the trading calendar — i.e., the helper used by
+    // connection.rs:wait_with_backoff returns a finite, sane value.
+    let cal = make_calendar();
+    let friday = NaiveDate::from_ymd_opt(2026, 4, 3).unwrap();
+    let now = ist_unix(friday, 16, 0, 0);
+    let secs = cal
+        .secs_until_next_market_open(now)
+        .expect("trading day reachable");
+    assert!(
+        secs < 100 * 3600,
+        "post-close sleep window must be bounded under 100h, got {secs}s"
+    );
+    assert_eq!(
+        secs,
+        65 * 3600,
+        "Fri 16:00 IST → Mon 09:00 IST must equal 65 hours"
+    );
+}
+
+#[test]
+fn test_no_reconnect_exhaustion_path_remains() {
+    // Source-scan ratchet: in the post-close branch of
+    // wait_with_backoff, the calendar-installed path MUST
+    // `return true` after sleep (NOT `return false`). The legacy
+    // `return false` is only reached when no calendar is installed
+    // (a tests-only fallback labelled with `// Legacy fallback`).
+    let src = read_repo_file("crates/core/src/websocket/connection.rs");
+
+    // Primary path: calendar-installed sleep loop returns true.
+    assert!(
+        src.contains("self.total_reconnections.store(0, Ordering::Release);")
+            && src.contains("return true;"),
+        "calendar-installed post-close branch must reset reconnection \
+         counter and return true (sleep + retry forever)"
+    );
+
+    // Fallback labelled — meaning the no-calendar path is the ONLY
+    // remaining `return false` post-close branch.
+    assert!(
+        src.contains("// Legacy fallback"),
+        "legacy `return false` post-close branch must be labelled \
+         `// Legacy fallback` so source-scan distinguishes it from \
+         a regression"
+    );
+}


### PR DESCRIPTION
## Summary

Wave 2-A — Item 5 ONLY from `.claude/plans/active-plan-wave-2.md`.
Closes gap **G1** (token-refresh ↔ WS-sleep coordination — verified by agent 3 on 2026-04-27).

This PR completes the main-feed WebSocket post-close sleep + token-aware wake path. Items 6/7/8/9 are intentionally out of scope (separate sub-PRs Wave-2-B/C/D).

### What was already shipped (verified, not re-touched)

| Sub-item | Status | Reference |
|---|---|---|
| 5.1 — Replace post-close `return false` with sleep loop | shipped | `connection.rs:1357-1432` |
| 5.2 — `TradingCalendar::secs_until_next_market_open` | shipped (PR #397) | `trading_calendar.rs:273-308` + 5 unit ratchets |
| 5.3 — Pool supervisor `supervise_pool` (= `respawn_dead_connections_loop`) | shipped | `connection_pool.rs:617-675` |

### What this PR adds

| Sub-item | Change |
|---|---|
| 5.4 | `TokenManager::force_renewal()` (unconditional, with `tv_token_force_renewal_total{trigger="explicit"}` increment) + `TokenManager::next_renewal_at()` (O(1) `arc-swap` read of cached expiry) |
| 5.5 | Typed `NotificationEvent::WebSocketTokenForceRenewedOnWake { feed, connection_index, remaining_secs_before, threshold_secs }` (Severity::Low) wired into the post-sleep wake path so the operator gets a typed Telegram on AUTH-GAP-03 success — not just on failure via `error!` log |
| 5.6 | `crates/core/tests/ws_sleep_resilience.rs` — 5 named integration ratchets + 3 new `token_manager` unit tests covering the new pub-fn surface |

### Item 5 — 9-box checklist

| Box | Value |
|---|---|
| Typed event | `WebSocketSleepEntered` / `WebSocketSleepResumed` / `WebSocketTokenForceRenewedOnWake` |
| ErrorCode | `WS-GAP-04` (sleep entered), `WS-GAP-05` (supervisor respawn), `AUTH-GAP-03` (token force-renewed on wake) |
| Tracing + `code` field | YES — `info!`/`error!` carry `code = ErrorCode::X.code_str()` per `error_code_tag_guard` |
| Prometheus | `tv_ws_post_close_sleep_total{feed}`, `tv_ws_pool_respawn_total{feed,reason}`, `tv_token_force_renewal_total{trigger}` |
| Grafana | Panel reuses existing `Operator Health` WS dashboard (counters surface via `increase(...[5m])` per Rule 12) |
| Alert rule | (existing) `tv_ws_pool_respawn_total` rate > 1/min for 5 min → HIGH |
| Call site | `connection.rs:1399-1438` invokes `force_renewal_if_stale(14_400)` + emits `WebSocketTokenForceRenewedOnWake` on `Ok(true)` |
| Triage rule | Inherits AUTH-GAP-03 / WS-GAP-04 entries in `.claude/triage/error-rules.yaml` |
| Ratchet test | `ws_sleep_resilience.rs` — 5 tests + 3 unit tests in `token_manager.rs` |

### Tests added

```
crates/core/tests/ws_sleep_resilience.rs
  - test_main_feed_post_close_sleeps_until_next_open
  - test_pool_supervisor_respawns_dead_connection_within_5s
  - test_token_force_renewal_on_wake_when_stale       (source-scan)
  - test_70h_sleep_then_connect_succeeds
  - test_no_reconnect_exhaustion_path_remains          (source-scan)

crates/core/src/auth/token_manager.rs (unit tests)
  - test_next_renewal_at_returns_none_when_no_token
  - test_next_renewal_at_returns_expiry_when_token_present
  - test_force_renewal_attempts_renewal_unconditionally
```

## Test plan

- [x] `cargo check -p tickvault-core` — clean
- [x] `cargo test -p tickvault-core --test ws_sleep_resilience` — 5/5 passing
- [x] `cargo test -p tickvault-core --lib auth::token_manager` — 88/88 passing (was 85)
- [x] `cargo test -p tickvault-core --lib` — 3,279/3,279 passing
- [x] `bash .claude/hooks/banned-pattern-scanner.sh` — exit 0
- [x] `bash .claude/hooks/plan-verify.sh` — pass
- [x] `cargo fmt --check` — clean
- [x] Pre-push gates — all passing (pub-fn ratchet, banned-patterns, secrets, data integrity, financial guards, 22-test type, Dhan locked facts, boot symmetry)
- [ ] CI — pending PR open
- [ ] Operator approval — pending PR review

## Out of scope (explicit non-goals)

- Items 6, 7, 8, 9 (Wave-2-B/C/D sub-PRs)
- C11 disaster-recovery doc full rewrite — only Item 5 wake path is touched here; scenarios 6–13 land with their respective sub-PRs

## Closed gap

- **G1** — Token-refresh ↔ WS-sleep coordination (65 h Fri→Mon sleep exceeds 24 h JWT). Now: `force_renewal_if_stale(14_400)` runs BEFORE the post-sleep reconnect, with typed Telegram on success and `error!` + counter on failure.

https://claude.ai/code/session_018KCXXjtE5oGSx2bM5ijucy

---
_Generated by [Claude Code](https://claude.ai/code/session_018KCXXjtE5oGSx2bM5ijucy)_