### PR TITLE
security: redact QuestDB URL from reqwest::Error in Loki logs

### DIFF
--- a/crates/api/src/handlers/market_data.rs
+++ b/crates/api/src/handlers/market_data.rs
@@ -288,8 +288,15 @@ fn unwrap_or_log(
     match result {
         Ok(v) => v,
         Err(err) => {
+            // PR #455 (2026-05-04) MEDIUM-fix: `?err` Debug formatter
+            // can embed wrapped reqwest URL (containing internal
+            // QuestDB host:port) when anyhow's chain wraps a
+            // reqwest::Error. Use Display (`%err`) which only shows
+            // the top error message — no URL leak. Loss of wrapped
+            // chain context is acceptable; the explicit `code` field
+            // + list name are enough for triage.
             tracing::error!(
-                ?err,
+                error = %err,
                 list = list_name,
                 code = "API-MOVERS-01",
                 "QuestDB query for /api/market/stock-movers list failed"
@@ -503,8 +510,12 @@ pub async fn get_option_movers(
     {
         Ok(r) => r,
         Err(err) => {
+            // PR #455 (2026-05-04) MEDIUM-fix: strip URL from reqwest error
+            // before formatting (Display embeds URL containing internal
+            // QuestDB host:port).
+            let err = err.without_url();
             tracing::error!(
-                ?err,
+                error = %err,
                 code = "API-MOVERS-02",
                 "QuestDB query for /api/market/option-movers failed"
             );
@@ -519,8 +530,10 @@ pub async fn get_option_movers(
     let body: serde_json::Value = match resp.json().await {
         Ok(v) => v,
         Err(err) => {
+            // PR #455: same URL redaction.
+            let err = err.without_url();
             tracing::error!(
-                ?err,
+                error = %err,
                 code = "API-MOVERS-02",
                 "Failed to parse QuestDB JSON response for /api/market/option-movers"
             );

--- a/crates/api/src/handlers/movers.rs
+++ b/crates/api/src/handlers/movers.rs
@@ -480,7 +480,12 @@ pub async fn get_movers(
     {
         Ok(c) => c,
         Err(err) => {
-            tracing::error!(?err, code = "MOVERS-04", "build reqwest client failed");
+            // PR #455 (2026-05-04) MEDIUM-fix: `?err` Debug formatter
+            // embeds reqwest URL (containing internal QuestDB host:port)
+            // in Loki structured logs. Use `.without_url()` to strip
+            // the URL before formatting via Display.
+            let err = err.without_url();
+            tracing::error!(error = %err, code = "MOVERS-04", "build reqwest client failed");
             return service_unavailable("client_build_failed");
         }
     };
@@ -493,7 +498,9 @@ pub async fn get_movers(
     {
         Ok(r) => r,
         Err(err) => {
-            tracing::error!(?err, code = "MOVERS-04", "QuestDB /exec request failed");
+            // PR #455: same URL redaction as above.
+            let err = err.without_url();
+            tracing::error!(error = %err, code = "MOVERS-04", "QuestDB /exec request failed");
             return service_unavailable("questdb_unreachable");
         }
     };
@@ -507,7 +514,9 @@ pub async fn get_movers(
     let body: serde_json::Value = match resp.json().await {
         Ok(v) => v,
         Err(err) => {
-            tracing::error!(?err, code = "MOVERS-05", "QuestDB JSON parse failed");
+            // PR #455: same URL redaction.
+            let err = err.without_url();
+            tracing::error!(error = %err, code = "MOVERS-05", "QuestDB JSON parse failed");
             return service_unavailable("questdb_parse_failed");
         }
     };
@@ -710,7 +719,9 @@ pub async fn get_expiries(
     {
         Ok(c) => c,
         Err(err) => {
-            tracing::error!(?err, code = "MOVERS-06", "build reqwest client failed");
+            // PR #455: see movers.rs:483 fix — strip URL from reqwest error.
+            let err = err.without_url();
+            tracing::error!(error = %err, code = "MOVERS-06", "build reqwest client failed");
             return service_unavailable("client_build_failed");
         }
     };
@@ -723,8 +734,10 @@ pub async fn get_expiries(
     {
         Ok(r) => r,
         Err(err) => {
+            // PR #455: same URL redaction.
+            let err = err.without_url();
             tracing::error!(
-                ?err,
+                error = %err,
                 code = "MOVERS-06",
                 "QuestDB /api/movers/expiries query failed"
             );
@@ -745,8 +758,10 @@ pub async fn get_expiries(
     let body: serde_json::Value = match resp.json().await {
         Ok(v) => v,
         Err(err) => {
+            // PR #455: same URL redaction.
+            let err = err.without_url();
             tracing::error!(
-                ?err,
+                error = %err,
                 code = "MOVERS-06",
                 "QuestDB JSON parse failed for /api/movers/expiries"
             );


### PR DESCRIPTION
## Summary

Closes the MEDIUM security finding from PR #449 + #450 adversarial reviews: `?err` Debug formatter on `reqwest::Error` embeds the request URL (containing internal QuestDB `host:port`) in Loki structured logs. Internal-network topology should not leak to log aggregators.

## Fix pattern

For 7 reqwest-error sites:
```rust
// Before — Debug includes URL
tracing::error!(?err, code = "MOVERS-04", "...");

// After — Display via .without_url()
let err = err.without_url();
tracing::error!(error = %err, code = "MOVERS-04", "...");
```

For 1 anyhow-wrapped site (`unwrap_or_log` helper):
```rust
// Before
tracing::error!(?err, ...);

// After — Display only shows top, not wrapped reqwest URL
tracing::error!(error = %err, ...);
```

Total **9 sites updated** across:
- `crates/api/src/handlers/movers.rs` — 6 sites (`get_movers` + `get_expiries`)
- `crates/api/src/handlers/market_data.rs` — 3 sites (`unwrap_or_log` + `get_option_movers`)

## Why no automated regression test

Verifying "Display does not contain URL" requires either patching reqwest internals (brittle), running a live HTTP request (CI flake), or snapshot-testing (fragile). The invariant is captured by inline comments + the explicit `.without_url()` line — future regressions show up as a code-review diff.

## Test plan

- [x] `cargo check -p tickvault-api` GREEN
- [x] `cargo test -p tickvault-api --lib` 342/342 GREEN
- [x] `cargo fmt --all` clean
- [x] ErrorCode taxonomy unchanged (`code = "MOVERS-04/05/06"` + `code = "API-MOVERS-01/02"` preserved verbatim)

## Notes

- Commits unsigned per operator authorization (signing server returning HTTP 400 "missing source")
- Builds on top of merged PR #454

https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS)_