### PR TITLE
feat(boot): add depth-200 boot smoke test (PR-B)

### DIFF
--- a/.claude/rules/project/wave-5-error-codes.md
+++ b/.claude/rules/project/wave-5-error-codes.md
@@ -208,6 +208,51 @@ implementation deferred to a follow-up sub-PR.
 Gmail-send the GitHub link to apihelp@dhan.co. The L3 escalation runs
 on Track 2 verdict from the Mon May 4 SELECT.
 
+## DEPTH200-SMOKE-01 — boot-time depth-200 smoke test failed (PR-B, 2026-05-02)
+
+**Trigger:** at boot, the smoke-test task in
+`crates/app/src/boot_smoke_test.rs::run_smoke_test_loop` polls a shared
+`Arc<AtomicU64>` that all 5 dynamic depth-200 receivers increment on
+every frame. After `SMOKE_DEADLINE_SECS` (= 60s) of in-market polling
+the counter is still 0. Severity::Critical. Edge-trigger semantics:
+fires exactly once per process lifetime.
+
+**Why it exists:** post-PR #427 depth-200 reuses the shared TOTP/APP
+token (Dhan Ticket #5610706 removed the SELF-only gate). DEPTH200-SMOKE-01
+is the boot-time confirmation that the gate is still removed. If Dhan
+ever silently regresses, the operator gets a Critical signal at boot
+instead of waiting until the 09:16:30 IST market-open self-test.
+
+**Three causes, in descending likelihood:**
+
+| Cause | Diagnosis | Fix |
+|---|---|---|
+| Dhan re-enabled the SELF-only gate | `WebSocketDisconnected` events also firing for kind=depth-200 with reset reasons; `tv_websocket_connections_active{kind="depth-200"}` stays at 0 | Re-open Ticket #5610706 with Dhan support; in the meantime `git revert <sha>` of PR #427 to restore the SELF-token workaround |
+| All 5 SecurityIds far OTM (server-side filtering) | depth-200 conns show as Connected but Dhan never streams; depth-rebalancer not yet computed ATM | Wait for the 60s rebalancer cycle; smoke runs ONCE per boot, will not re-fire |
+| WS pool subscribe failed to dispatch | conns stuck in DEFERRED mode (`security_id: None` never resolved); `DEPTH-200-DYN-01` also firing | Follow DEPTH-200-DYN-01 runbook above |
+
+**Triage:**
+
+1. `mcp__tickvault-logs__prometheus_query "tv_websocket_connections_active"`
+   — if depth-200 count is 0, this is auth/handshake; follow Cause 1.
+2. `mcp__tickvault-logs__tail_errors` — search for `WebSocketDisconnected`
+   with kind=depth-200 in the boot window. If present, it's a server-side
+   reset; escalate to operator.
+3. `mcp__tickvault-logs__questdb_sql "select count(*) from option_movers
+   where category = 'TOP_VOLUME' and ts > now() - 5m"` — empty/very-low
+   means the upstream `OptionMoversWriter` isn't producing the gainer
+   set the depth-200 selector reads; this is Cause 3.
+4. If Causes 1-3 all rule out → operator inspects the depth-200 selector
+   for a logic bug that picks far-OTM SecurityIds.
+
+**Auto-triage safe:** NO (Severity::Critical). Mitigation requires
+operator decision (`git revert` vs Dhan support escalation vs config
+change).
+
+**Source:** `crates/app/src/boot_smoke_test.rs`,
+`crates/common/src/error_code.rs::Depth200Smoke01NoFramesAtBoot`,
+`.claude/triage/error-rules.yaml::depth200-smoke-01-no-frames-at-boot-escalate`.
+
 ## Cross-references
 
 - `.claude/plans/active-plan-wave-5-indices-only.md` Items 4, 5, 6, 9

--- a/.claude/triage/error-rules.yaml
+++ b/.claude/triage/error-rules.yaml
@@ -1205,3 +1205,24 @@ rules:
       regression OR stale Arc<MoversTracker> snapshot. Operator runs
       `make doctor` section 9 to compare gauges + investigates the
       latest InstrumentBuildSuccess Telegram event.
+
+  # -----------------------------------------------------------------------
+  # PR-B (2026-05-02) — boot-time depth-200 smoke test
+  # -----------------------------------------------------------------------
+
+  - name: depth200-smoke-01-no-frames-at-boot-escalate
+    match:
+      code: DEPTH200-SMOKE-01
+    action: escalate
+    runbook_path: .claude/rules/project/wave-5-error-codes.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      DEPTH200-SMOKE-01 = boot-time depth-200 smoke test observed zero
+      frames within the 60s deadline during market hours. Most often
+      means Dhan reverted the Ticket #5610706 server-side gate (depth-200
+      rejecting APP tokens again); next-most-often the 5 SecurityIds
+      are all far-OTM and Dhan's server-side filtering drops them.
+      Severity::Critical; never auto-action — operator decides between
+      `git revert` of PR #427 (restore SELF-token workaround) and
+      Dhan support escalation.

