### PR TITLE
fix(notification): stop double-prefixing severity tag on coalesced Telegram messages

### DIFF
--- a/crates/core/src/notification/coalescer.rs
+++ b/crates/core/src/notification/coalescer.rs
@@ -568,17 +568,24 @@ mod tests {
         // a verbose `Coalesced summary [topic] count=1 / Samples: 1. ...`
         // envelope when there's nothing to summarise. Single-event fast
         // path returns just the sample body.
+        // 2026-05-03 fix: samples are stored UNPREFIXED — the dispatcher's
+        // `deliver_summaries` adds the severity tag exactly once on drain.
+        // Storing the prefixed string here caused the duplicate
+        // `✅ [LOW] ✅ [LOW]` Telegram bug observed by Parthiban.
         let summary = DrainedSummary {
             topic: "AuthenticationSuccess",
             severity: Severity::Low,
             count: 1,
             first_ts_ms: 1_700_000_000_000,
             last_ts_ms: 1_700_000_000_000,
-            samples: vec!["✅ [LOW] Auth OK — Dhan JWT acquired".into()],
+            samples: vec!["Auth OK — Dhan JWT acquired".into()],
             samples_capped: false,
         };
         let msg = summary.render_message();
-        assert_eq!(msg, "✅ [LOW] Auth OK — Dhan JWT acquired");
+        assert_eq!(msg, "Auth OK — Dhan JWT acquired");
+        // The severity tag must NOT be in the rendered body — it is added
+        // by the dispatcher when sending to Telegram.
+        assert!(!msg.contains("[LOW]"));
         assert!(!msg.contains("Coalesced summary"));
         assert!(!msg.contains("count="));
         assert!(!msg.contains("Samples:"));

--- a/crates/core/src/notification/coalescer.rs
+++ b/crates/core/src/notification/coalescer.rs
@@ -633,6 +633,49 @@ mod tests {
     }
 
     #[test]
+    fn test_end_to_end_no_double_prefix_on_coalesced_telegram_body() {
+        // Regression guard for the 2026-05-03 operator-visible bug:
+        //   ✅ [LOW] ✅ [LOW] Auth OK — Dhan JWT acquired
+        //
+        // Simulates the full pipeline a Severity::Low event takes through
+        // the production dispatcher:
+        //   1. dispatch_immediate computes `body = event.to_message()`
+        //      (NO severity tag).
+        //   2. coalescer.observe stores `body` in the bucket.
+        //   3. drain_mature returns DrainedSummary.
+        //   4. deliver_summaries renders
+        //      `format!("{} {}", severity.tag(), summary.render_message())`.
+        //
+        // The final Telegram body MUST contain the `[LOW]` tag exactly
+        // ONCE. Two occurrences = the bug is back.
+        let c = TelegramCoalescer::new(CoalescerConfig {
+            window: Duration::from_millis(5),
+            flush_interval: Duration::from_millis(2),
+        });
+        let unprefixed_body = "Auth OK — Dhan JWT acquired".to_string();
+        c.observe("AuthenticationSuccess", Severity::Low, || {
+            unprefixed_body.clone()
+        });
+        std::thread::sleep(Duration::from_millis(15));
+        let drained = c.drain_mature();
+        assert_eq!(drained.len(), 1);
+        let summary = &drained[0];
+
+        // Mirror deliver_summaries' format! call.
+        let final_body = format!("{} {}", summary.severity.tag(), summary.render_message());
+        let low_count = final_body.matches("[LOW]").count();
+        assert_eq!(
+            low_count, 1,
+            "expected exactly one [LOW] tag in final Telegram body, got {low_count}: {final_body:?}"
+        );
+        assert!(final_body.starts_with("✅ [LOW] "));
+        assert!(final_body.contains("Auth OK"));
+        // And the inner sample must NOT have the tag (regression guard
+        // for the upstream bug at the source).
+        assert!(!summary.samples[0].contains("[LOW]"));
+    }
+
+    #[test]
     fn test_format_ist_ms_handles_midnight_boundary() {
         // 2026-01-01 00:00:00 UTC = 05:30:00 IST
         let ms = 1_767_225_600_000;

--- a/crates/core/src/notification/service.rs
+++ b/crates/core/src/notification/service.rs
@@ -321,7 +321,13 @@ impl NotificationService {
                 // Parthiban workflow: any [HIGH] / [CRITICAL] message goes
                 // straight to Claude Code for debugging.
                 let topic = event.topic();
-                let message = format!("{} {}", severity.tag(), event.to_message());
+                // Render the body WITHOUT the severity tag — the prefix is
+                // added exactly once by either (a) `deliver_summaries` on
+                // drain (coalesced path) or (b) the bypass branch below.
+                // Storing the prefixed string in the coalescer caused the
+                // duplicate `✅ [LOW] ✅ [LOW]` Telegram bug observed by
+                // Parthiban on 2026-05-03 (drain re-prepended the tag).
+                let body = event.to_message();
 
                 // Wave 3-B Item 11: bucket-coalesce Severity::Low and
                 // Severity::Info events. Bypass everything else (Critical,
@@ -330,7 +336,7 @@ impl NotificationService {
                 // the same call covers both branches; we only short-circuit
                 // when it returns `Coalesced`.
                 if let Some(coalescer) = self.coalescer.as_ref() {
-                    let decision = coalescer.observe(topic, severity, || message.clone());
+                    let decision = coalescer.observe(topic, severity, || body.clone());
                     if matches!(decision, CoalesceDecision::Coalesced) {
                         metrics::counter!(
                             "tv_telegram_dispatched_total",
@@ -349,6 +355,11 @@ impl NotificationService {
                     "coalesced" => "false",
                 )
                 .increment(1);
+
+                // Bypass path: prefix the body with the severity tag once.
+                // (The coalesced path applies the same prefix in
+                // `deliver_summaries` on drain.)
+                let message = format!("{} {}", severity.tag(), body);
 
                 // Always: Telegram. Messages > 4000 chars get split into
                 // ordered chunks per Telegram's 4096-char hard limit so


### PR DESCRIPTION
## Summary

Operator screenshot 2026-05-03 showed every `Severity::Low` / `Severity::Info` Telegram event arriving with the severity tag duplicated:

```
✅ [LOW] ✅ [LOW] Auth OK — Dhan JWT acquired
✅ [LOW] ✅ [LOW] Order Update WS connected
ℹ️ [INFO] ℹ️ [INFO] tickvault started
✅ [LOW] ✅ [LOW] Historical candles OK
```

## Root cause

In `crates/core/src/notification/service.rs`:

1. `dispatch_immediate()` built `message = format!("{} {}", severity.tag(), event.to_message())` — prefix added once.
2. That already-prefixed string was passed to `coalescer.observe(topic, severity, || message.clone())`, so the bucket sample carried the prefix.
3. On drain, `deliver_summaries()` did `format!("{} {}", summary.severity.tag(), summary.render_message())` — re-prepending the tag.
4. Net effect on every coalesced (Low/Info) event: `✅ [LOW] ✅ [LOW] …`.

The bypass path (Critical/High/Medium) was unaffected — only one prefix.

## Fix

- Pass the **unprefixed** `event.to_message()` body into the coalescer.
- The single severity prefix is now applied exactly once by either:
  - (a) `deliver_summaries` on drain (Low/Info coalesced path), or
  - (b) the bypass branch (Critical/High/Medium direct path).
- SMS path (Severity::High+) continues to use the prefixed `message` from the bypass branch.

## Test plan

- [x] Updated `test_render_message_count_one_omits_envelope` to store an unprefixed sample and assert the rendered body contains no `[LOW]` tag (regression guard).
- [x] `cargo test -p tickvault-core --lib notification::` — 275 tests pass.
- [x] `cargo test -p tickvault-core --lib` — 3601 tests pass.
- [ ] Operator restarts the app on `claude/fix-duplicate-logs-P9AZ8` and confirms the next `[LOW]` / `[INFO]` Telegram message has a single prefix.

https://claude.ai/code/session_01K4pdLarMpZBRtCYX26TCci


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4pdLarMpZBRtCYX26TCci)_