### PR TITLE
perf(storage): bump tick rescue ring 600K → 2M (224 MB) for extreme outage handling

### DIFF
--- a/.claude/rules/project/per-wave-guarantee-matrix.md
+++ b/.claude/rules/project/per-wave-guarantee-matrix.md
@@ -46,7 +46,7 @@ checklist or in a dedicated "Per-Item Guarantee Matrix" subsection:
 
 | Demand | Honest envelope | Per-item proof |
 |---|---|---|
-| Zero ticks lost | Bounded zero loss inside chaos envelope: ring 600K → spill NDJSON → DLQ | item must not introduce new tick-drop path |
+| Zero ticks lost | Bounded zero loss inside chaos envelope: ring 2M → spill NDJSON → DLQ | item must not introduce new tick-drop path |
 | WS never disconnects | DETECT ≤5s, reconnect with `SubscribeRxGuard`, sleep-until-open post-close | item must not break SubscribeRxGuard or pool watchdog |
 | Never slow/locked/hanged | DHAT ≤4 alloc blocks/8KB across 10K calls; Criterion p99 ≤100ns; tick-gap >30s Telegram; core_affinity Core 0 | item must not add hot-path allocation |
 | QuestDB never fails | ABSORB via 3-tier rescue→spill→DLQ + schema self-heal | item must not break self-heal |
@@ -60,12 +60,12 @@ When any plan / PR / commit body uses the phrase "100% guarantee", it MUST be
 qualified exactly:
 
 > "100% inside the tested envelope, with ratcheted regression coverage:
-> ≤60s QuestDB outage absorbed by rescue→spill→DLQ; ≤600,000-tick ring
-> buffer capacity (constant `TICK_BUFFER_CAPACITY`,
+> ≤60s QuestDB outage absorbed by rescue→spill→DLQ;
+> ≤2,000,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`,
 > `crates/common/src/constants.rs`, ratcheted by
 > `crates/storage/tests/zero_tick_loss_alert_guard.rs`); bench-gated
-> O(1) hot path; composite-key uniqueness; chaos-tested 65h Fri 16:00
-> IST → Mon 09:00 IST weekend sleep/wake
+> O(1) hot path; composite-key uniqueness;
+> chaos-tested 65h Fri 16:00 IST → Mon 09:00 IST weekend sleep/wake
 > (`crates/core/tests/ws_sleep_resilience.rs`). Beyond the envelope,
 > DLQ NDJSON catches every payload as recoverable text. Outstanding
 > (Wave-6): >65h holiday-weekend dormant sleep test (W6-2)."

--- a/.claude/rules/project/wave-4-shared-preamble.md
+++ b/.claude/rules/project/wave-4-shared-preamble.md
@@ -232,12 +232,12 @@ Aspirational claims like "I tried hard" = REJECT IN REVIEW.
 When the PR description quotes "100% guarantee", it MUST be phrased exactly:
 
 > "100% inside the tested envelope, with ratcheted regression coverage:
-> <= 60s QuestDB outage absorbed by rescue->spill->DLQ; <= 600,000-tick
-> ring buffer capacity (constant `TICK_BUFFER_CAPACITY`,
+> <= 60s QuestDB outage absorbed by rescue->spill->DLQ;
+> <= 2,000,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`,
 > `crates/common/src/constants.rs`, ratcheted by
 > `crates/storage/tests/zero_tick_loss_alert_guard.rs`); bench-gated
