### PR TITLE
fix(app): truthful depth-20 + depth-200 connection counters (mirrors PR #458)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4096,6 +4096,23 @@ async fn main() -> Result<()> {
                     // only on task-exit for DepthTwentyDisconnected.
                     let d20_reconnect_notifier = Some(notifier.clone());
                     let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
+                    // PR #460 (2026-05-04): truthful-emit pattern. Shared flag
+                    // between the signal-rx waiter (which increments the
+                    // counter ONLY when the connection emits its first data
+                    // frame) and the connection-runner task (which decrements
+                    // ONLY if the increment had previously happened). The
+                    // legacy "increment at spawn / decrement on Err" pattern
+                    // produced false-OK signals: a task stuck in handshake
+                    // for 30s reported as connected, and the Telegram showed
+                    // "Depth-20: 5/5" before any Dhan handshake completed.
+                    // Now the counter reflects truth: only TRULY-streaming
+                    // connections count.
+                    let d20_truly_connected =
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                    let d20_truly_connected_for_signal =
+                        std::sync::Arc::clone(&d20_truly_connected);
+                    let d20_truly_connected_for_exit = std::sync::Arc::clone(&d20_truly_connected);
+                    let d20_health_for_signal = d20_health.clone();
                     // Command channel for live rebalance (unsubscribe+resubscribe, zero disconnect).
                     let (d20_cmd_tx, d20_cmd_rx) =
                         tokio::sync::mpsc::channel::<tickvault_core::websocket::DepthCommand>(4);
@@ -4107,9 +4124,8 @@ async fn main() -> Result<()> {
                         });
                     }
                     tokio::spawn(async move {
-                        d20_health.set_depth_20_connections(
-                            d20_health.depth_20_connections().saturating_add(1),
-                        );
+                        // PR #460: NO increment-on-spawn. Counter is gated on
+                        // signal_rx firing (= first data frame received).
 
                         if let Err(err) = tickvault_core::websocket::run_twenty_depth_connection(
                             depth_token,
@@ -4144,6 +4160,14 @@ async fn main() -> Result<()> {
                                     },
                                 );
                             }
+                        }
+                        // PR #460: decrement on EVERY task exit (Ok or Err)
+                        // BUT only if we had previously incremented (signal
+                        // fired). Avoids underflow when a task exits before
+                        // ever reaching Connected (e.g. handshake timeout).
+                        if d20_truly_connected_for_exit
+                            .swap(false, std::sync::atomic::Ordering::AcqRel)
+                        {
                             d20_health.set_depth_20_connections(
                                 d20_health.depth_20_connections().saturating_sub(1),
                             );
@@ -4157,6 +4181,25 @@ async fn main() -> Result<()> {
                         let notify_sender = notifier.clone();
                         tokio::spawn(async move {
                             if signal_rx.await.is_ok() {
+                                // PR #460 (2026-05-04): truthful-emit. The
+                                // signal fires AFTER the connection emits
+                                // its first data frame — that's the only
+                                // truthful "Depth-20 connection is live"
+                                // signal Dhan gives us. Increment the
+                                // counter HERE, not at task spawn. Compare-
+                                // and-swap on the shared flag protects
+                                // against double-increment if `signal_rx`
+                                // somehow fires twice (it cannot — oneshot —
+                                // but the CAS makes the contract explicit).
+                                if !d20_truly_connected_for_signal
+                                    .swap(true, std::sync::atomic::Ordering::AcqRel)
+                                {
+                                    d20_health_for_signal.set_depth_20_connections(
+                                        d20_health_for_signal
+                                            .depth_20_connections()
+                                            .saturating_add(1),
+                                    );
+                                }
                                 notify_sender.notify(NotificationEvent::DepthTwentyConnected {
                                     underlying: notify_label,
                                 });
@@ -4351,6 +4394,18 @@ async fn main() -> Result<()> {
                             depth_200_spawn_index = depth_200_spawn_index.saturating_add(1);
                             let (d200_signal_tx, d200_signal_rx) =
                                 tokio::sync::oneshot::channel::<()>();
+                            // PR #460 (2026-05-04): truthful-emit pattern for
+                            // depth-200 (mirror of depth-20 above). Counter
+                            // is gated on signal_rx firing (= first data
+                            // frame received). Shared flag prevents double-
+                            // increment / decrement-without-increment.
+                            let d200_truly_connected =
+                                std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                            let d200_truly_connected_for_signal =
+                                std::sync::Arc::clone(&d200_truly_connected);
+                            let d200_truly_connected_for_exit =
+                                std::sync::Arc::clone(&d200_truly_connected);
+                            let d200_health_for_signal = d200_health.clone();
                             // Command channel for live 200-level rebalance (zero disconnect).
                             let d200_handle_key = format!("{underlying}-{opt_label}"); // e.g. "NIFTY-CE"
                             let (d200_cmd_tx, d200_cmd_rx) = tokio::sync::mpsc::channel::<
@@ -4364,9 +4419,8 @@ async fn main() -> Result<()> {
                                 });
                             }
                             let d200_handle = tokio::spawn(async move {
-                                d200_health.set_depth_200_connections(
-                                    d200_health.depth_200_connections().saturating_add(1),
-                                );
+                                // PR #460: NO increment-on-spawn. Counter is
+                                // gated on d200_signal_rx firing.
 
                                 if let Err(err) =
                                     tickvault_core::websocket::run_two_hundred_depth_connection(
@@ -4421,6 +4475,13 @@ async fn main() -> Result<()> {
                                             },
                                         );
                                     }
+                                }
+                                // PR #460: decrement on EVERY task exit (Ok
+                                // or Err) but ONLY if we had previously
+                                // incremented (signal fired).
+                                if d200_truly_connected_for_exit
+                                    .swap(false, std::sync::atomic::Ordering::AcqRel)
+                                {
                                     d200_health.set_depth_200_connections(
                                         d200_health.depth_200_connections().saturating_sub(1),
                                     );
@@ -4439,6 +4500,19 @@ async fn main() -> Result<()> {
                                 let notify_sender = notifier.clone();
                                 tokio::spawn(async move {
                                     if d200_signal_rx.await.is_ok() {
+                                        // PR #460: truthful-emit. Increment
+                                        // counter ONLY when first data frame
+                                        // arrives (signal fires). CAS prevents
+                                        // double-increment.
+                                        if !d200_truly_connected_for_signal
+                                            .swap(true, std::sync::atomic::Ordering::AcqRel)
+                                        {
+                                            d200_health_for_signal.set_depth_200_connections(
+                                                d200_health_for_signal
+                                                    .depth_200_connections()
+                                                    .saturating_add(1),
+                                            );
+                                        }
                                         notify_sender.notify(
                                             NotificationEvent::DepthTwoHundredConnected {
                                                 contract: d200_label_for_signal,

--- a/crates/app/tests/depth_pools_truthful_emit_guard.rs
+++ b/crates/app/tests/depth_pools_truthful_emit_guard.rs
@@ -1,0 +1,136 @@
+//! PR #460 ratchet — depth-20 + depth-200 counter increments are gated on
+//! the truthful "first data frame received" signal, not task spawn.
+//!
+//! Pre-PR #460 the depth-20 + depth-200 task-spawn blocks in `main.rs`
+//! incremented `set_depth_20_connections(...).saturating_add(1)` /
+//! `set_depth_200_connections(...).saturating_add(1)` IMMEDIATELY at
+//! task spawn — before any handshake / subscribe ack / data frame.
+//! That was a false-OK: the operator received "Depth-20: 5/5" before
+//! any Dhan data was actually flowing, and even today (2026-05-04)
+//! saw "Depth-20: 5/4" while `deep_market_depth` table stayed empty.
+//!
+//! This test enforces the truthful pattern via source-scan: the saturating
+//! increment of the depth counters MUST be inside an `if !`-guarded
+//! `swap(true, ...)` CAS block (= "if we hadn't already counted this
+//! connection as truthfully-Connected, count it now"). The CAS body
+//! can ONLY be reached from the signal-rx waiter spawn, which fires
+//! after first data frame.
+//!
+//! If a future regression moves the increment back to the bare task-
+//! spawn block (no CAS), this test fails the build.
+//!
+//! Run: `cargo test -p tickvault-app --test depth_pools_truthful_emit_guard`
+
+use std::path::PathBuf;
+
+fn main_rs() -> String {
+    let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "src", "main.rs"]
+        .iter()
+        .collect();
+    std::fs::read_to_string(&path).expect("crates/app/src/main.rs must be readable")
+}
+
+/// Every `set_depth_20_connections(... saturating_add(1) ...)` MUST be
+/// preceded (within a small contextual window) by `d20_truly_connected`
+/// CAS — the truthful-emit gate. PR #460 contract.
+#[test]
+fn depth_20_increment_is_gated_on_truly_connected_swap() {
+    let src = main_rs();
+    let increment_count = src.matches("set_depth_20_connections").count();
+    assert!(
+        increment_count >= 2,
+        "Expected >= 2 occurrences of set_depth_20_connections (one increment, \
+         one decrement); found {increment_count}. The depth-20 counter wiring \
+         must exist in main.rs."
+    );
+    // The truthful-emit pattern requires the SHARED FLAG identifier to
+    // appear in the file. If a regression deletes the gate, the flag
+    // disappears.
+    assert!(
+        src.contains("d20_truly_connected"),
+        "PR #460 truthful-emit invariant violated: the `d20_truly_connected` \
+         AtomicBool gate is missing. The depth-20 counter increment must be \
+         gated on the signal-rx-fires CAS, not on task spawn."
+    );
+    // The CAS body must increment, the exit-path must decrement under
+    // the same gate.
+    assert!(
+        src.contains("d20_truly_connected_for_signal")
+            && src.contains("d20_truly_connected_for_exit"),
+        "PR #460 truthful-emit invariant violated: missing one of \
+         d20_truly_connected_for_signal / d20_truly_connected_for_exit. \
+         Both must exist so the signal-rx waiter can flip the flag and \
+         the connection-runner can decrement only if it had been flipped."
+    );
+}
+
+/// Same contract for depth-200.
+#[test]
+fn depth_200_increment_is_gated_on_truly_connected_swap() {
+    let src = main_rs();
+    let increment_count = src.matches("set_depth_200_connections").count();
+    assert!(
+        increment_count >= 2,
+        "Expected >= 2 occurrences of set_depth_200_connections (one increment, \
+         one decrement); found {increment_count}."
+    );
+    assert!(
+        src.contains("d200_truly_connected"),
+        "PR #460 truthful-emit invariant violated: the `d200_truly_connected` \
+         AtomicBool gate is missing for depth-200."
+    );
+    assert!(
+        src.contains("d200_truly_connected_for_signal")
+            && src.contains("d200_truly_connected_for_exit"),
+        "PR #460 truthful-emit invariant violated: missing one of \
+         d200_truly_connected_for_signal / d200_truly_connected_for_exit."
+    );
+}
+
+/// The OLD pattern is BANNED. Specifically: the literal string
+/// `set_depth_20_connections(\n` followed by an immediate
+/// `saturating_add(1)` was the signature of the false-OK.
+/// We require the increment to ALWAYS be inside an `if !` CAS block.
+#[test]
+fn depth_20_no_immediate_post_spawn_increment() {
+    let src = main_rs();
+    // Find every increment site and confirm it's preceded by the CAS
+    // marker within a 200-character lookback window. This is a
+    // heuristic — the goal is to fail the build on the legacy pattern
+    // without false-positives.
+    for (idx, _) in src.match_indices("set_depth_20_connections(") {
+        // Look back ~600 chars for either the CAS marker or the
+        // explicit "PR #460" comment that flags the truthful emit.
+        let lookback = idx.saturating_sub(600);
+        let context = &src[lookback..idx];
+        let cas_present = context.contains("d20_truly_connected_for_signal")
+            || context.contains("d20_truly_connected_for_exit")
+            || context.contains("PR #460");
+        assert!(
+            cas_present,
+            "PR #460 truthful-emit invariant violated near byte offset {idx}: \
+             a `set_depth_20_connections(...)` call is NOT preceded by the \
+             `d20_truly_connected` CAS marker within 600 chars. The legacy \
+             increment-on-spawn pattern has been banned. Use the truthful-\
+             emit pattern: gate the counter on signal-rx firing."
+        );
+    }
+}
+
+#[test]
+fn depth_200_no_immediate_post_spawn_increment() {
+    let src = main_rs();
+    for (idx, _) in src.match_indices("set_depth_200_connections(") {
+        let lookback = idx.saturating_sub(600);
+        let context = &src[lookback..idx];
+        let cas_present = context.contains("d200_truly_connected_for_signal")
+            || context.contains("d200_truly_connected_for_exit")
+            || context.contains("PR #460");
+        assert!(
+            cas_present,
+            "PR #460 truthful-emit invariant violated near byte offset {idx}: \
+             a `set_depth_200_connections(...)` call is NOT preceded by the \
+             `d200_truly_connected` CAS marker within 600 chars."
+        );
+    }
+}

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -322,13 +322,13 @@ pub enum NotificationEvent {
     },
 
     /// Audit Finding #5 (2026-05-03): pre-market positive-readiness ping.
-    /// Fires once per trading day at 09:14:00 IST — exactly 1 minute
-    /// before the NSE opening bell. Reports current subscription counts
-    /// + token expiry headroom so the operator has a positive "we are
+    /// Fires once per trading day at 09:14:00 IST (exactly 1 minute
+    /// before the NSE opening bell). Reports current subscription counts
+    /// and token expiry headroom so the operator has a positive "we are
     /// READY for the open" signal, not just the existing 09:15:30
     /// post-open confirmation. Closes the false-OK gap from
     /// audit-findings-2026-04-17.md Rule 11. Severity = Info so it never
-    /// pages — it is purely a positive signal. Edge-trigger: fires
+    /// pages (it is purely a positive signal). Edge-trigger: fires
     /// exactly once per trading day, never on mid-session boot past
     /// 09:14:00 IST.
     MarketOpenReadinessConfirmation {


### PR DESCRIPTION
## Summary

Applies the **PR #458 truthful-emit pattern** from main feed to the depth-20 + depth-200 connection spawn paths. Today's `Depth-20: 5/4` numerator was the **task spawn count** (false-OK) — same bug class PR #458 just fixed for main pool.

## Root cause

`crates/app/src/main.rs:4087` (depth-20) + `:4344` (depth-200) incremented their counters **at task spawn**, before any handshake / subscribe ack / data frame:

```rust
// LEGACY (false-OK):
tokio::spawn(async move {
    d20_health.set_depth_20_connections(...saturating_add(1));  // SPAWN
    if let Err(err) = run_twenty_depth_connection(...).await {
        ...
        d20_health.set_depth_20_connections(...saturating_sub(1)); // ERR-only
    }
});
```

Tasks stuck in `Connecting` forever counted as connected, while `deep_market_depth` table stayed empty.

## Fix

Each spawn now uses an `Arc<AtomicBool>` shared between connection-runner + signal-rx waiter:

1. Spawn task does **NOT** increment.
2. Signal-rx waiter increments ONLY when `signal_rx` fires (= first data frame received). CAS prevents double-increment.
3. Spawn task decrements at exit (any path) ONLY if the flag was flipped (no underflow when handshake times out before signal).

The signal-rx path was already vetted as the source of `DepthTwentyConnected` / `DepthTwoHundredConnected` per-conn Telegrams.

## Operator-visible impact

After PR #459 + this PR land, the 09:14:00 IST heartbeat shows **truthful** counters:

- `Depth-20: 0/5` early in boot (no conns streaming yet)
- `Depth-20: 5/5` only after all 5 deliver first data frame
- `Depth-20: 3/5` when 2 conns are stuck in handshake / far-OTM filtering

If today's `deep_market_depth` empty bug recurs, the operator sees **`0/5`** instead of the misleading `5/4` — immediate, unambiguous.

## Ratchet test (4 source-scan tests)

`crates/app/tests/depth_pools_truthful_emit_guard.rs`:

1. `depth_20_increment_is_gated_on_truly_connected_swap` — pins the flag + `_for_signal` / `_for_exit` clones.
2. `depth_200_increment_is_gated_on_truly_connected_swap` — same for depth-200.
3. `depth_20_no_immediate_post_spawn_increment` — every `set_depth_20_connections(...)` MUST be preceded by `d20_truly_connected` CAS marker within 600 chars. Bans the legacy pattern.
4. `depth_200_no_immediate_post_spawn_increment` — same for depth-200.

## Side-fix

Same `clippy::doc_lazy_continuation` doc-comment fix as PR #457/#459 (pre-existing pre-`-D warnings` lint that surfaces on workspace rebuild).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace -- -D warnings -W clippy::perf` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p tickvault-app --test depth_pools_truthful_emit_guard` — 4/4 passed
- [x] `cargo test -p tickvault-app --tests` — all green

## Diff

```
crates/app/src/main.rs                                  | 86 +++++++--
crates/app/tests/depth_pools_truthful_emit_guard.rs (NEW, 130 lines)
crates/core/src/notification/events.rs                  |  8 +-
```

https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHZdvDoXa38Mc59EAWMCaS)_