### PR TITLE
perf(depth-dyn): zero-alloc exchange_segment in DepthDiffEntry (~250 allocs/cycle saved)

### DIFF
--- a/crates/app/src/depth_dynamic_pipeline_v2.rs
+++ b/crates/app/src/depth_dynamic_pipeline_v2.rs
@@ -889,7 +889,7 @@ fn resolve_op_entries(
         if let Some(inst) = registry.get_with_segment(sid, segment) {
             out.push(tickvault_core::notification::DepthDiffEntry {
                 security_id: sid,
-                exchange_segment: segment.as_str().to_string(),
+                exchange_segment: segment.as_str(),
                 display_label: inst.display_label.clone(),
                 underlying_symbol: inst.underlying_symbol.clone(),
             });

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -1007,11 +1007,16 @@ pub enum NotificationEvent {
 /// Resolved from `(security_id, exchange_segment)` via the instrument
 /// registry's O(1) `get_with_segment` lookup. Preserves the composite-key
 /// uniqueness invariant per I-P1-11.
+///
+/// 2026-05-02 (hot-path-reviewer fix): `exchange_segment` is `&'static str`
+/// (not `String`) because `ExchangeSegment::as_str()` already returns a
+/// compile-time constant. Eliminates ~250 String allocations per cycle on
+/// a full reshuffle — bounded but unnecessary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DepthDiffEntry {
     pub security_id: u32,
     /// Stable SYMBOL value (`"NSE_FNO"`, `"BSE_FNO"`, etc.).
-    pub exchange_segment: String,
+    pub exchange_segment: &'static str,
     /// Human-readable contract label, e.g. `"NIFTY 23000 CE 2026-06-26"`.
     pub display_label: String,
     /// Bare underlying, e.g. `"NIFTY"`.
@@ -2385,7 +2390,7 @@ mod tests {
         // Operator-requested 2026-05-02: precise symbol + sid + segment.
         let entry = DepthDiffEntry {
             security_id: 70123,
-            exchange_segment: "NSE_FNO".to_string(),
+            exchange_segment: "NSE_FNO",
             display_label: "NIFTY 23000 CE 2026-06-26".to_string(),
             underlying_symbol: "NIFTY".to_string(),
         };
@@ -2402,7 +2407,7 @@ mod tests {
     fn test_depth_diff_entry_format_line_html_escapes_display_label() {
         let entry = DepthDiffEntry {
             security_id: 99999,
-            exchange_segment: "NSE_FNO".to_string(),
+            exchange_segment: "NSE_FNO",
             display_label: r#"</b><a href="http://attacker.com">click</a><b>"#.to_string(),
             underlying_symbol: "EVIL".to_string(),
         };
@@ -2433,7 +2438,7 @@ mod tests {
         let long = "A".repeat(200);
         let entry = DepthDiffEntry {
             security_id: 1,
-            exchange_segment: "NSE_FNO".to_string(),
+            exchange_segment: "NSE_FNO",
             display_label: long,
             underlying_symbol: "TEST".to_string(),
         };


### PR DESCRIPTION
## Summary

Last remaining WARNING from the 3-agent adversarial review on PR #435 — eliminates ~250 `String` allocations per full-reshuffle cycle in `resolve_op_entries`.

## What changes

`DepthDiffEntry::exchange_segment` changed from `String` to `&'static str`. `ExchangeSegment::as_str()` already returns a compile-time constant per the impl in `tickvault_common::types`, so `.to_string()` was pure allocation waste.

| Site | Before | After |
|---|---|---|
| `crates/app/src/depth_dynamic_pipeline_v2.rs:892` | `segment.as_str().to_string()` | `segment.as_str()` |
| `events.rs::tests` × 3 fixtures | `"NSE_FNO".to_string()` | `"NSE_FNO"` |

## Impact

- ~250 small `String` allocations saved per full-reshuffle cycle (60s cadence)
- Worst case: ~4 alloc/sec savings during volatile rebalances
- Bounded — cold path (60s cadence), not hot path — but the principle is no waste anywhere
- The 3 existing ratchet tests still pass with the new type

## Tests

- `cargo check -p tickvault-app` → clean
- `cargo test -p tickvault-core --lib notification::events::tests::test_depth_diff` → 3 passed
- The 3 ratchets pinning the rendering (`test_depth_diff_entry_format_line_*`) all hold with the new `&'static str` type

## Why this needed a separate PR

PR #435 had landed before the hot-path agent's report flagged this WARNING (it was deferred as "future cleanup"). PR #436 addressed the 3 HIGH findings. This 1 WARNING is the last lingering item — a 1-line type change in the struct + 4 call sites updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAJDo1RGgWoQkruyzsmD7W)_