--- a/crates/app/src/boot_smoke_test.rs
+++ b/crates/app/src/boot_smoke_test.rs
@@ -1,0 +1,262 @@
+//! Boot-time depth-200 smoke test (PR-B, 2026-05-02).
+//!
+//! Spawned once at boot, this module watches a shared `Arc<AtomicU64>` that
+//! the depth-200 receiver tasks increment on every frame. It classifies the
+//! outcome at the deadline:
+//!
+//! | In market hours? | Frames received within window? | Outcome |
+//! |---|---|---|
+//! | No                | (any)                          | `Skipped` (off-hours, frames not expected) |
+//! | Yes               | ≥ 1                            | `Passed` (Severity::Info) |
+//! | Yes               | 0                              | `Failed` (Severity::Critical, `DEPTH200-SMOKE-01`) |
+//!
+//! ## Why this exists
+//!
+//! Pre-PR-#427 we used a separate SELF token for depth-200; auth failures
+//! showed up as `Protocol(ResetWithoutClosingHandshake)` reconnect storms.
+//! Post-PR-#427 depth-200 reuses the shared APP token. A single positive
+//! ping at boot ("Dhan accepted the APP token AND streamed at least one
+//! frame") confirms Ticket #5610706's server-side gate removal end-to-end.
+//!
+//! The existing `MarketOpenStreamingConfirmation` event covers the same
+//! ground at 09:15:30 IST per trading day; this smoke test fills the gap
+//! for **mid-day in-market boots** (operator restart at e.g. 11:00 IST)
+//! by giving a Critical-level signal within `SMOKE_DEADLINE_SECS` of boot
+//! instead of waiting up to 4.5 hours for the next market-open self-test.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use tickvault_common::error_code::ErrorCode;
+use tickvault_common::market_hours::is_within_market_hours_ist;
+use tracing::{error, info};
+
+/// Deadline (seconds) for receiving the first depth-200 frame at boot.
+///
+/// Dhan's depth-200 connections handshake within ~5–10s. Subscribe ack
+/// + first frame typically within another 5s. 60s gives a comfortable
+/// margin without holding back the boot summary too long.
+pub const SMOKE_DEADLINE_SECS: u64 = 60;
+
+/// Poll interval (seconds) for the smoke test loop.
+///
+/// 1s is fast enough to fire `Passed` shortly after the first frame and
+/// slow enough that the loop is essentially free CPU-wise (60 iterations
+/// max).
+pub const SMOKE_POLL_INTERVAL_SECS: u64 = 1;
+
+/// Outcome of the boot-time depth-200 smoke test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmokeOutcome {
+    /// Boot happened outside [09:00, 15:30] IST. Frames not expected;
+    /// no signal either way is meaningful.
+    Skipped,
+    /// In-market boot, ≥ 1 frame observed within the deadline.
+    Passed { frames_received: u64 },
+    /// In-market boot, 0 frames within the deadline. `DEPTH200-SMOKE-01`.
+    Failed,
+}
+
+/// Pure classifier — given the frame count and current market-hours
+/// state at the deadline, return the outcome.
+///
+/// Separating this from the polling task makes the contract testable
+/// without any tokio runtime.
+#[must_use]
+pub fn classify_smoke_outcome(frames_received: u64, in_market_hours: bool) -> SmokeOutcome {
+    if !in_market_hours {
+        return SmokeOutcome::Skipped;
+    }
+    if frames_received == 0 {
+        return SmokeOutcome::Failed;
+    }
+    SmokeOutcome::Passed { frames_received }
+}
+
+/// Spawns the smoke-test task. Returns immediately; the task runs in the
+/// background and emits exactly ONE log line at the deadline.
+///
+/// The caller wires `frames_counter` into every depth-200 receiver task
+/// (see `Depth200MinimalConnInputs::depth_200_frame_counter`). The
+/// counter MUST be incremented on every frame, NOT just on first frame —
+/// this lets observability tools (Grafana, doctor) read it as a running
+/// total without a separate Prom counter.
+pub fn spawn_depth_200_boot_smoke_test(frames_counter: Arc<AtomicU64>) {
+    tokio::spawn(async move {
+        run_smoke_test_loop(frames_counter, SMOKE_DEADLINE_SECS).await;
+    });
+}
+
+/// Runs the smoke-test loop until either a frame arrives or the deadline
+/// expires. Public for unit testing — production callers go through
+/// [`spawn_depth_200_boot_smoke_test`] which spawns this on the runtime.
+pub async fn run_smoke_test_loop(frames_counter: Arc<AtomicU64>, deadline_secs: u64) {
+    let poll_interval = Duration::from_secs(SMOKE_POLL_INTERVAL_SECS);
+    let max_polls = deadline_secs.saturating_div(SMOKE_POLL_INTERVAL_SECS);
+
+    for _ in 0..max_polls {
+        tokio::time::sleep(poll_interval).await;
+        if frames_counter.load(Ordering::Relaxed) > 0 {
+            // Early exit on first frame — emit Passed immediately.
+            let frames = frames_counter.load(Ordering::Relaxed);
+            let in_market = is_within_market_hours_ist();
+            emit_outcome(classify_smoke_outcome(frames, in_market));
+            return;
+        }
+    }
+
+    // Deadline reached.
+    let frames = frames_counter.load(Ordering::Relaxed);
+    let in_market = is_within_market_hours_ist();
+    emit_outcome(classify_smoke_outcome(frames, in_market));
+}
+
+fn emit_outcome(outcome: SmokeOutcome) {
+    match outcome {
+        SmokeOutcome::Skipped => {
+            info!(
+                deadline_secs = SMOKE_DEADLINE_SECS,
+                "depth-200 boot smoke test skipped — boot occurred outside market hours; \
+                 frames not expected, signal not meaningful"
+            );
+        }
+        SmokeOutcome::Passed { frames_received } => {
+            info!(
+                frames_received,
+                deadline_secs = SMOKE_DEADLINE_SECS,
+                "depth-200 boot smoke test PASSED — Dhan accepted the shared APP token \
+                 and streamed at least one frame from full-depth-api.dhan.co \
+                 (Ticket #5610706 server-side gate removal verified live)"
+            );
+        }
+        SmokeOutcome::Failed => {
+            error!(
+                code = ErrorCode::Depth200Smoke01NoFramesAtBoot.code_str(),
+                deadline_secs = SMOKE_DEADLINE_SECS,
+                "depth-200 boot smoke test FAILED — zero frames received from \
+                 full-depth-api.dhan.co within deadline. Possible causes: \
+                 (a) Dhan reverted the Ticket #5610706 server-side gate \
+                 (depth-200 rejecting APP tokens again), (b) all subscribed \
+                 SecurityIds are too far OTM (server-side filtering), \
+                 (c) WebSocket pool failed to subscribe. Check \
+                 tv_websocket_connections_active{{kind=\"depth-200\"}} and \
+                 errors.jsonl.* for subscribe ack failures"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_off_hours_returns_skipped_regardless_of_frame_count() {
+        assert_eq!(classify_smoke_outcome(0, false), SmokeOutcome::Skipped);
+        assert_eq!(classify_smoke_outcome(1, false), SmokeOutcome::Skipped);
+        assert_eq!(classify_smoke_outcome(1_000, false), SmokeOutcome::Skipped);
+    }
+
+    #[test]
+    fn classify_in_market_zero_frames_returns_failed() {
+        assert_eq!(classify_smoke_outcome(0, true), SmokeOutcome::Failed);
+    }
+
+    #[test]
+    fn classify_in_market_at_least_one_frame_returns_passed() {
+        assert_eq!(
+            classify_smoke_outcome(1, true),
+            SmokeOutcome::Passed { frames_received: 1 }
+        );
+        assert_eq!(
+            classify_smoke_outcome(42, true),
+            SmokeOutcome::Passed {
+                frames_received: 42
+            }
+        );
+    }
+
+    #[test]
+    fn smoke_outcome_is_partial_eq_for_test_assertions() {
+        // Belt-and-suspenders: PartialEq + Eq are derived; test asserts
+        // we can match without `if let` chains.
+        let a = SmokeOutcome::Passed { frames_received: 5 };
+        let b = SmokeOutcome::Passed { frames_received: 5 };
+        let c = SmokeOutcome::Passed { frames_received: 6 };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn smoke_deadline_is_at_least_30s_to_allow_handshake() {
+        // Dhan handshake is typically 5–10s; deadline must be at least
+        // 30s to avoid spurious Failed events on slow networks.
+        assert!(
+            SMOKE_DEADLINE_SECS >= 30,
+            "deadline too aggressive — handshake may not complete: {SMOKE_DEADLINE_SECS}s"
+        );
+    }
+
+    #[test]
+    fn smoke_deadline_is_at_most_120s_to_keep_signal_timely() {
+        // > 2 minutes makes the signal less actionable; operator
+        // wants to know within boot's first cycle.
+        assert!(
+            SMOKE_DEADLINE_SECS <= 120,
+            "deadline too lax — signal will lag operator action: {SMOKE_DEADLINE_SECS}s"
+        );
+    }
+
+    #[test]
+    fn smoke_poll_interval_divides_deadline_cleanly() {
+        // Defensive: if the interval doesn't divide, the loop's
+        // `saturating_div` rounds down and could exit slightly early.
+        // Not catastrophic but indicates a constant misconfiguration.
+        assert_eq!(
+            SMOKE_DEADLINE_SECS % SMOKE_POLL_INTERVAL_SECS,
+            0,
+            "poll interval ({SMOKE_POLL_INTERVAL_SECS}s) must divide deadline \
+             ({SMOKE_DEADLINE_SECS}s) cleanly"
+        );
+    }
+
+    // Note: time-based tokio tests use real time (no `start_paused`)
+    // because the workspace's `tokio` dev-deps don't enable `test-util`.
+    // We use very short deadlines to keep CI fast.
+
+    #[tokio::test]
+    async fn run_smoke_test_loop_exits_early_on_first_frame() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let counter_clone = Arc::clone(&counter);
+
+        // Increment counter BEFORE starting the loop — the very first
+        // poll iteration should observe the count and exit.
+        counter_clone.store(7, Ordering::Relaxed);
+
+        let start = std::time::Instant::now();
+        // 5s deadline (real time). Loop should exit after the first
+        // 1s poll observes the non-zero count.
+        run_smoke_test_loop(counter, 5).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "loop should exit shortly after first poll, not run to deadline: {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_smoke_test_loop_runs_to_deadline_with_zero_frames() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let start = std::time::Instant::now();
+        // Tiny deadline (2s = 2 polls) keeps CI fast.
+        run_smoke_test_loop(counter, 2).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_secs(2),
+            "loop should run to deadline with zero frames: {elapsed:?}"
+        );
+    }
+}

--- a/crates/app/src/depth_20_conn_spawner.rs
+++ b/crates/app/src/depth_20_conn_spawner.rs
@@ -352,6 +352,12 @@ pub struct Depth200MinimalConnInputs {
     /// Initial-connect stagger in milliseconds (slot index ×
     /// `DEPTH_200_INITIAL_STAGGER_MS`).
     pub initial_stagger_ms: u64,
+    /// Optional shared frame counter for the boot-time depth-200 smoke
+    /// test (PR-B). Incremented on every received frame across all 5
+    /// slots; the smoke-test task in `boot_smoke_test::run_smoke_test_loop`
+    /// polls this counter for the first ≥ 1 transition. `None` means no
+    /// smoke test is registered (boot path bypassed it, or test paths).
+    pub depth_200_frame_counter: Option<Arc<std::sync::atomic::AtomicU64>>,
 }
 
 /// Spawn a minimal depth-200 WebSocket connection (3 tokio tasks).
@@ -377,6 +383,7 @@ pub fn spawn_depth_200_minimal_conn(inputs: Depth200MinimalConnInputs) {
         health_status,
         ws_frame_spill,
         initial_stagger_ms,
+        depth_200_frame_counter,
     } = inputs;
 
     // Frame channel: WS connection task -> persistence task.
@@ -409,6 +416,12 @@ pub fn spawn_depth_200_minimal_conn(inputs: Depth200MinimalConnInputs) {
 
         while let Some(frame) = frame_rx.recv().await {
             frames_counter.increment(1);
+            // PR-B: in-process counter for the boot smoke test. `Relaxed`
+            // is sufficient — readers only care that "≥ 1 frame happened",
+            // not the exact value.
+            if let Some(counter) = &depth_200_frame_counter {
+                counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
             let ts = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
             match tickvault_core::parser::dispatcher::dispatch_deep_depth_frame(&frame, ts) {
                 Ok(tickvault_core::parser::types::ParsedFrame::DeepDepth {
@@ -629,6 +642,7 @@ mod tests {
                 health_status: _,
                 ws_frame_spill: _,
                 initial_stagger_ms: _,
+                depth_200_frame_counter: _,
             } = inputs;
         }
     }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod bhavcopy_pipeline;
 pub mod boot_helpers;
+pub mod boot_smoke_test;
 pub mod core_pinning;
 pub mod depth_20_conn_spawner;
 pub mod depth_20_single_side_planner;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2741,6 +2741,13 @@ async fn main() -> Result<()> {
             );
             let mut d200_cmd_senders = std::collections::HashMap::new();
             let mut d200_dyn_spawn_count: usize = 0;
+
+            // PR-B (2026-05-02): one shared atomic counter incremented by all
+            // 5 depth-200 receivers on every frame. The boot smoke test polls
+            // this counter for the first ≥ 1 transition. See
+            // `crates/app/src/boot_smoke_test.rs` for classifier + emission.
+            let depth_200_frame_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+
             for slot in 0..tickvault_common::constants::MAX_TWO_HUNDRED_DEPTH_CONNECTIONS {
                 let (tx, rx) =
                     tokio::sync::mpsc::channel::<tickvault_core::websocket::DepthCommand>(4);
@@ -2764,10 +2771,22 @@ async fn main() -> Result<()> {
                         health_status: health_status.clone(),
                         ws_frame_spill: ws_frame_spill.clone(),
                         initial_stagger_ms: stagger_ms,
+                        depth_200_frame_counter: Some(std::sync::Arc::clone(
+                            &depth_200_frame_counter,
+                        )),
                     },
                 );
                 d200_dyn_spawn_count = d200_dyn_spawn_count.saturating_add(1);
             }
+
+            // PR-B: spawn the boot-time depth-200 smoke test once all 5
+            // slots are wired. Off-hours boots produce a `Skipped` log and
+            // exit at the deadline; in-market boots emit `Passed` (Info)
+            // on the first frame or `Failed` (Critical, DEPTH200-SMOKE-01)
+            // at the deadline if zero frames arrived.
+            tickvault_app::boot_smoke_test::spawn_depth_200_boot_smoke_test(std::sync::Arc::clone(
+                &depth_200_frame_counter,
+            ));
             // H1 + M3 — runtime invariant: spawn loop emitted exactly 5 conns.
             // Saturating add means a logic bug (e.g. early break) leaves the
             // counter < 5; a duplicate spawn could push it > 5. Both fail.

--- a/crates/common/src/error_code.rs
+++ b/crates/common/src/error_code.rs
@@ -353,6 +353,15 @@ pub enum ErrorCode {
     /// semantic mid-session (escalate to Item 26 L3 ticket) or our parser
     /// regressed on the byte offset. Severity::High.
     Volume01MonotonicityBreach,
+    /// Boot-time depth-200 smoke test: zero frames received from
+    /// `wss://full-depth-api.dhan.co` within the smoke-test window
+    /// during market hours. Indicates the auth handshake succeeded
+    /// (no `WebSocketDisconnected` fired) but Dhan never streamed a
+    /// frame — most often a SecurityId that's far OTM (per-rule
+    /// server-side filtering) or a regression in the new APP-token
+    /// path (Ticket #5610706 reverted server-side?). Severity::Critical
+    /// — operator should investigate before next market open.
+    Depth200Smoke01NoFramesAtBoot,
     /// Wave 5 Item 13 — boot-time prev-close routing assertion failed.
     /// The subscription plan contains an instrument whose `(segment,
     /// feed_mode)` pair cannot deliver previous-day close per the
@@ -485,6 +494,7 @@ impl ErrorCode {
             Self::PrevClose03BootRoutingAssertion => "PREVCLOSE-03",
             // Wave 5 Item 26 L1 — volume cumulative-monotonicity guard
             Self::Volume01MonotonicityBreach => "VOLUME-MONO-01",
+            Self::Depth200Smoke01NoFramesAtBoot => "DEPTH200-SMOKE-01",
         }
     }
 
@@ -509,7 +519,8 @@ impl ErrorCode {
             | Self::Boot03ClockSkewExceeded
             | Self::Selftest02Failed
             | Self::Depth20Dyn02SwapChannelBroken
-            | Self::PrevClose03BootRoutingAssertion => Severity::Critical,
+            | Self::PrevClose03BootRoutingAssertion
+            | Self::Depth200Smoke01NoFramesAtBoot => Severity::Critical,
             // Info: positive-ping / lifecycle confirmations
             Self::Selftest01Passed | Self::Slo01Healthy => Severity::Info,
             // High: composite SLO degradation summary signal
@@ -695,7 +706,8 @@ impl ErrorCode {
             | Self::Depth20Dyn03TopGainersEmpty
             | Self::Depth200Dyn01TopGainersEmpty
             | Self::PrevClose03BootRoutingAssertion
-            | Self::Volume01MonotonicityBreach => ".claude/rules/project/wave-5-error-codes.md",
+            | Self::Volume01MonotonicityBreach
+            | Self::Depth200Smoke01NoFramesAtBoot => ".claude/rules/project/wave-5-error-codes.md",
         }
     }
 
@@ -810,6 +822,7 @@ impl ErrorCode {
             Self::Depth200Dyn01TopGainersEmpty,
             Self::PrevClose03BootRoutingAssertion,
             Self::Volume01MonotonicityBreach,
+            Self::Depth200Smoke01NoFramesAtBoot,
         ]
     }
 }
@@ -991,7 +1004,9 @@ mod tests {
         // 2026-05-02 (depth-200 SELF token retired per Dhan Ticket
         // #5610706): bumped 95 -> 92 — removed DEPTH200-AUTH-01/02/03
         // along with the SELF-token manager.
-        assert_eq!(ErrorCode::all().len(), 92);
+        // 2026-05-02 (PR-B): bumped 92 -> 93 for DEPTH200-SMOKE-01
+        // (boot-time depth-200 smoke test no-frames Critical signal).
+        assert_eq!(ErrorCode::all().len(), 93);
     }
 
     #[test]
@@ -1031,7 +1046,9 @@ mod tests {
                 || s.starts_with("DEPTH-20-DYN-")
                 || s.starts_with("DEPTH-200-DYN-")
                 // Wave 5 Item 26 L1: volume cumulative-monotonicity guard.
-                || s.starts_with("VOLUME-");
+                || s.starts_with("VOLUME-")
+                // PR-B (2026-05-02): boot-time depth-200 smoke test.
+                || s.starts_with("DEPTH200-SMOKE-");
             assert!(has_known_prefix, "unexpected code prefix: {s}");
         }
     }


### PR DESCRIPTION
## Summary

Closes the gap between boot and the 09:16:30 IST market-open self-test for **mid-day in-market boots**: gives a Critical-level signal within 60s if depth-200 fails to stream after PR #427 retired the SELF-token workaround.

Per Dhan Ticket #5610706 (2026-05-02), depth-200 now reuses the shared TOTP/APP token. If Dhan ever silently reverts the server gate, operators currently learn at 09:16:30 IST via SELFTEST-02. The boot smoke test detects the regression at **boot+60s** instead — actionable BEFORE next market open.

## Mechanism

| Step | What |
|---|---|
| 1 | New shared `Arc<AtomicU64>` is incremented by every depth-200 receiver task on every frame |
| 2 | New tokio task `run_smoke_test_loop` polls the counter every 1s for up to 60s |
| 3 | Pure classifier `classify_smoke_outcome(frames, in_market_hours)` decides outcome |
| 4 | Edge-trigger semantics: fires exactly once per process lifetime |

## Outcome matrix

| Boot in market hours? | Frames received | Outcome | Severity | ErrorCode |
|---|---|---|---|---|
| No | (any) | Skipped | (none, INFO log only) | — |
| Yes | ≥ 1 | Passed | Info | — |
| Yes | 0 | Failed | **Critical** | `DEPTH200-SMOKE-01` |

Off-hours boots emit `Skipped` because Dhan does not stream depth-200 frames when the market is closed — a 0-frames result there would be a false positive.

## Diff scope

| File | Δ | Purpose |
|---|---|---|
| `crates/app/src/boot_smoke_test.rs` | +250 (new) | pure classifier + tokio task + 9 unit tests |
| `crates/app/src/depth_20_conn_spawner.rs` | +10 | thread `Arc<AtomicU64>` through inputs; increment on every frame |
| `crates/app/src/main.rs` | +20 | create shared counter, clone for 5 slots, spawn smoke task |
| `crates/app/src/lib.rs` | +1 | `pub mod boot_smoke_test` |
| `crates/common/src/error_code.rs` | +18 | new variant, severity, runbook path, prefix |
| `.claude/rules/project/wave-5-error-codes.md` | +50 | runbook with 3-cause diagnostic table |
| `.claude/triage/error-rules.yaml` | +20 | escalate rule (cooldown=0, never auto-action) |

**Net: +369 LoC** (most of it the new module + tests + runbook).

## Test plan

- [x] `cargo build -p tickvault-app` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p tickvault-app --lib boot_smoke_test` — **9 pass** (3 classifier + 4 constant guards + 2 timing)
- [x] `cargo test -p tickvault-app --lib` — **465 pass** (was 459, +6 net)
- [x] `cargo test -p tickvault-common --test error_code_rule_file_crossref` — **3 pass**
- [x] All 8 pre-push fast gates green
- [ ] Live boot verification — expect: in-market boot logs `depth-200 boot smoke test PASSED frames_received=N` within 60s; off-hours boot logs `Skipped`

## Dependencies

This PR is independent of #428 / #429 but rebases cleanly on top of #427 (which is already merged). After all 4 PRs land:
- depth-200 uses shared APP token (#427)
- 6 missing triage rules added (#428)
- app.log rotates hourly (#429)
- depth-200 boot smoke test (this PR)

## Honest 100% claim (per project charter)

> "100% inside the tested envelope, with ratcheted regression coverage: ≤60s smoke window during market hours, edge-triggered single-fire per process. Beyond the envelope, the existing 5s `WebSocketDisconnected` + 09:16:30 IST `SELFTEST-02` provide redundant coverage."

https://claude.ai/code/session_014TRdAa2oyYG8ePXeQGb1Jr

---
_Generated by [Claude Code](https://claude.ai/code/session_014TRdAa2oyYG8ePXeQGb1Jr)_