### PR TITLE
fix(api): silence /favicon.ico WARN spam + adaptive option-chain polling

### DIFF
--- a/crates/api/src/handlers/static_file.rs
+++ b/crates/api/src/handlers/static_file.rs
@@ -40,6 +40,16 @@ pub async fn portal() -> impl IntoResponse {
     )
 }
 
+/// GET /favicon.ico — returns 204 No Content so browser auto-fetches don't
+/// hit the auth-layer fallback and emit a `GAP-SEC-01: missing Authorization`
+/// WARN per portal page load. The 204 response is cached by browsers.
+pub async fn favicon() -> impl IntoResponse {
+    (
+        StatusCode::NO_CONTENT,
+        [(header::CACHE_CONTROL, "public, max-age=86400")],
+    )
+}
+
 /// GET /portal/market-dashboard — serves the live Market Dashboard.
 // TEST-EXEMPT: static HTML serving — tested via pattern tests below
 pub async fn market_dashboard() -> impl IntoResponse {
@@ -158,6 +168,57 @@ mod tests {
     async fn test_options_chain_handler_returns_ok() {
         let response = options_chain().await.into_response();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_favicon_returns_204_no_content() {
+        // Browsers auto-fetch /favicon.ico on every portal page load.
+        // The handler MUST return 204 (not 401, not 404) so the request
+        // bypasses the auth-layer fallback that produced
+        // `WARN GAP-SEC-01: missing Authorization` once per page load.
+        let response = favicon().await.into_response();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_favicon_sets_cache_control_header() {
+        // 24h browser cache prevents repeat fetches per page navigation.
+        let response = favicon().await.into_response();
+        let cache_control = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            cache_control.contains("max-age="),
+            "favicon must set Cache-Control max-age, got: {cache_control:?}"
+        );
+    }
+
+    #[test]
+    fn test_options_chain_html_uses_adaptive_polling_cadence() {
+        // Regression: PR introducing this ratchet replaced the fixed-5s
+        // setInterval with adaptive polling that backs off to 60s on 404
+        // (typical on non-trading days / fresh boots — eliminates the
+        // 12 404s/min spam in the API log). The fast/slow constants must
+        // both remain in the HTML; the fixed `REFRESH_INTERVAL = 5000`
+        // literal must NOT regress.
+        assert!(
+            OPTIONS_CHAIN_HTML.contains("REFRESH_INTERVAL_FAST_MS"),
+            "options-chain.html must declare REFRESH_INTERVAL_FAST_MS for in-market cadence"
+        );
+        assert!(
+            OPTIONS_CHAIN_HTML.contains("REFRESH_INTERVAL_SLOW_MS"),
+            "options-chain.html must declare REFRESH_INTERVAL_SLOW_MS for 404-backoff cadence"
+        );
+        assert!(
+            !OPTIONS_CHAIN_HTML.contains("setInterval(loadOptionChain"),
+            "options-chain.html must NOT use a fixed setInterval — use scheduleNextRefresh()"
+        );
+        assert!(
+            OPTIONS_CHAIN_HTML.contains("scheduleNextRefresh"),
+            "options-chain.html must use scheduleNextRefresh() so 404 → 60s back-off works"
+        );
     }
 
     #[test]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -95,6 +95,17 @@ pub fn build_router_with_auth(
             "/health",
             axum::routing::get(handlers::health::health_check),
         )
+        // Browsers auto-fetch /favicon.ico on every portal page load. Without
+        // an explicit handler, axum's merge of public + protected routers
+        // routes unmatched paths through the protected router's auth-layer
+        // fallback, producing a `WARN GAP-SEC-01: missing Authorization`
+        // entry per page load. Returning 204 No Content here short-circuits
+        // before that fallback. Browsers cache the empty response, so the
+        // request usually fires once per session.
+        .route(
+            "/favicon.ico",
+            axum::routing::get(handlers::static_file::favicon),
+        )
         .route("/api/stats", axum::routing::get(handlers::stats::get_stats))
         .route(
             "/api/quote/{security_id}",

--- a/crates/api/static/options-chain.html
+++ b/crates/api/static/options-chain.html
@@ -829,8 +829,16 @@
         const API_URL = '/api';
         const API_OPTION_CHAIN_PATH = '/api/option-chain';
         const API_PCR_PATH = '/api/pcr';
-        const REFRESH_INTERVAL = 5000;
+        // Refresh cadence — adaptive. FAST is the in-market polling rate; SLOW
+        // kicks in when the backend returns 404 (no greeks data yet — typical
+        // on non-trading days, fresh boots, or off-hours) so we don't generate
+        // 12 404s/min in the API logs. The page returns to FAST as soon as
+        // any 200 response arrives.
+        const REFRESH_INTERVAL_FAST_MS = 5000;
+        const REFRESH_INTERVAL_SLOW_MS = 60000;
         const LOT_SIZE = 65;
+        let currentRefreshIntervalMs = REFRESH_INTERVAL_FAST_MS;
+        let refreshTimerId = null;
 
         let currentUnderlying = 'NIFTY';
         let currentExpiry = '2026-04-13';
@@ -849,9 +857,24 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             loadOptionChain();
-            setInterval(loadOptionChain, REFRESH_INTERVAL);
+            scheduleNextRefresh();
             updateConnectionStatus();
         });
+
+        function scheduleNextRefresh() {
+            if (refreshTimerId !== null) clearTimeout(refreshTimerId);
+            refreshTimerId = setTimeout(async () => {
+                await loadOptionChain();
+                scheduleNextRefresh();
+            }, currentRefreshIntervalMs);
+        }
+
+        function setRefreshInterval(ms) {
+            if (ms === currentRefreshIntervalMs) return;
+            currentRefreshIntervalMs = ms;
+            // Reschedule the next tick at the new cadence.
+            scheduleNextRefresh();
+        }
 
         function setupEventListeners() {
             document.getElementById('nextExpiryBtn').addEventListener('click', toggleExpiryDropdown);
@@ -877,14 +900,29 @@
         async function loadOptionChain() {
             try {
                 const response = await fetch(`${API_URL}/option-chain?underlying=${currentUnderlying}&expiry=${currentExpiry}`);
-                const result = await response.json();
 
-                if (result.error) {
+                // 404 = greeks pipeline hasn't populated dhan_option_chain_raw yet
+                // (non-trading day, fresh boot, off-hours). Slow the polling
+                // cadence so the API log isn't dominated by 404s. The page
+                // returns to fast polling as soon as a 200 arrives.
+                if (response.status === 404) {
+                    setRefreshInterval(REFRESH_INTERVAL_SLOW_MS);
                     showNoData();
                     updateConnectionStatus(false);
                     return;
                 }
 
+                const result = await response.json();
+
+                if (result.error) {
+                    setRefreshInterval(REFRESH_INTERVAL_SLOW_MS);
+                    showNoData();
+                    updateConnectionStatus(false);
+                    return;
+                }
+
+                // Successful 200 — back to fast in-market cadence.
+                setRefreshInterval(REFRESH_INTERVAL_FAST_MS);
                 optionChainData = result.data;
                 spotPrice = result.data.spot_price;
                 populateExpiryTabs(result.data.available_expiries);
@@ -892,6 +930,10 @@
                 loadPCR();
                 updateConnectionStatus(true);
             } catch (error) {
+                // Network error — also back off (the next 60s poll won't fix
+                // the underlying connectivity issue, but at least the page
+                // doesn't hammer the server).
+                setRefreshInterval(REFRESH_INTERVAL_SLOW_MS);
                 console.error('Failed to load option chain:', error);
                 updateConnectionStatus(false);
             }


### PR DESCRIPTION
## Summary

Two operator-visible noise sources observed in today's live boot log (2026-05-03 11:16 IST), both fixed in this PR. Pure cleanup — no prod logic changes.

### 1. `/favicon.ico` 401 + WARN per portal page load

Every portal page navigation triggered:
```
WARN GAP-SEC-01: API auth failed — missing Authorization header
GET /favicon.ico → 401
```

Root cause: `/favicon.ico` was unmatched by both routers; axum's merge routed unmatched paths through the auth-protected router's auth-layer fallback. Fix: explicit `GET /favicon.ico → 204 No Content` handler in `public_routes` with `Cache-Control: max-age=86400`. Short-circuits before auth.

### 2. `/api/option-chain` 404 every 5s on non-trading days

The portal page polled at a fixed 5-second cadence regardless of response. On non-trading days the handler correctly returns 404 — but 12 404s/min was spamming the API log.

Fix: replaced fixed `setInterval` with adaptive `scheduleNextRefresh()`:

| Response | Next-poll cadence |
|---|---|
| 200 OK | FAST = 5s (in-market, unchanged) |
| 404 / `result.error` / network error | SLOW = 60s (back off) |

Returns to FAST instantly on a 200. Eliminates the 720 404s/hour off-hours floor.

## Test plan

- [x] `cargo test -p tickvault-api` — 381 tests pass (3 new ratchets):
  - `test_favicon_returns_204_no_content`
  - `test_favicon_sets_cache_control_header`
  - `test_options_chain_html_uses_adaptive_polling_cadence` (regression guard against re-introducing the fixed setInterval)
- [x] `cargo clippy -p tickvault-api --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash .claude/hooks/banned-pattern-scanner.sh` — exit 0
- [ ] Operator restarts the running app, verifies:
  - No `WARN GAP-SEC-01` on portal page load
  - API log shows ~1 `/api/option-chain` request per minute outside market hours instead of 1 per 5 seconds

## What this does NOT change

- No prod logic edits — purely two cleanup paths
- Auth middleware behaviour unchanged for any actual API endpoint (`/api/instruments/rebuild` still requires bearer token)
- In-market portal cadence unchanged (FAST = 5s on 200 response)
- No new metrics, alerts, or Telegram events

https://claude.ai/code/session_01K4pdLarMpZBRtCYX26TCci


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4pdLarMpZBRtCYX26TCci)_