### PR TITLE
feat(app): Option Chain REST previous_oi overlay for NIFTY/BANKNIFTY/SENSEX

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2695,11 +2695,20 @@ async fn main() -> Result<()> {
             // downstream movers_pipeline then operates with
             // `current_OI - 0 = current_OI` for OI Change — a
             // gracefully-degraded fallback rather than a HALT.
-            let prev_oi_cache = tickvault_app::prev_oi_loader::load_prev_oi_cache_at_boot(
-                registry,
-                trading_calendar.as_ref(),
-            )
-            .await;
+            // PR #456 (2026-05-04): boot calls the OVERLAY variant
+            // which runs bhavcopy first, then layers Dhan-canonical
+            // Option Chain `previous_oi` for NIFTY/BANKNIFTY/SENSEX
+            // on top (last-wins). Total boot cost: ~5-6 min bhavcopy
+            // + ~18s overlay (3 underlyings × 2 calls × 3s rate-limit).
+            let prev_oi_cache =
+                tickvault_app::prev_oi_loader::load_prev_oi_cache_at_boot_with_overlay(
+                    registry,
+                    trading_calendar.as_ref(),
+                    token_handle.clone(),
+                    ws_client_id.clone(),
+                    config.dhan.rest_api_base_url.clone(),
+                )
+                .await;
             if prev_oi_cache.is_empty() {
                 // The loader's internal error sites already emitted
                 // PREVOI-01. This WARN at the spawn site documents the

--- a/crates/app/src/prev_oi_loader.rs
+++ b/crates/app/src/prev_oi_loader.rs
@@ -243,11 +243,195 @@ pub async fn load_prev_oi_cache_at_boot(
         cache_size,
         bhavcopy_rows = nse_rows.len(),
         derivative_contracts = derivatives.len(),
-        "prev_oi loader: cache built successfully — /api/movers OI Change \
-         column will display Dhan-precise values"
+        "prev_oi loader: bhavcopy cache built successfully — \
+         /api/movers OI Change column will display Dhan-precise values \
+         (Option Chain REST overlay disabled at this call site; use \
+         load_prev_oi_cache_at_boot_with_overlay to add Dhan-canonical \
+         override for NIFTY/BANKNIFTY/SENSEX top 3)"
     );
 
     Arc::new(cache)
+}
+
+// ---------------------------------------------------------------------------
+// PR #456 (2026-05-04) — Option Chain REST overlay for top 3 underlyings
+// ---------------------------------------------------------------------------
+
+/// The 3 most-watched index F&O underlyings — `(symbol, scrip_id, options_segment_code)`.
+///
+/// Mirrors `VALIDATION_MUST_EXIST_INDICES[..3]` from
+/// `crates/common/src/constants.rs:897`. The `options_segment_code` is
+/// the **option contract** segment (NSE_FNO=2 / BSE_FNO=8), NOT the
+/// underlying's IDX_I segment — extracted prev_oi cache keys are per
+/// option, so the segment code stamped on each cache entry must match
+/// the OPTION's segment (matches the `(security_id, segment_code)`
+/// composite key used by the bhavcopy loader and consumed by
+/// `movers_pipeline`).
+///
+/// Hardcoded: these 3 SecurityIds + segment assignments are stable
+/// per Dhan instrument-master + IDX_I/NSE_FNO mapping convention.
+const TOP_3_OVERLAY_INDICES: &[(&str, u64, u8)] = &[
+    ("NIFTY", 13, 2),     // NSE_FNO options
+    ("BANKNIFTY", 25, 2), // NSE_FNO options
+    ("SENSEX", 51, 8),    // BSE_FNO options
+];
+
+/// Loads the prev_oi cache from bhavcopy AND applies the Option Chain
+/// REST overlay for NIFTY/BANKNIFTY/SENSEX.
+///
+/// Sequence:
+/// 1. Bhavcopy fetch + parse (calls `load_prev_oi_cache_at_boot`)
+/// 2. For each of the top 3 underlyings: fetch nearest expiry + chain,
+///    extract `previous_oi`, MERGE INTO accumulator (last-wins per
+///    `merge_prev_oi_cache` semantics — Option Chain values override
+///    bhavcopy on collision because Dhan-canonical > T+1 NSE static).
+///
+/// # Why an overlay (not replacement)
+///
+/// Option Chain REST has a 1-req/3-sec rate limit per
+/// `.claude/rules/dhan/option-chain.md` rule 4. Loading prev_oi for
+/// our full 219 (underlying, expiry) universe would take ~11 minutes.
+/// The overlay covers the 3 highest-traffic indices in ~18 seconds
+/// (3 underlyings × 2 calls × 3s rate-limit), giving operators
+/// Dhan-canonical values for the contracts that matter most while
+/// bhavcopy provides T+1 baseline for the rest.
+///
+/// # Failure handling
+///
+/// Per-underlying try; one failure (404 / network timeout / unauth)
+/// does NOT abort the others. Bhavcopy values remain authoritative
+/// when overlay fails. Logged at WARN, not ERROR — degradation is
+/// graceful (T+1 staleness for the affected underlying).
+///
+/// # Arguments
+///
+/// `client_id` is the Dhan account client ID (loaded from SSM at
+/// boot, plain `String` here per project convention — sensitive bits
+/// stay in the `TokenHandle`).
+pub async fn load_prev_oi_cache_at_boot_with_overlay(
+    registry: &InstrumentRegistry,
+    calendar: &TradingCalendar,
+    token_handle: tickvault_core::auth::token_manager::TokenHandle,
+    client_id: String,
+    rest_api_base_url: String,
+) -> Arc<HashMap<(u32, u8), i64>> {
+    // Step 1: bhavcopy baseline (existing function).
+    let bhavcopy_cache = load_prev_oi_cache_at_boot(registry, calendar).await;
+    let bhavcopy_size = bhavcopy_cache.len();
+
+    // Strip Arc to mutate; we'll re-wrap at the end.
+    let mut accumulator: HashMap<(u32, u8), i64> = (*bhavcopy_cache).clone();
+
+    // Step 2: Option Chain overlay.
+    let mut chain_client = match tickvault_core::option_chain::client::OptionChainClient::new(
+        token_handle,
+        client_id,
+        rest_api_base_url,
+    ) {
+        Ok(c) => c,
+        Err(err) => {
+            // Overlay disabled — bhavcopy stays authoritative.
+            warn!(
+                code = ErrorCode::PrevOi01CacheEmptyAtBoot.code_str(),
+                error = %err,
+                "prev_oi overlay: OptionChainClient::new failed — \
+                 bhavcopy cache stays authoritative for ALL underlyings \
+                 (top 3 will lack Dhan-canonical override)"
+            );
+            return Arc::new(accumulator);
+        }
+    };
+
+    let mut overlay_total: usize = 0;
+    let mut overlay_underlyings_succeeded: usize = 0;
+
+    for &(symbol, scrip_id, options_segment_code) in TOP_3_OVERLAY_INDICES {
+        // The underlying is IDX_I; the option chain query takes the
+        // underlying's IDX_I scrip ID + segment "IDX_I" — NSE/BSE
+        // distinction is implicit in the scrip_id.
+        let underlying_seg = "IDX_I";
+
+        // Step 2a: fetch expiry list to get the nearest expiry.
+        let expiry_list = match chain_client
+            .fetch_expiry_list(scrip_id, underlying_seg)
+            .await
+        {
+            Ok(list) => list,
+            Err(err) => {
+                warn!(
+                    code = ErrorCode::PrevOi01CacheEmptyAtBoot.code_str(),
+                    underlying = symbol,
+                    error = %err,
+                    "prev_oi overlay: fetch_expiry_list failed — \
+                     bhavcopy values for this underlying remain authoritative"
+                );
+                continue;
+            }
+        };
+        let nearest_expiry = match expiry_list.data.first() {
+            Some(e) => e.clone(),
+            None => {
+                warn!(
+                    underlying = symbol,
+                    "prev_oi overlay: expiry list returned empty — skipping"
+                );
+                continue;
+            }
+        };
+
+        // Step 2b: fetch the option chain for nearest expiry.
+        let response = match chain_client
+            .fetch_option_chain(scrip_id, underlying_seg, &nearest_expiry)
+            .await
+        {
+            Ok(r) => r,
+            Err(err) => {
+                warn!(
+                    code = ErrorCode::PrevOi01CacheEmptyAtBoot.code_str(),
+                    underlying = symbol,
+                    expiry = %nearest_expiry,
+                    error = %err,
+                    "prev_oi overlay: fetch_option_chain failed — \
+                     bhavcopy values for this underlying remain authoritative"
+                );
+                continue;
+            }
+        };
+
+        // Step 2c: extract + merge (last-wins overrides bhavcopy on collision).
+        let overlay_entries =
+            tickvault_core::option_chain::prev_oi::extract_prev_oi_from_option_chain(
+                &response,
+                options_segment_code,
+            );
+        let entry_count = overlay_entries.len();
+        tickvault_core::option_chain::prev_oi::merge_prev_oi_cache(
+            &mut accumulator,
+            overlay_entries,
+        );
+        overlay_total = overlay_total.saturating_add(entry_count);
+        overlay_underlyings_succeeded = overlay_underlyings_succeeded.saturating_add(1);
+
+        info!(
+            underlying = symbol,
+            expiry = %nearest_expiry,
+            options_segment_code,
+            overlay_entries = entry_count,
+            cumulative_overlay_total = overlay_total,
+            "prev_oi overlay: applied Dhan-canonical previous_oi values"
+        );
+    }
+
+    info!(
+        bhavcopy_size,
+        overlay_added_or_overrode = overlay_total,
+        overlay_underlyings_succeeded,
+        overlay_underlyings_total = TOP_3_OVERLAY_INDICES.len(),
+        final_cache_size = accumulator.len(),
+        "prev_oi cache: bhavcopy + Option Chain overlay complete"
+    );
+
+    Arc::new(accumulator)
 }
 
 // ---------------------------------------------------------------------------
@@ -322,5 +506,59 @@ mod tests {
     fn test_format_yyyymmdd_handles_year_boundary() {
         let date = NaiveDate::from_ymd_opt(2099, 1, 1).unwrap();
         assert_eq!(format_yyyymmdd(date), "20990101");
+    }
+
+    /// PR #456 ratchet: TOP_3_OVERLAY_INDICES MUST contain exactly the
+    /// 3 most-watched index F&O underlyings (NIFTY/BANKNIFTY/SENSEX) —
+    /// mirroring `VALIDATION_MUST_EXIST_INDICES[..3]`. Adding more
+    /// underlyings without operator approval would breach Dhan's
+    /// 1-req/3s rate limit budget for the boot-time overlay.
+    #[test]
+    fn test_top_3_overlay_indices_pinned_to_exactly_three_underlyings() {
+        assert_eq!(TOP_3_OVERLAY_INDICES.len(), 3);
+        let symbols: Vec<&str> = TOP_3_OVERLAY_INDICES.iter().map(|(s, _, _)| *s).collect();
+        assert_eq!(symbols, vec!["NIFTY", "BANKNIFTY", "SENSEX"]);
+    }
+
+    /// PR #456 ratchet: NIFTY + BANKNIFTY options live on NSE_FNO
+    /// (segment_code 2). SENSEX options live on BSE_FNO (segment_code
+    /// 8). Pinning so a future regression doesn't accidentally stamp
+    /// the wrong segment on cache keys (would silently corrupt
+    /// I-P1-11 composite-key entries).
+    #[test]
+    fn test_top_3_overlay_options_segments_per_dhan_annexure() {
+        for &(symbol, _scrip, segment_code) in TOP_3_OVERLAY_INDICES {
+            match symbol {
+                "NIFTY" | "BANKNIFTY" => {
+                    assert_eq!(
+                        segment_code, 2,
+                        "{symbol} options must use NSE_FNO=2 segment_code"
+                    );
+                }
+                "SENSEX" => {
+                    assert_eq!(
+                        segment_code, 8,
+                        "SENSEX options must use BSE_FNO=8 segment_code"
+                    );
+                }
+                _ => panic!("unexpected symbol in TOP_3_OVERLAY_INDICES: {symbol}"),
+            }
+        }
+    }
+
+    /// PR #456 ratchet: scrip IDs MUST match the canonical
+    /// `VALIDATION_MUST_EXIST_INDICES` from
+    /// `crates/common/src/constants.rs:897` so the overlay queries
+    /// the SAME underlyings the universe builder validates.
+    #[test]
+    fn test_top_3_overlay_scrip_ids_match_validation_must_exist_indices() {
+        let expected = [("NIFTY", 13_u64), ("BANKNIFTY", 25_u64), ("SENSEX", 51_u64)];
+        for (i, &(sym, scrip, _)) in TOP_3_OVERLAY_INDICES.iter().enumerate() {
+            assert_eq!(sym, expected[i].0);
+            assert_eq!(
+                scrip, expected[i].1,
+                "{sym} scrip_id must match VALIDATION_MUST_EXIST_INDICES"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #454 (boot-time bhavcopy `prev_oi` loader). Overlays Dhan-canonical Option Chain REST `previous_oi` values on top of the bhavcopy baseline for the 3 most-watched index F&O underlyings (NIFTY/BANKNIFTY/SENSEX).

| | bhavcopy (PR #454) | + Option Chain overlay (this PR) |
|---|---|---|
| Coverage | All ~22K NSE F&O contracts | + Dhan-canonical override for top 3 indices |
| Latency | ~5-6 min | + ~18s overlay (3 underlyings × 2 calls × 3s rate-limit) |
| Staleness | T+1 (yesterday's NSE close) | T (today's Dhan-canonical) for top 3 |
| Cost | FREE | Counts against Dhan Data API quota for 6 calls |

## Why an overlay (not full replacement)

Option Chain REST is rate-limited at 1 unique req per 3s per `.claude/rules/dhan/option-chain.md` rule 4. A full sweep of our 219 (underlying, expiry) universe would take ~11 min. The overlay covers the highest-traffic 3 indices in 18s and lets bhavcopy provide T+1 baseline for the rest.

## Sequence

1. Bhavcopy baseline (PR #454 logic)
2. For each of `TOP_3_OVERLAY_INDICES` `[(NIFTY,13,2), (BANKNIFTY,25,2), (SENSEX,51,8)]`:
   - `OptionChainClient::fetch_expiry_list(scrip_id, "IDX_I")` → nearest expiry
   - `OptionChainClient::fetch_option_chain(scrip_id, "IDX_I", expiry)`
   - `extract_prev_oi_from_option_chain(response, options_segment_code)` (PR #450 commit 3 primitive)
   - `merge_prev_oi_cache(&mut accumulator, overlay_entries)` (last-wins overrides bhavcopy)
3. Return Arc-wrapped final cache

## Failure handling (graceful per-underlying)

Per-underlying try; one failure does NOT abort the others. Bhavcopy stays authoritative when overlay fails. Logged at WARN per audit-findings Rule 11 (no false-OK).

## I-P1-11 critical: segment-code semantics

NIFTY + BANKNIFTY options live on **NSE_FNO** (segment_code 2). SENSEX options live on **BSE_FNO** (segment_code 8). Each `TOP_3_OVERLAY_INDICES` entry pins the correct OPTIONS segment_code (NOT the underlying's IDX_I) so cache keys composite correctly with bhavcopy entries.

## Tests (3 new ratchets)

- `test_top_3_overlay_indices_pinned_to_exactly_three_underlyings` — locks the count + symbol order
- `test_top_3_overlay_options_segments_per_dhan_annexure` — pins NIFTY/BANKNIFTY=NSE_FNO=2, SENSEX=BSE_FNO=8
- `test_top_3_overlay_scrip_ids_match_validation_must_exist_indices` — locks scrip IDs against canonical list

## Test plan

- [x] `cargo check --workspace` GREEN
- [x] `cargo test -p tickvault-app --lib prev_oi_loader` 9/9 GREEN (6 prior + 3 new)
- [x] `cargo test --workspace --lib` 1225/1225 GREEN
- [x] `cargo fmt --all` clean

## Notes

- Commits unsigned per operator authorization (signing server returning HTTP 400)
- Builds on top of PR #454 (already merged) + PR #455 (URL redaction, just merged)

https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS)_