### PR TITLE
fix(config): apply M1+M2 from PR #445 hostile-bug-hunt — cohort_size alias + min_volume upper bound

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -148,6 +148,24 @@ impl DepthDynamicConfig {
                  audit-2026-05-03 operator clarification"
             );
         }
+        // Audit-2026-05-03 PR #447 — hostile-bug-hunt M2 fix: cap
+        // `min_liquidity_volume` at `i64::MAX as u64` to prevent the
+        // operator-misconfig path where a value > QuestDB LONG range
+        // produces a structurally-unsatisfiable SQL predicate
+        // (`volume >= 18446744073709551615`) → zero-row cohort EVERY
+        // cycle → `next_set` empty forever → silent depth-subscription
+        // outage. The QuestDB `volume` column is a LONG (i64) so any
+        // value above `i64::MAX` cannot match a real row.
+        const MAX_LIQUIDITY_VOLUME: u64 = i64::MAX as u64;
+        if self.universe.min_liquidity_volume > MAX_LIQUIDITY_VOLUME {
+            bail!(
+                "{label}.dynamic.universe.min_liquidity_volume = {} exceeds QuestDB LONG range cap of {} \
+                 — values above i64::MAX produce a structurally-unsatisfiable SQL predicate \
+                 → zero-row cohort forever. Typical floors are 10_000-100_000.",
+                self.universe.min_liquidity_volume,
+                MAX_LIQUIDITY_VOLUME,
+            );
+        }
         if self.universe.window_secs == 0 {
             bail!("{label}.dynamic.universe.window_secs must be > 0");
         }
@@ -198,7 +216,17 @@ pub struct DepthDynamicUniverseConfig {
     /// fall back to `default_min_liquidity_volume()` rather than
     /// failing figment deserialisation. Audit-2026-05-03
     /// security-reviewer LOW #2 — defensive hardening.
-    #[serde(default = "default_min_liquidity_volume")]
+    ///
+    /// Audit-2026-05-03 PR #447 — hostile-bug-hunt M1 fix: also
+    /// accept the legacy field name `cohort_size` via `serde(alias)`.
+    /// Operators with pre-#445 environment override files (which had
+    /// `cohort_size = 500`) will now have that value parsed into
+    /// `min_liquidity_volume = 500` instead of silently falling back
+    /// to the default. The boot-time `assert_invariants` will then
+    /// catch the unrealistically-low value (< MIN_LIQUIDITY_VOLUME_FLOOR
+    /// after the threshold check) and bail with a clear error pointing
+    /// the operator to the new field name + valid range.
+    #[serde(default = "default_min_liquidity_volume", alias = "cohort_size")]
     pub min_liquidity_volume: u64,
     /// Re-rank metric. Reserved for future use; `select_top_k_dynamic`
     /// always sorts by `change_pct DESC`.
@@ -2758,6 +2786,71 @@ mod tests {
             ..DepthDynamicConfig::default()
         };
         assert!(cfg.assert_invariants("depth_20", 5).is_ok());
+    }
+
+    /// Audit-2026-05-03 PR #447 (hostile-bug-hunt M1 fix) ratchet:
+    /// the `cohort_size` legacy field name MUST still parse via
+    /// `serde(alias)` so pre-#445 environment override files don't
+    /// silently fall back to the default. The aliased value lands in
+    /// `min_liquidity_volume` and goes through `assert_invariants`.
+    #[test]
+    fn test_depth_dynamic_universe_config_accepts_legacy_cohort_size_via_alias() {
+        use figment::Figment;
+        use figment::providers::{Format, Toml};
+
+        // Operator has a stale config with `cohort_size = 100_000`
+        // (pre-#445 naming). Should parse into min_liquidity_volume.
+        let toml = r#"
+            exchange_segments = ["NSE_FNO"]
+            cohort_size = 100000
+            window_secs = 60
+        "#;
+        let cfg: DepthDynamicUniverseConfig = Figment::new()
+            .merge(Toml::string(toml))
+            .extract()
+            .expect("legacy cohort_size alias must parse");
+        assert_eq!(
+            cfg.min_liquidity_volume, 100_000,
+            "cohort_size value must land in min_liquidity_volume via serde alias"
+        );
+    }
+
+    /// Audit-2026-05-03 PR #447 (hostile-bug-hunt M2 fix) ratchet:
+    /// `min_liquidity_volume` MUST be capped at `i64::MAX as u64`
+    /// because the QuestDB `volume` column is LONG (i64) — values
+    /// above this produce a structurally-unsatisfiable SQL predicate.
+    #[test]
+    fn test_depth_dynamic_config_rejects_min_liquidity_volume_above_i64_max() {
+        let cfg = DepthDynamicConfig {
+            universe: DepthDynamicUniverseConfig {
+                // u64::MAX is ~2x i64::MAX — must reject
+                min_liquidity_volume: u64::MAX,
+                ..DepthDynamicConfig::default().universe
+            },
+            ..DepthDynamicConfig::default()
+        };
+        let err = cfg.assert_invariants("depth_20", 5).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exceeds QuestDB LONG range cap"),
+            "must reject u64::MAX with explicit error, got: {msg}"
+        );
+    }
+
+    /// Boundary test: i64::MAX as u64 (exactly the cap) MUST be accepted.
+    #[test]
+    fn test_depth_dynamic_config_accepts_min_liquidity_volume_at_i64_max() {
+        let cfg = DepthDynamicConfig {
+            universe: DepthDynamicUniverseConfig {
+                min_liquidity_volume: i64::MAX as u64,
+                ..DepthDynamicConfig::default().universe
+            },
+            ..DepthDynamicConfig::default()
+        };
+        assert!(
+            cfg.assert_invariants("depth_20", 5).is_ok(),
+            "i64::MAX boundary must be acceptable"
+        );
     }
 
     /// Audit-2026-05-03: redesign retired the `cohort_size` field +


