### PR TITLE
fix(notification): truthful WebSocket pool-online emit + Tier-2 human-readable Telegram

### DIFF
--- a/config/base.toml
+++ b/config/base.toml
@@ -370,6 +370,13 @@ depth_dynamic_top_volume = true     # Wave 5 Items 4+5 LIVE
 # dynamic) — both code paths remain in the codebase as a rollback
 # option pending production validation.
 depth_dynamic_pipeline_v2 = true
+# PR #449 — kill-switch for the historical fetch + cross-verification +
+# pre-warmup subsystem. Default `false` until we migrate the historical
+# source from Dhan (NSE-aggregate) to a broker-traded feed (Groww API,
+# tracked in PR #455). When `false`, main.rs skips
+# spawn_historical_candle_fetch + verify_candle_integrity +
+# cross_match_historical_vs_live across both boot paths.
+historical_fetch_enabled = false
 
 # ---------------------------------------------------------------------------
 # Depth-dynamic redesign (PR-C2) — config-driven all-5-dynamic depth pools.

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1408,7 +1408,14 @@ async fn main() -> Result<()> {
             // FAST BOOT parity with slow boot (main.rs ~1760):
             // emit per-connection + aggregate Telegram alerts so an operator
             // can see the pool came up after a crash-recovery restart.
-            emit_websocket_connected_alerts(&fast_notifier, handles.len()).await;
+            // PR #458: now polls pool.health() for truthful state.
+            emit_websocket_connected_alerts(
+                &fast_notifier,
+                &pool_arc,
+                tickvault_core::notification::events::BootPathLabel::Fast,
+                boot_start,
+            )
+            .await;
             (handles, Some(pool_arc))
         } else {
             (Vec::new(), None)
@@ -3320,7 +3327,14 @@ async fn main() -> Result<()> {
         );
         // FAST BOOT parity: helper emits per-connection + aggregate Telegram
         // alerts on BOTH boot paths (main.rs ~830 for FAST BOOT, here for slow).
-        emit_websocket_connected_alerts(&notifier, handles.len()).await;
+        // PR #458: now polls pool.health() for truthful state.
+        emit_websocket_connected_alerts(
+            &notifier,
+            &pool_arc,
+            tickvault_core::notification::events::BootPathLabel::Slow,
+            boot_start,
+        )
+        .await;
         (handles, Some(pool_arc))
     } else {
         (Vec::new(), None)
@@ -7260,44 +7274,109 @@ async fn spawn_websocket_connections(
     handles
 }
 
-/// Stagger in milliseconds between per-connection `WebSocketConnected` events.
-/// Telegram rate-limits bursts of identical-from messages; spacing the emits
-/// avoids silent drops. A 5-connection pool at 150 ms adds ~750 ms to boot,
-/// which is negligible against the 15-step boot budget.
-const WS_CONNECTED_ALERT_STAGGER_MS: u64 = 150;
+/// Per-connection deadline for the truthful boot-time emit. If a slot
+/// has not transitioned to `Connected` within this window after
+/// `pool.spawn_handles()` returned, it is reported in the
+/// `WebSocketPoolPartialAfterDeadline` event with its current state as
+/// the stuck reason.
+const WS_BOOT_PER_CONN_DEADLINE_SECS: u64 = 30;
+
+/// Polling interval inside the truthful emit loop. 250ms gives sub-second
+/// freshness for state transitions without burning CPU.
+const WS_BOOT_POLL_INTERVAL_MS: u64 = 250;
 
 /// Emits per-connection `WebSocketConnected` Telegram events plus a single
-/// aggregate `WebSocketPoolOnline` summary. Called from BOTH boot paths
-/// (FAST BOOT and slow boot) so an operator sees the same signal regardless
-/// of which path ran.
+/// aggregate `WebSocketPoolOnline` summary — but ONLY when each connection
+/// has actually reached `ConnectionState::Connected` per `pool.health()`,
+/// not merely "task spawned". Called from BOTH boot paths (FAST BOOT and
+/// slow boot) so an operator sees the same truthful signal regardless of
+/// which path ran.
 ///
-/// Why the summary: when 5 per-connection events fire in a tight loop,
-/// Telegram can drop individual messages (observed live on 2026-04-17 —
-/// only 3 of 5 arrived). The aggregate is delivered with a small stagger
-/// after the individuals so even if all per-connection drops happen, a
-/// single "N/total online" message still reaches the operator chat.
+/// PR #458 (2026-05-04): the legacy version emitted both events
+/// immediately after `pool.spawn_handles()` returned, using `handle_count`
+/// for both `connected` and `total` — a false-OK when handshake had not
+/// yet completed. The rewrite polls `pool.health()` every 250ms for up
+/// to 30s per slot and emits the per-connection event only on the rising
+/// edge of `Connected`. The aggregate `WebSocketPoolOnline` fires only
+/// when ALL slots are `Connected`; otherwise
+/// `WebSocketPoolPartialAfterDeadline` fires with the stuck-slot
+/// breakdown.
 async fn emit_websocket_connected_alerts(
     notifier: &std::sync::Arc<NotificationService>,
-    handle_count: usize,
+    pool: &std::sync::Arc<WebSocketConnectionPool>,
+    boot_path: tickvault_core::notification::events::BootPathLabel,
+    boot_start: std::time::Instant,
 ) {
-    if handle_count == 0 {
+    let healths_initial = pool.health();
+    let total = healths_initial.len();
+    if total == 0 {
         return;
     }
-    for i in 0..handle_count {
-        notifier.notify(NotificationEvent::WebSocketConnected {
-            connection_index: i,
-        });
-        if i + 1 < handle_count {
-            tokio::time::sleep(std::time::Duration::from_millis(
-                WS_CONNECTED_ALERT_STAGGER_MS,
-            ))
-            .await;
+    let capacity = tickvault_common::constants::MAX_INSTRUMENTS_PER_WEBSOCKET_CONNECTION;
+    let mut emitted_per_conn = vec![false; total];
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(WS_BOOT_PER_CONN_DEADLINE_SECS);
+
+    while std::time::Instant::now() < deadline {
+        let healths = pool.health();
+        for h in &healths {
+            let i = h.connection_id as usize;
+            if i >= total || emitted_per_conn[i] {
+                continue;
+            }
+            if h.state == tickvault_core::websocket::types::ConnectionState::Connected {
+                emitted_per_conn[i] = true;
+                notifier.notify(NotificationEvent::WebSocketConnected {
+                    connection_index: i,
+                    subscribed_count: h.subscribed_count,
+                    capacity,
+                    last_activity_secs_ago: h.last_activity_secs_ago,
+                });
+            }
+        }
+        if emitted_per_conn.iter().all(|v| *v) {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(WS_BOOT_POLL_INTERVAL_MS)).await;
+    }
+
+    // Final snapshot — derive aggregate truth from pool.health(), NOT
+    // from the spawn count.
+    let healths_final = pool.health();
+    let mut per_connection: Vec<(usize, usize, Option<u32>)> = vec![(0, capacity, None); total];
+    let mut connected_count = 0usize;
+    let mut stuck: Vec<(usize, String)> = Vec::new();
+    for h in &healths_final {
+        let i = h.connection_id as usize;
+        if i >= total {
+            continue;
+        }
+        per_connection[i] = (h.subscribed_count, capacity, h.last_activity_secs_ago);
+        if h.state == tickvault_core::websocket::types::ConnectionState::Connected {
+            connected_count = connected_count.saturating_add(1);
+        } else {
+            stuck.push((i, format!("state={}", h.state)));
         }
     }
-    notifier.notify(NotificationEvent::WebSocketPoolOnline {
-        connected: handle_count,
-        total: handle_count,
-    });
+    let boot_wall_clock_secs = boot_start.elapsed().as_secs_f64();
+
+    if connected_count == total {
+        notifier.notify(NotificationEvent::WebSocketPoolOnline {
+            connected: connected_count,
+            total,
+            per_connection,
+            boot_path,
+            boot_wall_clock_secs,
+        });
+    } else {
+        notifier.notify(NotificationEvent::WebSocketPoolPartialAfterDeadline {
+            connected: connected_count,
+            total,
+            per_connection,
+            stuck,
+            boot_path,
+        });
+    }
 }
 
 /// S4-T1a: Background pool health watchdog.

--- a/crates/app/tests/feature_flag_rollback_guard.rs
+++ b/crates/app/tests/feature_flag_rollback_guard.rs
@@ -36,12 +36,19 @@ use figment::Figment;
 use figment::providers::{Format, Toml};
 use tickvault_common::config::{ApplicationConfig, FeaturesConfig};
 
-/// Canonical list of all 14 C9 feature-flag names. Source of truth used
+/// Canonical list of all 16 C9 feature-flag names. Source of truth used
 /// by the drift-prevention meta-tests below — if any flag is renamed
 /// in `FeaturesConfig` or `config/base.toml`, this list MUST be updated
 /// too. The cross-check tests guarantee no silent drift between the
 /// three definitions (struct fields ↔ TOML keys ↔ this list).
-const EXPECTED_FLAGS: [&str; 14] = [
+///
+/// PR #458 (2026-05-04): array length corrected from `14` to `16`.
+/// PR #444 (2026-05-03) retired `preopen_movers` (decrement to 13) but
+/// PRs #449/#450 added `depth_dynamic_top_volume`,
+/// `depth_dynamic_pipeline_v2`, `historical_fetch_enabled` (back up
+/// to 16) without updating this list — pre-existing drift that
+/// blocked the build when the test harness compiled this file.
+const EXPECTED_FLAGS: [&str; 16] = [
     "hotpath_async_writers",
     "phase2_emit_guard",
     "stock_movers_full_universe",
@@ -56,6 +63,9 @@ const EXPECTED_FLAGS: [&str; 14] = [
     "telegram_bucket_coalescer",
     "market_open_self_test",
     "realtime_guarantee_score",
+    "depth_dynamic_top_volume",
+    "depth_dynamic_pipeline_v2",
+    "historical_fetch_enabled",
 ];
 
 // ---------------------------------------------------------------------------

--- a/crates/app/tests/ws_pool_online_truthful_emit_guard.rs
+++ b/crates/app/tests/ws_pool_online_truthful_emit_guard.rs
@@ -1,0 +1,167 @@
+//! PR #458 ratchet — `WebSocketPoolOnline` MUST NOT fire if any
+//! connection is not in `ConnectionState::Connected`.
+//!
+//! Pre-PR #458, `emit_websocket_connected_alerts` reported
+//! `connected: handle_count, total: handle_count` — the SPAWN count,
+//! not the count of actually-connected sockets. That was a false-OK:
+//! the operator received "WS pool online: 5/5 connected" Telegram
+//! while no Dhan handshake had completed yet. PR #458 rewires the
+//! emit logic to poll `pool.health()` and emit `WebSocketPoolOnline`
+//! ONLY when every slot has reached `Connected`.
+//!
+//! This test ratchets that contract on the format-string contract:
+//! given a fully-connected pool snapshot, the message says "live"; given
+//! a partial snapshot via `WebSocketPoolPartialAfterDeadline`, the
+//! message says "partially online" with stuck-slot breakdown. A future
+//! regression that swaps these wordings or merges the two variants will
+//! fail this test.
+//!
+//! Run: `cargo test -p tickvault-app --test ws_pool_online_truthful_emit_guard`
+
+use tickvault_core::notification::events::{BootPathLabel, NotificationEvent};
+
+#[test]
+fn pool_online_message_for_fully_connected_pool_says_live() {
+    let event = NotificationEvent::WebSocketPoolOnline {
+        connected: 5,
+        total: 5,
+        per_connection: vec![
+            (5_000, 5_000, Some(1)),
+            (5_000, 5_000, Some(1)),
+            (5_000, 5_000, Some(2)),
+            (5_000, 5_000, Some(2)),
+            (4_324, 5_000, Some(2)),
+        ],
+        boot_path: BootPathLabel::Slow,
+        boot_wall_clock_secs: 11.2,
+    };
+    let msg = event.to_message();
+    assert!(
+        msg.contains("✅") && msg.contains("live"),
+        "WebSocketPoolOnline must signal verdict + liveness in the first \
+         line; got: {msg}"
+    );
+    assert!(
+        msg.contains("All 5 of 5"),
+        "header MUST report connected/total = 5/5 from the truthful \
+         payload; got: {msg}"
+    );
+    assert!(
+        msg.contains("24,324"),
+        "comma-formatted aggregate subscription count is required; got: \
+         {msg}"
+    );
+    assert!(
+        msg.contains("Normal start"),
+        "boot_path must be surfaced in human form; got: {msg}"
+    );
+}
+
+#[test]
+fn pool_partial_after_deadline_says_partially_online() {
+    let event = NotificationEvent::WebSocketPoolPartialAfterDeadline {
+        connected: 3,
+        total: 5,
+        per_connection: vec![
+            (5_000, 5_000, Some(1)),
+            (5_000, 5_000, Some(2)),
+            (4_847, 5_000, Some(3)),
+            (0, 5_000, None),
+            (0, 5_000, None),
+        ],
+        stuck: vec![
+            (3, "state=Connecting".to_string()),
+            (4, "state=Disconnected".to_string()),
+        ],
+        boot_path: BootPathLabel::Slow,
+    };
+    let msg = event.to_message();
+    assert!(
+        msg.contains("⚠️") && msg.contains("partially online"),
+        "PartialAfterDeadline must signal warning + partial wording; \
+         got: {msg}"
+    );
+    assert!(
+        msg.contains("3 of 5"),
+        "header MUST report connected/total = 3/5 from the truthful \
+         payload; got: {msg}"
+    );
+    assert!(
+        msg.contains("Working feeds:") && msg.contains("Broken feeds:"),
+        "PartialAfterDeadline must split active vs stuck rows; got: {msg}"
+    );
+    assert!(
+        msg.contains("state=Connecting") && msg.contains("state=Disconnected"),
+        "stuck reasons must surface verbatim; got: {msg}"
+    );
+}
+
+#[test]
+fn pool_online_severity_is_medium_partial_is_high() {
+    use tickvault_core::notification::events::Severity;
+    let online = NotificationEvent::WebSocketPoolOnline {
+        connected: 5,
+        total: 5,
+        per_connection: vec![(5_000, 5_000, Some(1)); 5],
+        boot_path: BootPathLabel::Slow,
+        boot_wall_clock_secs: 10.0,
+    };
+    let partial = NotificationEvent::WebSocketPoolPartialAfterDeadline {
+        connected: 0,
+        total: 5,
+        per_connection: vec![(0, 5_000, None); 5],
+        stuck: vec![],
+        boot_path: BootPathLabel::Slow,
+    };
+    assert_eq!(online.severity(), Severity::Medium);
+    assert_eq!(partial.severity(), Severity::High);
+}
+
+#[test]
+fn ws_connected_payload_renders_capacity_percent_and_ping() {
+    let event = NotificationEvent::WebSocketConnected {
+        connection_index: 0,
+        subscribed_count: 5_000,
+        capacity: 5_000,
+        last_activity_secs_ago: Some(1),
+    };
+    let msg = event.to_message();
+    assert!(
+        msg.contains("Feed 1"),
+        "1-indexed Feed N display required; got: {msg}"
+    );
+    assert!(
+        msg.contains("100% full") || msg.contains("100.0% full") || msg.contains("100%"),
+        "100% capacity rendering required; got: {msg}"
+    );
+    assert!(
+        msg.contains("1s ago ✓"),
+        "ping freshness checkmark required for fresh frames; got: {msg}"
+    );
+}
+
+#[test]
+fn ws_connected_renders_no_data_yet_when_first_frame_pending() {
+    let event = NotificationEvent::WebSocketConnected {
+        connection_index: 4,
+        subscribed_count: 4_324,
+        capacity: 5_000,
+        last_activity_secs_ago: None,
+    };
+    let msg = event.to_message();
+    assert!(
+        msg.contains("Feed 5"),
+        "1-indexed Feed N display required; got: {msg}"
+    );
+    assert!(
+        msg.contains("—"),
+        "em-dash required when no first frame received yet; got: {msg}"
+    );
+}
+
+#[test]
+fn boot_path_label_human_strings_are_distinct() {
+    assert_ne!(BootPathLabel::Slow.human(), BootPathLabel::Fast.human());
+    assert!(BootPathLabel::Slow.human().contains("Normal"));
+    assert!(BootPathLabel::Fast.human().contains("crash recovery"));
+}

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -118,6 +118,41 @@ impl DepthRebalanceLevels {
     }
 }
 
+/// Which boot path was used to bring the WebSocket pool online.
+///
+/// Per operator policy 2026-05-04 + `boot_helpers::should_fast_boot`:
+/// - `Slow` is the DEFAULT path. Used pre-09:00 IST AND post-15:30 IST,
+///   AND mid-market when the auth/instrument cache is missing. Runs the
+///   full sequential init (auth → instrument master → QuestDB → universe
+///   → WS pool).
+/// - `Fast` is the EMERGENCY path. Used ONLY between 09:00–15:30 IST when
+///   a valid auth token cache + binary instrument cache are present.
+///   Skips ~30s of init by trusting the on-disk cache; intended for
+///   mid-market crash recovery so ticks resume flowing fast.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootPathLabel {
+    Slow,
+    Fast,
+}
+
+impl BootPathLabel {
+    /// Human-readable label for the Telegram message.
+    pub const fn human(self) -> &'static str {
+        match self {
+            Self::Slow => "Normal start (full init)",
+            Self::Fast => "Mid-market crash recovery (cached init)",
+        }
+    }
+
+    /// Short label for compact contexts.
+    pub const fn short(self) -> &'static str {
+        match self {
+            Self::Slow => "slow",
+            Self::Fast => "fast",
+        }
+    }
+}
+
 /// All events that produce a Telegram alert.
 ///
 /// Adding a new event: add a variant here, add its message arm in
@@ -182,14 +217,59 @@ pub enum NotificationEvent {
     /// Token renewal failed — background task will retry.
     TokenRenewalFailed { attempts: u32, reason: String },
 
-    /// WebSocket connection established.
-    WebSocketConnected { connection_index: usize },
+    /// WebSocket connection truly established — fires only when the
+    /// connection's state in `pool.health()` has transitioned to
+    /// `Connected` (TLS handshake done, subscribe acked, first frame
+    /// received). The fields carry per-connection capacity utilisation
+    /// and ping/pong heartbeat freshness so an operator sees subscription
+    /// + liveness without opening Grafana.
+    ///
+    /// PR #458 (2026-05-04): the pre-existing payload was just
+    /// `{ connection_index }` and was emitted from a tight loop right
+    /// after `pool.spawn_handles()` returned — i.e., before any actual
+    /// handshake had completed. That was a false-OK. The new payload
+    /// + emit gating makes this a truthful per-connection signal.
+    WebSocketConnected {
+        connection_index: usize,
+        subscribed_count: usize,
+        capacity: usize,
+        last_activity_secs_ago: Option<u32>,
+    },
 
-    /// Aggregate summary of the live-market-feed pool after spawn.
-    /// Emitted once per boot path so operators survive Telegram rate-limit
-    /// drops of the per-connection `WebSocketConnected` events.
-    /// `total` is the expected count (== connected on healthy boot).
-    WebSocketPoolOnline { connected: usize, total: usize },
+    /// Aggregate pool-online summary — fires on rising-edge when ALL
+    /// spawned connections have actually reached `Connected` state.
+    /// Carries the per-connection breakdown so the operator sees pool
+    /// capacity utilisation + heartbeat liveness at a glance.
+    ///
+    /// `boot_path` distinguishes pre-9am normal slow boot from the
+    /// mid-market crash-recovery fast boot (per operator intent
+    /// 2026-05-04: slow boot is the default, fast boot is reserved for
+    /// emergency restart between 09:00–15:30 IST when cache is valid).
+    ///
+    /// `per_connection[i] = (subscribed_count, capacity, last_activity_secs_ago)`
+    /// indexed by `connection_index`. Length == `total`.
+    WebSocketPoolOnline {
+        connected: usize,
+        total: usize,
+        per_connection: Vec<(usize, usize, Option<u32>)>,
+        boot_path: BootPathLabel,
+        boot_wall_clock_secs: f64,
+    },
+
+    /// Aggregate pool-degraded summary — fires when only a subset of
+    /// connections reached `Connected` after the per-conn deadline.
+    /// `stuck[i] = (connection_index, state_label)` describes each
+    /// non-Connected slot. Replaces the pre-existing
+    /// `WebSocketPoolDegraded { down_secs }` for the boot-time path
+    /// (the watchdog still emits the pre-existing variant for
+    /// mid-session pool-down events).
+    WebSocketPoolPartialAfterDeadline {
+        connected: usize,
+        total: usize,
+        per_connection: Vec<(usize, usize, Option<u32>)>,
+        stuck: Vec<(usize, String)>,
+        boot_path: BootPathLabel,
+    },
 
     /// Pool-level CRITICAL alert: every connection has been down longer than
     /// `POOL_DEGRADED_ALERT_SECS` (default 60). One alert per down-cycle.
@@ -1202,6 +1282,153 @@ fn render_cross_match_failed(
     out
 }
 
+/// Formats a `usize` with comma thousand separators for human-readable
+/// Telegram messages (e.g. `24324` -> `"24,324"`).
+fn format_with_commas(n: usize) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (i, byte) in bytes.iter().enumerate() {
+        if i > 0 && (len - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(*byte as char);
+    }
+    out
+}
+
+/// Formats the per-connection ping/pong heartbeat freshness for the
+/// `WebSocketConnected` Telegram payload.
+///
+/// `last_activity_secs_ago` is `None` when no inbound frame has been
+/// seen yet on this socket — render an explicit "no data yet" message
+/// rather than a misleading "0s ago".
+fn format_ping_freshness(secs: Option<u32>) -> String {
+    match secs {
+        None => "—".to_string(),
+        Some(0..=10) => format!("{}s ago ✓", secs.unwrap_or(0)),
+        // 11–30s: still alive (Dhan pings @10s; library auto-pongs)
+        Some(s @ 11..=30) => format!("{s}s ago ⚠"),
+        // > 30s: ping/pong watchdog will fire shortly
+        Some(s) => format!("{s}s ago ❌"),
+    }
+}
+
+/// Renders the WebSocket pool-online (HEALTHY) Telegram message in the
+/// Tier-2 human-readable format. Single message at boot — eye instantly
+/// catches the verdict, then per-feed breakdown for at-a-glance status.
+fn format_pool_online_message(
+    connected: usize,
+    total: usize,
+    per_connection: &[(usize, usize, Option<u32>)],
+    boot_path: BootPathLabel,
+    boot_wall_clock_secs: f64,
+) -> String {
+    let total_subscribed: usize = per_connection.iter().map(|(s, _, _)| *s).sum();
+    let total_capacity: usize = per_connection.iter().map(|(_, c, _)| *c).sum();
+    let pool_pct = if total_capacity == 0 {
+        0.0
+    } else {
+        (total_subscribed as f64 / total_capacity as f64) * 100.0
+    };
+    let mut out = String::new();
+    out.push_str("<b>✅ TickVault is live and ready to trade</b>\n\n");
+    out.push_str(&format!(
+        "📡 All {connected} of {total} market-data feeds connected\n"
+    ));
+    out.push_str(&format!(
+        "📊 Tracking {sub} instruments out of {cap} max ({pct:.0}% full)\n\n",
+        sub = format_with_commas(total_subscribed),
+        cap = format_with_commas(total_capacity),
+        pct = pool_pct,
+    ));
+    out.push_str("Per feed:\n");
+    for (idx, (sub, cap, last)) in per_connection.iter().enumerate() {
+        let display = idx.saturating_add(1);
+        let pct = if *cap == 0 {
+            0.0
+        } else {
+            (*sub as f64 / *cap as f64) * 100.0
+        };
+        let pct_label = if (pct - 100.0).abs() < f64::EPSILON {
+            "full".to_string()
+        } else {
+            format!("{pct:.0}% full")
+        };
+        let ping = format_ping_freshness(*last);
+        out.push_str(&format!(
+            "  Feed {display}: tracking {sub_fmt} instruments ({pct_label}) — last update {ping}\n",
+            sub_fmt = format_with_commas(*sub),
+        ));
+    }
+    out.push_str("\n💚 Heartbeat healthy on all feeds (Dhan pings every 10s, auto-pong)\n");
+    out.push_str(&format!(
+        "⏱️ Boot took {boot_wall_clock_secs:.1} seconds — {path}\n",
+        path = boot_path.human(),
+    ));
+    out.push_str("\nYou're good to go.");
+    out
+}
+
+/// Renders the WebSocket pool-degraded Telegram message in the Tier-2
+/// human-readable format. Includes per-slot stuck reason + retry plan.
+fn format_pool_partial_message(
+    connected: usize,
+    total: usize,
+    per_connection: &[(usize, usize, Option<u32>)],
+    stuck: &[(usize, String)],
+    boot_path: BootPathLabel,
+) -> String {
+    let total_subscribed: usize = per_connection.iter().map(|(s, _, _)| *s).sum();
+    let total_capacity: usize = per_connection.iter().map(|(_, c, _)| *c).sum();
+    let pool_pct = if total_capacity == 0 {
+        0.0
+    } else {
+        (total_subscribed as f64 / total_capacity as f64) * 100.0
+    };
+    let stuck_count = stuck.len();
+    let mut out = String::new();
+    out.push_str("<b>⚠️ TickVault is partially online — needs your attention</b>\n\n");
+    out.push_str(&format!(
+        "📡 {connected} of {total} market-data feeds connected ({stuck_count} stuck)\n"
+    ));
+    out.push_str(&format!(
+        "📊 Tracking {sub} instruments out of {cap} max ({pct:.0}%)\n\n",
+        sub = format_with_commas(total_subscribed),
+        cap = format_with_commas(total_capacity),
+        pct = pool_pct,
+    ));
+    out.push_str("Working feeds:\n");
+    let stuck_idxs: std::collections::HashSet<usize> = stuck.iter().map(|(i, _)| *i).collect();
+    for (idx, (sub, cap, last)) in per_connection.iter().enumerate() {
+        if stuck_idxs.contains(&idx) {
+            continue;
+        }
+        let display = idx.saturating_add(1);
+        let pct = if *cap == 0 {
+            0.0
+        } else {
+            (*sub as f64 / *cap as f64) * 100.0
+        };
+        let ping = format_ping_freshness(*last);
+        out.push_str(&format!(
+            "  Feed {display}: tracking {sub_fmt} instruments ({pct:.0}% full) — last update {ping}\n",
+            sub_fmt = format_with_commas(*sub),
+        ));
+    }
+    out.push_str("\nBroken feeds:\n");
+    for (idx, reason) in stuck {
+        let display = idx.saturating_add(1);
+        out.push_str(&format!("  Feed {display}: {reason}\n"));
+    }
+    out.push_str(&format!(
+        "\n🔄 The system will keep retrying every 5 seconds.\n   Boot path: {path}",
+        path = boot_path.human(),
+    ));
+    out
+}
+
 impl NotificationEvent {
     /// Formats the event as a Telegram message.
     ///
@@ -1273,17 +1500,49 @@ impl NotificationEvent {
                     redact_url_params(reason)
                 )
             }
-            Self::WebSocketConnected { connection_index } => {
-                // UX fix 2026-04-17: display as 1-indexed (WebSocket 1/5)
-                // so operators read a natural 1..N range instead of 0..N-1.
-                // Internal `connection_index` stays 0-based (array index).
+            Self::WebSocketConnected {
+                connection_index,
+                subscribed_count,
+                capacity,
+                last_activity_secs_ago,
+            } => {
+                // 1-indexed for human readability (Feed 1..N).
                 let display = connection_index.saturating_add(1);
                 let total = tickvault_common::constants::MAX_WEBSOCKET_CONNECTIONS;
-                format!("<b>WebSocket {display}/{total} connected</b>")
+                let pct = if *capacity == 0 {
+                    0.0
+                } else {
+                    (*subscribed_count as f64 / *capacity as f64) * 100.0
+                };
+                let ping = format_ping_freshness(*last_activity_secs_ago);
+                format!(
+                    "<b>📡 Feed {display}/{total} is now live</b>\n  \
+                     Tracking {sub} of {cap} instruments ({pct:.0}% full)\n  \
+                     Last update {ping}",
+                    sub = format_with_commas(*subscribed_count),
+                    cap = format_with_commas(*capacity),
+                )
             }
-            Self::WebSocketPoolOnline { connected, total } => {
-                format!("<b>WS pool online:</b> {connected}/{total} connected")
-            }
+            Self::WebSocketPoolOnline {
+                connected,
+                total,
+                per_connection,
+                boot_path,
+                boot_wall_clock_secs,
+            } => format_pool_online_message(
+                *connected,
+                *total,
+                per_connection,
+                *boot_path,
+                *boot_wall_clock_secs,
+            ),
+            Self::WebSocketPoolPartialAfterDeadline {
+                connected,
+                total,
+                per_connection,
+                stuck,
+                boot_path,
+            } => format_pool_partial_message(*connected, *total, per_connection, stuck, *boot_path),
             Self::WebSocketPoolDegraded { down_secs } => {
                 format!(
                     "<b>WS POOL DEGRADED</b>\nAll connections down for {down_secs}s. \
@@ -2207,6 +2466,7 @@ impl NotificationEvent {
             Self::TokenRenewalFailed { .. } => "TokenRenewalFailed",
             Self::WebSocketConnected { .. } => "WebSocketConnected",
             Self::WebSocketPoolOnline { .. } => "WebSocketPoolOnline",
+            Self::WebSocketPoolPartialAfterDeadline { .. } => "WebSocketPoolPartialAfterDeadline",
             Self::WebSocketPoolDegraded { .. } => "WebSocketPoolDegraded",
             Self::WebSocketPoolRecovered { .. } => "WebSocketPoolRecovered",
             Self::WebSocketPoolHalt { .. } => "WebSocketPoolHalt",
@@ -2353,6 +2613,7 @@ impl NotificationEvent {
             Self::CircuitBreakerClosed => Severity::Medium,
             Self::WebSocketConnected { .. } => Severity::Low,
             Self::WebSocketPoolOnline { .. } => Severity::Medium,
+            Self::WebSocketPoolPartialAfterDeadline { .. } => Severity::High,
             Self::WebSocketPoolDegraded { .. } => Severity::High,
             Self::WebSocketPoolRecovered { .. } => Severity::Medium,
             Self::WebSocketPoolHalt { .. } => Severity::High,
@@ -2919,12 +3180,23 @@ mod tests {
     #[test]
     fn test_websocket_connected_includes_index() {
         // UX fix 2026-04-17: display is 1-indexed (connection_index=2 → "3/5")
+        // PR #458 (2026-05-04): payload now includes subscribed/capacity/ping.
         let event = NotificationEvent::WebSocketConnected {
             connection_index: 2,
+            subscribed_count: 5_000,
+            capacity: 5_000,
+            last_activity_secs_ago: Some(2),
         };
         let msg = event.to_message();
         assert!(msg.contains("3"), "1-indexed display: 2 -> 3; got: {msg}");
-        assert!(msg.contains("connected"));
+        assert!(
+            msg.contains("Feed"),
+            "Tier-2 wording uses 'Feed'; got: {msg}"
+        );
+        assert!(
+            msg.contains("5,000"),
+            "comma-formatted subscribed count required; got: {msg}"
+        );
     }
 
     #[test]
@@ -3742,6 +4014,9 @@ mod tests {
     fn test_ws_connected_severity() {
         let event = NotificationEvent::WebSocketConnected {
             connection_index: 0,
+            subscribed_count: 5_000,
+            capacity: 5_000,
+            last_activity_secs_ago: Some(1),
         };
         assert_eq!(event.severity(), Severity::Low);
     }

--- a/crates/core/src/notification/service.rs
+++ b/crates/core/src/notification/service.rs
@@ -1371,6 +1371,9 @@ mod tests {
         });
         service.notify(NotificationEvent::WebSocketConnected {
             connection_index: 0,
+            subscribed_count: 5_000,
+            capacity: 5_000,
+            last_activity_secs_ago: Some(1),
         });
         service.notify(NotificationEvent::WebSocketDisconnected {
             connection_index: 1,
@@ -1945,6 +1948,9 @@ mod tests {
         let service = NotificationService::disabled();
         service.notify(NotificationEvent::WebSocketConnected {
             connection_index: 0,
+            subscribed_count: 5_000,
+            capacity: 5_000,
+            last_activity_secs_ago: Some(1),
         });
         service.notify(NotificationEvent::WebSocketDisconnected {
             connection_index: 0,

--- a/crates/core/src/websocket/connection.rs
+++ b/crates/core/src/websocket/connection.rs
@@ -283,6 +283,15 @@ pub struct WebSocketConnection {
     /// *forward progress*, not absolute values.
     activity_counter: Arc<AtomicU64>,
 
+    /// Wall-clock UTC epoch seconds of the most recent inbound frame
+    /// (binary / ping / pong / text). Stored as `i64` so a `0` sentinel
+    /// distinguishes "never seen a frame" from "frame at epoch 0".
+    /// Read by `health()` to surface ping/pong heartbeat liveness in
+    /// the `WebSocketConnected` Telegram payload. Bumped on every
+    /// inbound frame in the read loop alongside `activity_counter`.
+    /// O(1) per tick: single relaxed atomic store.
+    last_activity_at_epoch_secs: Arc<std::sync::atomic::AtomicI64>,
+
     /// STAGE-C.3: Notify handle the activity watchdog fires when it has
     /// observed no forward progress on `activity_counter` for longer than
     /// its threshold. The read loop awaits this in `tokio::select!` and
@@ -396,6 +405,7 @@ impl WebSocketConnection {
             shutdown_notify: Arc::new(tokio::sync::Notify::new()),
             wal_spill: None,
             activity_counter: Arc::new(AtomicU64::new(0)),
+            last_activity_at_epoch_secs: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             watchdog_notify: Arc::new(tokio::sync::Notify::new()),
             // O1-B: subscribe command channel installed lazily via builder.
             subscribe_cmd_rx: tokio::sync::Mutex::new(None),
@@ -481,11 +491,25 @@ impl WebSocketConnection {
     /// Returns a health snapshot for monitoring.
     #[allow(clippy::expect_used)] // APPROVED: lock poison is unrecoverable
     pub fn health(&self) -> ConnectionHealth {
+        // Compute "seconds since last inbound frame" from the wall-clock
+        // delta. `0` sentinel = no frame ever received → return None so
+        // the Telegram formatter can render "—" instead of a misleading
+        // "1714..." (epoch). On wall-clock skew where last > now, clamp
+        // to 0s rather than overflow.
+        let last_at = self.last_activity_at_epoch_secs.load(Ordering::Relaxed);
+        let last_activity_secs_ago = if last_at == 0 {
+            None
+        } else {
+            let now = chrono::Utc::now().timestamp();
+            let delta = now.saturating_sub(last_at);
+            Some(delta.clamp(0, u32::MAX as i64) as u32)
+        };
         ConnectionHealth {
             connection_id: self.connection_id,
             state: *self.state.lock().expect("state lock poisoned"), // APPROVED: lock poison is unrecoverable
             subscribed_count: self.instruments.len(),
             total_reconnections: self.total_reconnections.load(Ordering::Acquire),
+            last_activity_secs_ago,
         }
     }
 
@@ -1117,7 +1141,13 @@ impl WebSocketConnection {
                 // chrono::Utc::now().timestamp() is a clock_gettime
                 // syscall (~20ns) — acceptable on this path; the
                 // downstream parse + dispatch is ~10 μs anyway.
-                m_last_frame_epoch.set(chrono::Utc::now().timestamp() as f64);
+                let now_secs = chrono::Utc::now().timestamp();
+                m_last_frame_epoch.set(now_secs as f64);
+                // Bump the connection-local timestamp so health() can
+                // surface "last frame N seconds ago" in Telegram payloads
+                // for ping/pong heartbeat liveness.
+                self.last_activity_at_epoch_secs
+                    .store(now_secs, Ordering::Relaxed);
             }
 
             match frame_result {

--- a/crates/core/src/websocket/pool_watchdog.rs
+++ b/crates/core/src/websocket/pool_watchdog.rs
@@ -195,6 +195,7 @@ mod tests {
             state,
             subscribed_count: 0,
             total_reconnections: 0,
+            last_activity_secs_ago: None,
         }
     }
 

--- a/crates/core/src/websocket/types.rs
+++ b/crates/core/src/websocket/types.rs
@@ -333,6 +333,16 @@ pub struct ConnectionHealth {
     pub subscribed_count: usize,
     /// Total reconnections since startup.
     pub total_reconnections: u64,
+    /// Seconds since the most recent inbound frame on this connection
+    /// (binary / ping / pong / text). `None` if no frames have been
+    /// received yet on the current socket. Surfaced in the
+    /// `WebSocketConnected` + `WebSocketPoolOnline` Telegram payloads
+    /// so an operator can confirm ping/pong heartbeat liveness without
+    /// opening Grafana. Dhan pings every 10s + tokio-tungstenite
+    /// auto-pongs, so a healthy socket stays in the [0, 10] band.
+    /// Values > 30 indicate a silent socket — the per-connection
+    /// activity watchdog will fire shortly after.
+    pub last_activity_secs_ago: Option<u32>,
 }
 
 // ---------------------------------------------------------------------------
@@ -776,6 +786,7 @@ mod tests {
             state: ConnectionState::Connected,
             subscribed_count: 500,
             total_reconnections: 3,
+            last_activity_secs_ago: None,
         };
         let cloned = health.clone();
         assert_eq!(cloned.connection_id, 2);
@@ -791,6 +802,7 @@ mod tests {
             state: ConnectionState::Disconnected,
             subscribed_count: 0,
             total_reconnections: 0,
+            last_activity_secs_ago: None,
         };
         assert_eq!(health.connection_id, 0);
         assert_eq!(health.state, ConnectionState::Disconnected);
@@ -1058,6 +1070,7 @@ mod tests {
             state: ConnectionState::Reconnecting,
             subscribed_count: 1000,
             total_reconnections: 7,
+            last_activity_secs_ago: None,
         };
         let debug = format!("{health:?}");
         assert!(debug.contains("ConnectionHealth"));
@@ -1246,11 +1259,13 @@ mod tests {
             state: ConnectionState::Reconnecting,
             subscribed_count: 5000,
             total_reconnections: 99,
+            last_activity_secs_ago: Some(7),
         };
         assert_eq!(health.connection_id, 4);
         assert_eq!(health.state, ConnectionState::Reconnecting);
         assert_eq!(health.subscribed_count, 5000);
         assert_eq!(health.total_reconnections, 99);
+        assert_eq!(health.last_activity_secs_ago, Some(7));
     }
 
     #[test]
@@ -1260,6 +1275,7 @@ mod tests {
             state: ConnectionState::Connecting,
             subscribed_count: 100,
             total_reconnections: 1,
+            last_activity_secs_ago: None,
         };
         let cloned = original.clone();
         assert_eq!(cloned.connection_id, original.connection_id);


### PR DESCRIPTION
## Summary

Hotfix for the false-OK in the `WebSocketPoolOnline` Telegram notification, plus a major UX rewrite to **Tier-2 human-readable** format that even a non-technical user can understand.

### What was wrong

`emit_websocket_connected_alerts` in `crates/app/src/main.rs:7270-7273` emitted:

```rust
notifier.notify(NotificationEvent::WebSocketPoolOnline {
    connected: handle_count,   // <-- spawn count
    total: handle_count,        // <-- spawn count
});
```

Both fields used the **task spawn count**, not the count of connections actually in `ConnectionState::Connected`. The operator received "WS pool online: 5/5 connected" Telegram before any Dhan handshake had completed — and even when several connections later failed, the original 5/5 message stayed in chat as the last positive signal.

This violates audit-findings Rule 11 (no false-OK signals).

### What this PR does

1. **Truthful per-connection emit** — `emit_websocket_connected_alerts` now polls `pool.health()` every 250 ms with a 30 s per-slot deadline. `WebSocketConnected` fires ONLY on the rising-edge transition into `ConnectionState::Connected`.

2. **Truthful aggregate emit** — closing aggregate is computed from the final `pool.health()` snapshot:
   - All 5 reached `Connected` → `WebSocketPoolOnline` (HEALTHY)
   - Only some reached `Connected` → `WebSocketPoolPartialAfterDeadline` (DEGRADED) with per-slot stuck reason

3. **Per-connection capacity + ping/pong heartbeat** — added `last_activity_at_epoch_secs: Arc<AtomicI64>` bumped on every inbound frame. Surfaced as `last_activity_secs_ago: Option<u32>` in `ConnectionHealth` and rendered in Telegram as compact "Ns ago ✓/⚠/❌" markers.

4. **Tier-2 human-readable format** — first line is a verdict with emoji (✅/⚠️/🚨/🔄), one-sentence summary in plain English, numbers come with story ("tracking 5,000 instruments (full)" not "5,000/5,000 (100%)"), action line so operator never has to ask "now what?".

5. **Boot path label** — `BootPathLabel { Slow, Fast }` enum surfaced in the message:
   - `Slow` (DEFAULT, pre-09:00 IST and post-15:30 IST) → "Normal start (full init)"
   - `Fast` (09:00–15:30 IST emergency restart with valid cache) → "Mid-market crash recovery (cached init)"

### Telegram preview

**Healthy boot:**
```
✅ TickVault is live and ready to trade

📡 All 5 of 5 market-data feeds connected
📊 Tracking 24,324 instruments out of 25,000 max (97% full)

Per feed:
  Feed 1: tracking 5,000 instruments (full) — last update 1s ago ✓
  Feed 2: tracking 5,000 instruments (full) — last update 1s ago ✓
  Feed 3: tracking 5,000 instruments (full) — last update 2s ago ✓
  Feed 4: tracking 5,000 instruments (full) — last update 2s ago ✓
  Feed 5: tracking 4,324 instruments (87% full) — last update 2s ago ✓

💚 Heartbeat healthy on all feeds (Dhan pings every 10s, auto-pong)
⏱️ Boot took 11.2 seconds — Normal start (full init)

You're good to go.
```

**Degraded boot:**
```
⚠️ TickVault is partially online — needs your attention

📡 3 of 5 market-data feeds connected (2 stuck)
📊 Tracking 14,847 instruments out of 25,000 max (59%)

Working feeds:
  Feed 1: tracking 5,000 instruments (100% full) — last update 1s ago ✓
  Feed 2: tracking 5,000 instruments (100% full) — last update 2s ago ✓
  Feed 3: tracking 4,847 instruments (97% full) — last update 3s ago ✓

Broken feeds:
  Feed 4: state=Connecting
  Feed 5: state=Disconnected

🔄 The system will keep retrying every 5 seconds.
   Boot path: Normal start (full init)
```

### Side-fixes (pre-existing test debt)

- `feature_flag_rollback_guard.rs::EXPECTED_FLAGS` array length corrected `14` → `16`. PR #444 retired `preopen_movers` (decrement to 13) but PRs #449/#450 added 3 new flags without updating the list. Pre-existing drift, surfaced because the new ratchet test forced workspace test rebuild.
- `config/base.toml [features]` gained explicit `historical_fetch_enabled = false` line (was missing — masked at runtime by `Default` impl, but the drift-prevention guard couldn't see it).

### Diff

```
config/base.toml                                |   7 +
crates/app/src/main.rs                          | 139 +++++++++--
crates/app/tests/feature_flag_rollback_guard.rs |  14 +-
crates/app/tests/ws_pool_online_truthful_emit_guard.rs (NEW)
crates/core/src/notification/events.rs          | 307 ++++++++++++++++++++--
crates/core/src/notification/service.rs         |   6 +
crates/core/src/websocket/connection.rs         |  32 ++-
crates/core/src/websocket/pool_watchdog.rs      |   1 +
crates/core/src/websocket/types.rs              |  16 ++
9 files changed, 640 insertions(+), 49 deletions(-)
```

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p tickvault-core --lib` — 3,586 passed
- [x] `cargo test -p tickvault-app --lib` — 543 passed
- [x] `cargo test -p tickvault-app --tests` — all integration tests green
- [x] `cargo test -p tickvault-app --test ws_pool_online_truthful_emit_guard` — 6 ratchet tests passed
- [x] `cargo test -p tickvault-app --test feature_flag_rollback_guard` — 45 passed
- [x] `cargo test -p tickvault-app --test boot_path_notify_parity` — 3 passed (no regressions)

## Operator concerns deferred to follow-up PR

**"How do I get notified when the app itself doesn't start?"** — the in-app notifier is dead-stop-blind to app-down. Needs EXTERNAL watcher. Three layers planned:

1. AWS CloudWatch alarm on EC2 `StatusCheckFailed_Instance` + custom `tv_app_alive` heartbeat metric → SNS → Telegram bridge.
2. Lambda heartbeat that calls `/health` every 5 min.
3. Mac local launchd `KeepAlive=true` + `OnFailure=` script.

Will ship as separate PR — out of scope for this hotfix.

https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS)_