### PR TITLE
fix(workspace): clean strict-clippy + fix pre-existing I-P0-06 test desync

### DIFF
--- a/crates/app/src/boot_helpers.rs
+++ b/crates/app/src/boot_helpers.rs
@@ -430,8 +430,8 @@ pub fn create_log_file_writer() -> Option<std::fs::File> {
 /// alone produce ~7 MB/hour in `data/logs/app.YYYY-MM-DD-HH`, exceeding
 /// IDE code-insight thresholds (2.56 MB) and slowing `less` / `grep`.
 ///
-/// This filter applies to the FILE appender ONLY. Stdout (when enabled)
-/// + `errors.log` + `errors.jsonl.YYYY-MM-DD-HH` keep the configured
+/// This filter applies to the FILE appender ONLY. Stdout (when enabled),
+/// `errors.log`, and `errors.jsonl.YYYY-MM-DD-HH` keep the configured
 /// global level — DEBUG is preserved for triage at the source.
 ///
 /// # Arguments

--- a/crates/app/src/boot_smoke_test.rs
+++ b/crates/app/src/boot_smoke_test.rs
@@ -35,8 +35,8 @@ use tracing::{error, info};
 /// Deadline (seconds) for receiving the first depth-200 frame at boot.
 ///
 /// Dhan's depth-200 connections handshake within ~5–10s. Subscribe ack
-/// + first frame typically within another 5s. 60s gives a comfortable
-/// margin without holding back the boot summary too long.
+/// and first frame typically arrive within another 5s. 60s gives a
+/// comfortable margin without holding back the boot summary too long.
 pub const SMOKE_DEADLINE_SECS: u64 = 60;
 
 /// Poll interval (seconds) for the smoke test loop.
@@ -209,6 +209,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::modulo_one,
+        reason = "poll-interval ratchet — assertion stays meaningful if interval ever changes from 1"
+    )]
     fn smoke_poll_interval_divides_deadline_cleanly() {
         // Defensive: if the interval doesn't divide, the loop's
         // `saturating_div` rounds down and could exit slightly early.

--- a/crates/app/tests/preopen_movers_persistence_e2e.rs
+++ b/crates/app/tests/preopen_movers_persistence_e2e.rs
@@ -179,8 +179,8 @@ fn make_preopen_tick(
 // ---------------------------------------------------------------------------
 
 /// Wave-3-A Item 10 e2e: a tracker snapshot of 3 stocks + 2 indices
-/// + SENSEX-as-unavailable persists end-to-end through the live ILP
-/// wire path with zero drops.
+/// (plus SENSEX-as-unavailable) persists end-to-end through the live
+/// ILP wire path with zero drops.
 #[test]
 fn test_preopen_movers_e2e_snapshot_persists_phase_preopen_to_questdb() {
     let server = FakeQuestDb::start_ephemeral();
@@ -200,11 +200,11 @@ fn test_preopen_movers_e2e_snapshot_persists_phase_preopen_to_questdb() {
     // boot-time disk-cache seed in main.rs uses the same call).
     tracker.update_from_tick(&make_preopen_tick(2885, 1, 2_500.50, 2_490.00));
     tracker.update_from_tick(&make_preopen_tick(1594, 1, 1_485.75, 1_500.00));
-    tracker.update_from_tick(&make_preopen_tick(11536, 1, 3_750.00, 3_720.00));
+    tracker.update_from_tick(&make_preopen_tick(11536, 1, 3_750.0, 3_720.0));
     tracker.seed_prev_close(13, ExchangeSegment::IdxI, 24_500.0);
     tracker.seed_prev_close(25, ExchangeSegment::IdxI, 52_000.0);
-    tracker.update_from_tick(&make_preopen_tick(13, 0, 24_625.50, 0.0));
-    tracker.update_from_tick(&make_preopen_tick(25, 0, 51_780.00, 0.0));
+    tracker.update_from_tick(&make_preopen_tick(13, 0, 24_625.5, 0.0));
+    tracker.update_from_tick(&make_preopen_tick(25, 0, 51_780.0, 0.0));
 
     let snap = tracker.compute_snapshot();
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -2646,29 +2646,36 @@ mod tests {
 
     #[test]
     fn test_depth_dynamic_config_rejects_zero_conns() {
-        let mut cfg = DepthDynamicConfig::default();
-        cfg.conns = 0;
+        let cfg = DepthDynamicConfig {
+            conns: 0,
+            ..DepthDynamicConfig::default()
+        };
         assert!(cfg.assert_invariants("depth_20", 5).is_err());
     }
 
     #[test]
     fn test_depth_dynamic_config_rejects_conns_above_cap() {
-        let mut cfg = DepthDynamicConfig::default();
-        cfg.conns = 6;
+        let cfg = DepthDynamicConfig {
+            conns: 6,
+            ..DepthDynamicConfig::default()
+        };
         let err = cfg.assert_invariants("depth_20", 5).unwrap_err();
         assert!(err.to_string().contains("exceeds Dhan cap"));
     }
 
     #[test]
     fn test_depth_dynamic_config_rejects_zero_sids_per_conn() {
-        let mut cfg = DepthDynamicConfig::default();
-        cfg.sids_per_conn = 0;
+        let cfg = DepthDynamicConfig {
+            sids_per_conn: 0,
+            ..DepthDynamicConfig::default()
+        };
         assert!(cfg.assert_invariants("depth_20", 5).is_err());
     }
 
     #[test]
     fn test_depth_dynamic_config_rejects_empty_exchange_segments() {
         let mut cfg = DepthDynamicConfig::default();
+        // .clear() is a method call, not a field reassign — no clippy lint.
         cfg.universe.exchange_segments.clear();
         let err = cfg.assert_invariants("depth_20", 5).unwrap_err();
         assert!(err.to_string().contains("exchange_segments"));
@@ -2676,17 +2683,27 @@ mod tests {
 
     #[test]
     fn test_depth_dynamic_config_rejects_cohort_smaller_than_total_capacity() {
-        let mut cfg = DepthDynamicConfig::default();
         // 5×50 = 250 SIDs needed; cohort 100 must fail.
-        cfg.universe.cohort_size = 100;
+        let cfg = DepthDynamicConfig {
+            universe: DepthDynamicUniverseConfig {
+                cohort_size: 100,
+                ..DepthDynamicConfig::default().universe
+            },
+            ..DepthDynamicConfig::default()
+        };
         let err = cfg.assert_invariants("depth_20", 5).unwrap_err();
         assert!(err.to_string().contains("cohort_size"));
     }
 
     #[test]
     fn test_depth_dynamic_config_rejects_zero_window_secs() {
-        let mut cfg = DepthDynamicConfig::default();
-        cfg.universe.window_secs = 0;
+        let cfg = DepthDynamicConfig {
+            universe: DepthDynamicUniverseConfig {
+                window_secs: 0,
+                ..DepthDynamicConfig::default().universe
+            },
+            ..DepthDynamicConfig::default()
+        };
         assert!(cfg.assert_invariants("depth_20", 5).is_err());
     }
 
@@ -2728,8 +2745,10 @@ mod tests {
 
     #[test]
     fn test_under_provisioned_warning_fires_when_below_cap() {
-        let mut cfg = DepthDynamicConfig::default();
-        cfg.conns = 3;
+        let cfg = DepthDynamicConfig {
+            conns: 3,
+            ..DepthDynamicConfig::default()
+        };
         let warning = cfg.under_provisioned_warning("depth_20", 5).unwrap();
         assert!(warning.contains("conns = 3"));
         assert!(warning.contains("Dhan cap of 5"));
@@ -2740,8 +2759,10 @@ mod tests {
     fn test_under_provisioned_warning_does_not_fire_above_cap() {
         // assert_invariants would have already rejected this; but the
         // soft-check is well-defined and returns None, not a phantom warning.
-        let mut cfg = DepthDynamicConfig::default();
-        cfg.conns = 5;
+        let cfg = DepthDynamicConfig {
+            conns: 5,
+            ..DepthDynamicConfig::default()
+        };
         assert!(cfg.under_provisioned_warning("depth_20", 5).is_none());
     }
 }

--- a/crates/core/src/historical/candle_fetcher.rs
+++ b/crates/core/src/historical/candle_fetcher.rs
@@ -995,7 +995,7 @@ async fn fetch_historical_candles_inner(
 
                     // Wave 0 progress log every PROGRESS_LOG_EVERY_N successful
                     // instruments — bounded to ~20-40 lines per full run.
-                    if wave == 0 && instruments_fetched % PROGRESS_LOG_EVERY_N == 0 {
+                    if wave == 0 && instruments_fetched.is_multiple_of(PROGRESS_LOG_EVERY_N) {
                         let pct = if targets.is_empty() {
                             0
                         } else {

--- a/crates/core/src/instrument/bhavcopy_scheduler.rs
+++ b/crates/core/src/instrument/bhavcopy_scheduler.rs
@@ -49,7 +49,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, FixedOffset, NaiveTime, Utc};
+use chrono::{DateTime, FixedOffset, NaiveTime, Timelike, Utc};
 use tokio::process::Command;
 use tracing::info;
 
@@ -465,7 +465,3 @@ mod tests {
         assert_eq!(classify_bhavcopy_failure(&err), "csv_not_utf8");
     }
 }
-
-// `chrono::Timelike` is required for `.hour()` etc. on NaiveTime —
-// import shadow at module scope to avoid leaking into doctests.
-use chrono::Timelike;

--- a/crates/core/src/instrument/dynamic_subscription_state.rs
+++ b/crates/core/src/instrument/dynamic_subscription_state.rs
@@ -244,7 +244,7 @@ impl DynamicSubscriptionState {
             .copied()
             .filter(|key| !self.slot_assignment.contains_key(key))
             .collect();
-        to_add.sort_unstable_by(|a, b| (a.0, a.1.binary_code()).cmp(&(b.0, b.1.binary_code())));
+        to_add.sort_unstable_by_key(|key| (key.0, key.1.binary_code()));
         let added_count = to_add.len();
         for key in to_add {
             let (security_id, exchange_segment) = key;

--- a/crates/core/src/instrument/slo_score.rs
+++ b/crates/core/src/instrument/slo_score.rs
@@ -400,7 +400,7 @@ mod tests {
         let outcome = evaluate_slo_score(&inputs);
         match outcome {
             SloOutcome::Critical { score, weakest } => {
-                assert!(score >= 0.0 && score <= 1.0, "score {score} out of range");
+                assert!((0.0..=1.0).contains(&score), "score {score} out of range");
                 assert_eq!(score, 0.0);
                 // Tied at 0.0 — declaration-order tie-break gives qdb first.
                 assert_eq!(weakest, "qdb_health");

--- a/crates/core/src/notification/coalescer.rs
+++ b/crates/core/src/notification/coalescer.rs
@@ -193,14 +193,14 @@ impl DrainedSummary {
     /// coalesced — the operator's "what was suppressed?" question.
     pub fn render_message(&self) -> String {
         // Single-event fast path: no envelope, just the sample.
-        if self.count == 1 {
-            if let Some(sample) = self.samples.first() {
-                return sample.clone();
-            }
-            // Defensive: count=1 with no samples should be impossible
-            // (Telegram02CoalescerStateInconsistency catches it
-            // separately) — fall through to the envelope rather than
-            // emit an empty message.
+        // Defensive: count=1 with no samples should be impossible
+        // (Telegram02CoalescerStateInconsistency catches it
+        // separately) — fall through to the envelope rather than
+        // emit an empty message.
+        if self.count == 1
+            && let Some(sample) = self.samples.first()
+        {
+            return sample.clone();
         }
 
         let mut out = String::with_capacity(256);

--- a/crates/core/tests/gap_enforcement.rs
+++ b/crates/core/tests/gap_enforcement.rs
@@ -1224,10 +1224,14 @@ mod i_p0_06_emergency_download {
     fn test_i_p0_06_emergency_download_uses_critical_log() {
         let source = include_str!("../src/instrument/instrument_loader.rs");
 
-        // Must have CRITICAL log when all caches miss during market hours
+        // Must have CRITICAL log when the rkyv cache is corrupt during
+        // market hours. (The fresh-clone / first-boot branch is WARN by
+        // design — that's the expected emergency-download path, not an
+        // operational concern. See instrument_loader.rs:298-313 for the
+        // two-tier rationale.)
         assert!(
-            source.contains("CRITICAL: no instrument cache available during market hours"),
-            "I-P0-06: instrument_loader.rs must log CRITICAL when caches miss during market hours"
+            source.contains("CRITICAL: rkyv cache corrupt during market hours"),
+            "I-P0-06: instrument_loader.rs must log CRITICAL when rkyv cache is corrupt during market hours"
         );
 
         // Must have CRITICAL log when emergency download also fails

--- a/crates/storage/src/movers_unified_persistence.rs
+++ b/crates/storage/src/movers_unified_persistence.rs
@@ -177,9 +177,9 @@ pub fn movers_1s_alter_add_instrument_type_ddl() -> String {
 /// divide-by-zero on freshly-listed contracts).
 ///
 /// **BANNED aggregations** — SUM of volume / SUM of open_interest. Volume
-/// + OI are cumulative per Item 26 L1; summing across buckets
+/// and OI are cumulative per Item 26 L1; summing across buckets
 /// double/triple-counts. Source-scan ratchet
-/// `test_movers_ddl_no_sum_volume_anywhere` enforces.
+/// `test_movers_ddl_no_sum_volume_anywhere` enforces this.
 #[must_use]
 pub fn movers_view_ddl(timeframe: &str) -> String {
     format!(
@@ -224,6 +224,7 @@ pub fn movers_view_ddl(timeframe: &str) -> String {
 ///   1. CREATE the marker table idempotently first (`IF NOT EXISTS`)
 ///   2. SELECT count(*) from it
 ///   3. Parse the JSON body and require `dataset[0][0] >= 1`
+///
 /// Any deviation (HTTP error, parse failure, empty dataset, count = 0) →
 /// safe-fail to "not yet applied" → run the migration.
 ///

--- a/crates/storage/src/tick_spill_drain.rs
+++ b/crates/storage/src/tick_spill_drain.rs
@@ -233,13 +233,12 @@ mod tests {
 
         // Wait a short window for the async write to complete.
         for _ in 0..50 {
-            if path.exists() {
-                if let Ok(contents) = tokio::fs::read(&path).await
-                    && contents == payload
-                {
-                    let _ = tokio::fs::remove_file(&path).await;
-                    return;
-                }
+            if path.exists()
+                && let Ok(contents) = tokio::fs::read(&path).await
+                && contents == payload
+            {
+                let _ = tokio::fs::remove_file(&path).await;
+                return;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }

--- a/crates/storage/tests/chaos_burst_indices_only.rs
+++ b/crates/storage/tests/chaos_burst_indices_only.rs
@@ -59,6 +59,10 @@ const WAVE_5_PEAK_TPS: usize = 110_180;
 const WAVE_5_QUESTDB_OUTAGE_TOLERANCE_SECS: usize = 5;
 
 #[test]
+#[allow(
+    clippy::assertions_on_constants,
+    reason = "compile-time constant ratchet — assertion IS the test"
+)]
 fn test_chaos_burst_envelope_constants_match_wave_5_plan() {
     // The plan's hard cap.
     assert_eq!(
@@ -110,6 +114,10 @@ fn test_chaos_burst_rescue_ring_absorbs_5s_questdb_outage_at_peak_tps() {
 }
 
 #[test]
+#[allow(
+    clippy::assertions_on_constants,
+    reason = "compile-time constant ratchet — assertion IS the test"
+)]
 fn test_chaos_burst_high_watermark_alert_fires_before_overflow() {
     // The high-watermark is the level at which the operator gets paged
     // ("ring at 80% capacity"). It MUST be strictly below capacity so
@@ -153,6 +161,10 @@ fn test_chaos_burst_synthetic_200k_row_vecdeque_bounded_no_panic() {
 }
 
 #[test]
+#[allow(
+    clippy::assertions_on_constants,
+    reason = "compile-time constant ratchet — assertion IS the test"
+)]
 fn test_chaos_burst_invariant_documentation_complete() {
     // Documentation ratchet: ensure the named constants the plan cites
     // are reachable + non-zero. Trivial today but pins regression where

--- a/crates/storage/tests/wave_2d_s3_lifecycle_guard.rs
+++ b/crates/storage/tests/wave_2d_s3_lifecycle_guard.rs
@@ -92,10 +92,10 @@ fn five_other_audit_rules_keep_their_5y_expiration() {
         if prefix == "order_audit/" {
             continue;
         }
-        if let Some(exp) = r.get("Expiration") {
-            if exp["Days"].as_i64() == Some(1825) {
-                count_with_5y_expiration += 1;
-            }
+        if let Some(exp) = r.get("Expiration")
+            && exp["Days"].as_i64() == Some(1825)
+        {
+            count_with_5y_expiration += 1;
         }
     }
     assert_eq!(


### PR DESCRIPTION
## Summary

Sweep follow-up to PR #439 — running `cargo clippy --workspace --all-targets -- -D warnings` (the strict bar) surfaced 14 clippy issues + 1 pre-existing test failure invisible to CI's deliberately-loose `cargo clippy --workspace --no-deps` invocation (per `.github/workflows/ci.yml:106-113` comment).

## Two distinct fixes

### 1. Strict clippy clean (14 sites)

Pure cleanup — no prod logic changes. Doc reflows, struct-update syntax, `&&-let` collapses, `is_multiple_of`, `RangeInclusive::contains`, `sort_unstable_by_key`, items-after-test-module hoist, 4 intentional `#[allow]` with explicit `reason =` for compile-time ratchet assertions.

| Crate | Sites |
|---|---|
| `tickvault-common` | 5 (config.rs tests) |
| `tickvault-storage` | 6 (movers_unified, tick_spill_drain, wave_2d_s3 + chaos_burst test allows) |
| `tickvault-core` | 5 (candle_fetcher, dynamic_subscription_state, coalescer, bhavcopy_scheduler, slo_score) |
| `tickvault-app` | 3 (boot_helpers doc, boot_smoke_test doc + test allow, preopen_movers_e2e doc + float) |

### 2. Pre-existing I-P0-06 test desync (PR #408 regression)

`test_i_p0_06_emergency_download_uses_critical_log` asserted a literal CRITICAL string that PR #408 deliberately split into a two-tier design (rkyv-corrupt → ERROR, fresh-clone → WARN per I-P0-06). The test was not updated and has been failing on `main` since PR #408 merged. Updated assertion to the current source's CRITICAL string. Both gap_enforcement tests for I-P0-06 now pass.

Verified the failure pre-exists on main by checking out main and re-running the test (still RED there).

## Verification

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p tickvault-common --lib` — 675 pass
- [x] `cargo test -p tickvault-storage --lib` — 1612 pass
- [x] `cargo test -p tickvault-core --lib` — 3602 pass, 3 ignored
- [x] `cargo test -p tickvault-core --test gap_enforcement` — 121 pass (was 120 + 1 fail before)
- [x] `cargo test -p tickvault-app --lib` — 524 pass
- [x] `bash .claude/hooks/banned-pattern-scanner.sh` — exit 0

## What this does NOT change

- No prod logic edits — cleanup + struct syntax + doc reflow only
- No alert / metric / Telegram changes
- No hot-path code touched
- Does NOT change CI's clippy invocation. Tightening CI clippy from `--workspace --no-deps` to `--workspace --all-targets -- -D warnings` is a separate decision for the operator (would also pin the strict bar going forward).

## Honest envelope (per `wave-4-shared-preamble.md` Section 8)

100% inside the strict-clippy + test-suite envelope, with ratcheted regression coverage: workspace clippy at the strictest setting is now zero-warning, and the I-P0-06 ratchet test is now actually verifying what its docstring claims.

https://claude.ai/code/session_01K4pdLarMpZBRtCYX26TCci


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4pdLarMpZBRtCYX26TCci)_