### PR DESCRIPTION
## Goal

Close the 2 deferred MEDIUMs from PR #445's adversarial bug-hunt review.

| Finding | Severity | Source |
|---|---|---|
| M1 | MED | PR #445 hostile-bug-hunt — `cohort_size` field rename caused silent fallback for legacy override files |
| M2 | MED | PR #445 hostile-bug-hunt — `min_liquidity_volume = u64::MAX` produces zero-row cohort forever |

## Changes

### M1 — `cohort_size` legacy alias
`crates/common/src/config.rs::DepthDynamicUniverseConfig::min_liquidity_volume`:
- Added `#[serde(alias = "cohort_size")]`
- Pre-#445 environment override files containing `cohort_size = N` now parse into `min_liquidity_volume = N`
- Boot-time `assert_invariants` then catches out-of-range values with explicit error pointing to the new field name

### M2 — `min_liquidity_volume` upper bound
`crates/common/src/config.rs::DepthDynamicConfig::assert_invariants`:
- Added `MAX_LIQUIDITY_VOLUME = i64::MAX as u64` cap
- QuestDB `volume` column is LONG (i64) — values above this produce structurally-unsatisfiable SQL predicate → zero-row cohort forever
- Explicit error message points to QuestDB LONG range constraint

## Ratchet tests added (3 new)

| Test | What it pins |
|---|---|
| `test_depth_dynamic_universe_config_accepts_legacy_cohort_size_via_alias` | Legacy `cohort_size = 100_000` parses into `min_liquidity_volume = 100_000` |
| `test_depth_dynamic_config_rejects_min_liquidity_volume_above_i64_max` | `u64::MAX` rejected with explicit "exceeds QuestDB LONG range cap" message |
| `test_depth_dynamic_config_accepts_min_liquidity_volume_at_i64_max` | Boundary: exactly `i64::MAX as u64` is acceptable |

## Honest scope split (post-#447 roadmap)

The PR #445 review also flagged a need to migrate `/api/market/stock-movers` + `/api/market/option-movers` to `movers_5s` BEFORE the legacy `stock_movers`/`option_movers` table DROP migration is wired. During PR #447 planning I discovered the legacy tables have richer schemas (`rank`, `symbol`, `contract_name`, `strike`, `expiry`, `spot_price`, `oi_change_pct`) that `movers_5s` doesn't expose without view-schema extension or per-row JOIN. That work is genuinely 2 PRs:

| Future PR | Scope |
|---|---|
| **#448** | Migrate `/api/market/stock-movers` to `movers_5s` SQL (simpler — equity columns map cleanly) |
| **#449** | Migrate `/api/market/option-movers` (needs view-schema extension OR JOIN with `derivative_contracts`) + wire DROP migration |
| **#450** | Delete in-memory trackers + final rename `movers_base_*` → `movers_*` |
| **#451** | Tick rescue ring 600K → 4.5M (500MB) — operator-requested for extreme memory pressure |
| **#452** | 8:15 AM ready boot orchestrator |
| **#453** | 90-day historical pre-warmup |
| **#454** | Depth M3 doc + ratchet |

## Test plan

- [x] 13/13 depth_dynamic config tests pass (3 new ratchets)
- [x] `cargo fmt` clean
- [ ] CI green (Build, all 6 crate tests, Security & Audit, Mutation, Lint)
- [ ] 3-agent adversarial review (hot-path + security + general-purpose) — running

https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS)_