-> O(1) hot path; composite-key uniqueness; chaos-tested 65h Fri 16:00
-> IST -> Mon 09:00 IST weekend sleep/wake
+> O(1) hot path; composite-key uniqueness;
+> chaos-tested 65h Fri 16:00 IST -> Mon 09:00 IST weekend sleep/wake
 > (`crates/core/tests/ws_sleep_resilience.rs`). Beyond the envelope,
 > DLQ NDJSON catches every payload as recoverable text."
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1328,7 +1328,7 @@ async fn main() -> Result<()> {
                 .map(|p| std::sync::Arc::new(p.registry.clone()));
 
             // CRITICAL: Use new_disconnected() instead of None — ticks buffer in
-            // ring buffer (600K) + disk spill immediately, even before QuestDB connects.
+            // ring buffer (2M, PR #452 bumped from 600K) + disk spill immediately, even before QuestDB connects.
             // Without this, the only persistence path is the broadcast cold-path consumer,
             // which CAN drop ticks on lag (broadcast::Lagged). With new_disconnected(),
             // the hot-path writer buffers ALL ticks and drains when QuestDB is ready.
@@ -8153,7 +8153,7 @@ async fn run_tick_persistence_consumer(
                 // C2: CRITICAL — ticks permanently lost due to broadcast lag.
                 // This fires ERROR log → Loki → Telegram alert automatically.
                 // Root cause: QuestDB ILP flush is slower than tick ingestion rate.
-                // Defense: broadcast capacity 262K + tick writer ring buffer 600K + disk spill.
+                // Defense: broadcast capacity 262K + tick writer ring buffer 2M (PR #452) + disk spill.
                 error!(
                     skipped,
                     "CRITICAL: cold-path tick persistence lagged — {} ticks permanently lost",

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -1418,17 +1418,39 @@ pub const TICK_FLUSH_INTERVAL_MS: u64 = 1000;
 /// Holds ticks in memory when QuestDB is down, drains on recovery.
 ///
 /// Sized for 25K instruments (5 WS connections × 5,000 each):
-/// - 600,000 ticks × ~112 bytes = ~64MB RAM
-/// - At 10K ticks/sec (realistic peak) = 60 seconds before disk spill
-/// - At 25K ticks/sec (extreme peak) = 24 seconds before disk spill
+/// - 2,000,000 ticks × ~112 bytes = ~224 MB RAM (pre-allocated at boot
+///   via `VecDeque::with_capacity` in `tick_persistence.rs`)
+/// - At 10K ticks/sec (realistic peak) = 200 seconds (3m20s) before disk spill
+/// - At 25K ticks/sec (extreme peak) = 80 seconds before disk spill
 /// - Full-day QuestDB outage: disk spill handles overflow (~23 GB for 10K/sec)
-pub const TICK_BUFFER_CAPACITY: usize = 600_000;
+///
+/// **Memory budget audit (2026-05-03 PR #452):** AWS c7i.xlarge has
+/// 8 GB total. Per `aws-budget.md` the Docker containers consume
+/// 7.4 GB (QuestDB 4G + Valkey 1G + Prometheus 512M + Grafana 1G +
+/// Alertmanager 256M + Traefik 512M + Valkey-exporter 128M),
+/// leaving ~600 MB for OS + tickvault binary. The 224 MB ring fits
+/// comfortably with ~376 MB margin for the rest of the binary + OS.
+///
+/// **Why 2M (not 4.5M)**: operator-confirmed cap on c7i.xlarge —
+/// 4.5M / 504 MB ring would leave only ~96 MB for OS + rest of
+/// binary, too tight. Operator chose Option B (2M / 224 MB) over
+/// Option A (1M / 112 MB) for higher outage-survival headroom while
+/// staying within the c7i.xlarge envelope. Bumping to c7i.2xlarge
+/// (16 GB) would cost an extra ₹2,478/mo per `aws-budget.md` and
+/// is explicitly out of scope per "NEVER provision a larger
+/// instance than c7i.xlarge without Parthiban's approval".
+///
+/// **Bump history:**
+/// - 600K → 2M (PR #452, 2026-05-03): operator-spec'd extreme
+///   memory pressure handling. 233% capacity increase. ~3.3× outage
+///   survival window before disk spill kicks in.
+pub const TICK_BUFFER_CAPACITY: usize = 2_000_000;
 
 /// High watermark threshold for tick ring buffer (80% of capacity).
 /// When buffer occupancy exceeds this, a WARN-level alert fires once
 /// to signal imminent disk spill. Triggers Telegram via Loki ERROR rule.
-/// 80% of 600,000 = 480,000 ticks.
-pub const TICK_BUFFER_HIGH_WATERMARK: usize = TICK_BUFFER_CAPACITY * 4 / 5; // 480,000
+/// 80% of 2,000,000 = 1,600,000 ticks.
+pub const TICK_BUFFER_HIGH_WATERMARK: usize = TICK_BUFFER_CAPACITY * 4 / 5; // 1,600,000
 
 /// Minimum free disk space (bytes) to log a warning before spill write.
 /// 100 MB — below this, a WARN fires on each spill open to alert operator

--- a/crates/common/tests/wave4_section8_wording_guard.rs
+++ b/crates/common/tests/wave4_section8_wording_guard.rs
@@ -7,8 +7,13 @@
 //! the §8 prior wording cited "≤600K rescue ring capacity" and
 //! "chaos-tested 70h sleep/wake" without locatable code/test evidence.
 //!
+//! 2026-05-03 (PR #452): rescue ring capacity bumped 600K → 2M (224 MB
+//! pre-allocated VecDeque) per operator-spec'd extreme memory pressure
+//! handling. Wording in `wave-4-shared-preamble.md` + `per-wave-guarantee-matrix.md`
+//! updated to "2,000,000-tick" in tandem.
+//!
 //! After investigation:
-//! - `TICK_BUFFER_CAPACITY = 600_000` exists in
+//! - `TICK_BUFFER_CAPACITY = 2_000_000` exists in
 //!   `crates/common/src/constants.rs` and is ratcheted by
 //!   `crates/storage/tests/zero_tick_loss_alert_guard.rs`.
 //! - The 65h Fri 16:00 → Mon 09:00 IST weekend sleep/wake test
@@ -50,16 +55,17 @@ fn section8_does_not_claim_unproven_70h_chaos() {
 }
 
 #[test]
-fn section8_keeps_600k_rescue_ring_claim_with_evidence_pointer() {
+fn section8_keeps_2m_rescue_ring_claim_with_evidence_pointer() {
     for (label, path) in [("preamble", PREAMBLE_PATH), ("matrix", MATRIX_PATH)] {
         let text = read(path);
-        // The 600_000-tick ring buffer claim must remain because it IS
-        // proven, AND it must cite the constant + ratchet test so
-        // future readers can verify the proof in one grep.
+        // PR #452 (2026-05-03): rescue ring bumped 600K → 2M. The
+        // claim must cite the constant + ratchet test so future
+        // readers can verify the proof in one grep.
         assert!(
-            text.contains("600,000-tick ring buffer capacity"),
-            "{label} ({path}) must keep the proven 600,000-tick ring \
-             buffer capacity claim with the new precise wording."
+            text.contains("2,000,000-tick ring buffer capacity"),
+            "{label} ({path}) must keep the proven 2,000,000-tick ring \
+             buffer capacity claim (PR #452 bumped 600K → 2M for \
+             extreme memory pressure handling)."
         );
         assert!(
             text.contains("`TICK_BUFFER_CAPACITY`"),
@@ -69,7 +75,7 @@ fn section8_keeps_600k_rescue_ring_claim_with_evidence_pointer() {
         assert!(
             text.contains("zero_tick_loss_alert_guard.rs"),
             "{label} ({path}) must cite the ratchet test that pins the \
-             600,000 value."
+             2,000,000 value."
         );
     }
 }

--- a/crates/storage/tests/chaos_burst_indices_only.rs
+++ b/crates/storage/tests/chaos_burst_indices_only.rs
@@ -19,15 +19,15 @@
 //! - A synthetic 200K-row VecDeque (the rescue ring's underlying type)
 //!   absorbs without panic — bounded memory, FIFO eviction.
 //! - The Wave 5 envelope numbers (11,018 instruments × ~10 pkts/sec ≈
-//!   ~110K tps) fit comfortably under the 600K ring capacity at >5s
-//!   QuestDB outage tolerance.
+//!   ~110K tps) fit comfortably under the 2M ring capacity (PR #452
+//!   bumped from 600K, 2026-05-03) at >18s QuestDB outage tolerance.
 //!
 //! What this test does NOT do:
 //! - Spin up a real QuestDB / parser / WS pipeline. The full burst test
 //!   requires Docker QuestDB + replay harness — see
 //!   `chaos_questdb_full_session.rs` for the integration path.
 //! - Promise "no drops ever". The honest envelope acknowledges that
-//!   beyond ~600K queued rows + spill capacity + DLQ, OS resources can
+//!   beyond ~2M queued rows + spill capacity + DLQ, OS resources can
 //!   exhaust. PROC-01 + RESOURCE-01..03 cover those.
 //!
 //! Run cost: ~10 ms. No Docker, no network, no root.
@@ -55,7 +55,7 @@ const WAVE_5_PEAK_TPS: usize = 110_180;
 /// Worst-case QuestDB outage the rescue ring should absorb without
 /// dropping a single row, per the plan's "≤60s outage absorbed" SLA.
 /// Result: 110,180 × 5 = 550,900 ticks queued at 5-second outage; the
-/// 600K ring covers it with 49,100 headroom.
+/// 2M ring (PR #452, was 600K) covers it with ~1.4M headroom.
 const WAVE_5_QUESTDB_OUTAGE_TOLERANCE_SECS: usize = 5;
 
 #[test]

--- a/crates/storage/tests/zero_tick_loss_alert_guard.rs
+++ b/crates/storage/tests/zero_tick_loss_alert_guard.rs
@@ -124,7 +124,9 @@ fn tick_persistence_emits_spill_dropped_total_with_reason_label() {
 fn tick_persistence_buffer_capacity_is_at_least_one_lakh() {
     // TICK_BUFFER_CAPACITY must stay above 100K to absorb normal market
     // bursts without spill-to-disk. The exact floor is 100_000; current
-    // value is 600_000 per the docstring. Checked via constant reference
+    // value is 2_000_000 per the docstring (PR #452 2026-05-03 bumped
+    // 600_000 → 2_000_000 for extreme memory pressure handling within
+    // the c7i.xlarge 600 MB OS budget). Checked via constant reference
     // in source.
     let common_constants = load_text("crates/common/src/constants.rs");
 


### PR DESCRIPTION
## Summary

Bumps `TICK_BUFFER_CAPACITY` 600,000 → 2,000,000 ticks per operator spec for extreme outage memory pressure handling.

| Aspect | Before | After |
|---|---|---|
| Capacity | 600,000 ticks | 2,000,000 ticks (+233%) |
| Pre-allocated memory | ~64 MB | ~224 MB |
| Outage survival @ 10K tps | 60s | 200s (3m20s) |
| Outage survival @ 25K tps | 24s | 80s |
| `TICK_BUFFER_HIGH_WATERMARK` (80%) | 480,000 | 1,600,000 |

## Memory budget audit (c7i.xlarge)

Per `.claude/rules/project/aws-budget.md`:

| Resource | c7i.xlarge (8 GB) |
|---|---|
| Docker containers | 7.4 GB |
| Free for OS + tickvault | 600 MB |
| 224 MB ring fits with | ~376 MB margin |

**Operator chose Option B (2M / 224 MB)** over:
- Option A (1M / 112 MB) — too cautious
- Option C (4.5M / 504 MB) — wouldn't fit c7i.xlarge (only 96 MB free)

## Changes

- `crates/common/src/constants.rs` — constant + docstring with budget audit + bump history
- `crates/common/tests/wave4_section8_wording_guard.rs` — assertions updated to "2,000,000-tick" + renamed `_600k_` → `_2m_`
- `.claude/rules/project/wave-4-shared-preamble.md` §8 — honest 100% claim wording
- `.claude/rules/project/per-wave-guarantee-matrix.md` — 7-row resilience matrix + §7 honest claim
- `crates/storage/tests/zero_tick_loss_alert_guard.rs` — comment update (assertion stays `>= 100_000`)
- `crates/storage/tests/chaos_burst_indices_only.rs` — module docstring + comment updates
- `crates/app/src/main.rs` — 2 inline comments

## Test plan

- [x] `cargo check --workspace` GREEN
- [x] `cargo test --workspace --lib` 1225/1225 GREEN
- [x] `cargo test -p tickvault-common --test wave4_section8_wording_guard` 5/5 GREEN
- [x] `cargo test -p tickvault-storage --test zero_tick_loss_alert_guard` 8/8 GREEN
- [x] `cargo fmt --all` clean

## Notes

- Commits unsigned per operator authorization (signing server returning HTTP 400 "missing source")
- `TICK_BUFFER_HIGH_WATERMARK` auto-derives from `TICK_BUFFER_CAPACITY * 4 / 5` — no manual update needed
- The hot-path tick processor logic is unchanged (same `VecDeque::with_capacity()` call site, just larger constant)
- DHAT zero-alloc guarantee preserved: ring is pre-allocated at boot, runtime push/pop is O(1) without allocation

https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS)_