### PR TITLE
feat(core,storage,app): Phase 2.8 — HIGH findings from adversarial review

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -3315,23 +3315,55 @@ async fn main() -> Result<()> {
         );
         let tick_enricher =
             std::sync::Arc::new(tickvault_core::pipeline::tick_enricher::TickEnricher::new());
-        match tick_enricher
+        // Phase 2.8 H4 fix: only mark the gate ready on Ok. On Err the
+        // gate stays in `AwaitingOiCache` and `try_authorize_subscribe`
+        // refuses authorization — the operator gets a typed ERROR
+        // (PREVCLOSE-01) and Telegram, not a False-OK. Loading
+        // graceful-degrades on truly empty candles_1d (Ok with
+        // count=0), only flagging the actual QuestDB-unreachable /
+        // schema-broken cases as failures.
+        let oi_cache_load_succeeded = match tick_enricher
             .prev_oi_cache
             .load_from_questdb(&config.questdb)
             .await
         {
-            Ok(count) => tracing::info!(
-                entries = count,
-                "prev_oi_cache loaded for tick enricher (Phase 2.6 production attach)"
-            ),
-            Err(err) => tracing::warn!(
-                ?err,
-                "prev_oi_cache load failed; enricher continues with empty cache \
-                 (prev_day_oi=0 default → formulas return 0.0 pct, graceful \
-                 degradation per L14)"
-            ),
+            Ok(count) => {
+                tracing::info!(
+                    entries = count,
+                    "prev_oi_cache loaded for tick enricher (Phase 2.6 production attach)"
+                );
+                metrics::counter!("tv_prev_oi_cache_load_total", "outcome" => "ok").increment(1);
+                if count == 0 {
+                    // Phase 2.8 H3 partial fix: emit a Prom counter +
+                    // structured WARN so an empty candles_1d doesn't
+                    // silently produce 0% OI changes for the day. The
+                    // gate still authorizes (count=0 is valid for fresh
+                    // deploy / first trading day), but operator sees
+                    // the diagnostic.
+                    metrics::counter!("tv_prev_oi_cache_empty_total").increment(1);
+                    tracing::warn!(
+                        "prev_oi_cache loaded zero entries — fresh deploy or candles_1d \
+                         empty for the prior trading day. OI Change panels will read 0% \
+                         until the next IST midnight rollover repopulates the cache."
+                    );
+                }
+                true
+            }
+            Err(err) => {
+                tracing::error!(
+                    code = tickvault_common::error_code::ErrorCode::PrevClose01IlpFailed.code_str(),
+                    ?err,
+                    "prev_oi_cache load FAILED — boot ordering gate stays \
+                     AwaitingOiCache, subscribe will not be authorized this boot. \
+                     Investigate QuestDB candles_1d availability."
+                );
+                metrics::counter!("tv_prev_oi_cache_load_total", "outcome" => "err").increment(1);
+                false
+            }
+        };
+        if oi_cache_load_succeeded {
+            boot_ordering_gate.mark_oi_cache_loaded();
         }
-        boot_ordering_gate.mark_oi_cache_loaded();
         boot_ordering_gate.mark_engines_ready();
         boot_ordering_gate.mark_replay_completed();
         if !boot_ordering_gate.try_authorize_subscribe() {

--- a/crates/core/src/pipeline/prev_oi_cache.rs
+++ b/crates/core/src/pipeline/prev_oi_cache.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 
 use papaya::HashMap;
 use reqwest::Client;
-use tracing::{info, warn};
+use tracing::{error, info};
 
 use tickvault_common::config::QuestDbConfig;
 
@@ -176,16 +176,20 @@ impl PrevOiCache {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            warn!(
+            // Phase 2.8 H4 fix (security/hostile review): on failure
+            // we do NOT mark loaded=true. Without that flag the
+            // BootOrderingGate stays in `AwaitingOiCache`, which the
+            // caller logs as ERROR + Telegram. Treating this as
+            // "loaded with empty cache" was the False-OK class bug
+            // flagged by the adversarial review — operator never
+            // saw a signal that QuestDB candles_1d failed to load.
+            error!(
+                code = tickvault_common::error_code::ErrorCode::PrevClose01IlpFailed.code_str(),
                 %status,
                 body = body.chars().take(200).collect::<String>(),
-                "prev_oi_cache load returned non-success — cache stays empty"
+                "prev_oi_cache load returned non-success — gate stays AwaitingOiCache; \
+                 operator must investigate before next subscribe"
             );
-            // Mark loaded=true even on empty/error so the boot gate
-            // doesn't block forever. The downstream lookup returns None
-            // → NULL OI → 0.0 pct change. Graceful degradation.
-            self.loaded
-                .store(true, std::sync::atomic::Ordering::Release);
             return Err(LoadError::QuestDbError {
                 status: status.as_u16(),
             });
@@ -259,19 +263,37 @@ fn segment_str_to_code(s: &str) -> Option<u8> {
     }
 }
 
-/// Errors that can arise during cache load. The boot-ordering gate (L14)
-/// treats every variant as graceful degradation (cache stays empty,
-/// boot continues) — these errors only surface in metrics/logs.
+/// Errors that can arise during cache load.
+///
+/// Phase 2.8 security HIGH fix: the `Display` form of `reqwest::Error`
+/// includes the full URL with any query params. While this code uses
+/// the internal QuestDB endpoint (no secrets in the URL), the pattern
+/// is defence-in-depth — if a future commit reuses this struct's
+/// `Display` for an authenticated endpoint (Dhan REST, auth.dhan.co)
+/// the bearer token in the URL would leak into Loki + Telegram. The
+/// new `Display` form embeds `reqwest::Error::status()` only — never
+/// `{0}` of the inner error. The full underlying error is still
+/// available via `#[source]` for structured logging that opts into it
+/// explicitly.
 #[derive(Debug, thiserror::Error)]
 pub enum LoadError {
-    #[error("failed to build HTTP client: {0}")]
-    HttpClient(reqwest::Error),
-    #[error("HTTP request to QuestDB failed: {0}")]
-    HttpRequest(reqwest::Error),
+    #[error("failed to build HTTP client (reqwest internal error)")]
+    HttpClient(#[source] reqwest::Error),
+    #[error(
+        "HTTP request to QuestDB failed: kind={} status={:?}",
+        if .0.is_timeout() { "timeout" }
+        else if .0.is_connect() { "connect" }
+        else if .0.is_request() { "request" }
+        else if .0.is_body() { "body" }
+        else if .0.is_decode() { "decode" }
+        else { "other" },
+        .0.status()
+    )]
+    HttpRequest(#[source] reqwest::Error),
     #[error("QuestDB returned non-success status {status}")]
     QuestDbError { status: u16 },
-    #[error("failed to parse QuestDB response JSON: {0}")]
-    JsonParse(serde_json::Error),
+    #[error("failed to parse QuestDB response JSON")]
+    JsonParse(#[source] serde_json::Error),
     #[error("malformed security_id in QuestDB row")]
     MalformedSecurityId,
     #[error("malformed segment in QuestDB row")]

--- a/crates/core/tests/phase2_8_high_findings_fixes.rs
+++ b/crates/core/tests/phase2_8_high_findings_fixes.rs
@@ -1,0 +1,151 @@
+//! Phase 2.8 — HIGH findings from the 3-agent adversarial review.
+//!
+//! Pins the four fixes from the security + hostile-bug-hunt reports
+//! on the Phase 2 production diff:
+//!
+//! - **H4** — `prev_oi_cache.load_from_questdb` failure DOES NOT mark
+//!   the gate ready; main.rs gates `mark_oi_cache_loaded` on Ok only,
+//!   so an actual QuestDB failure surfaces as ERROR + Telegram instead
+//!   of silently authorizing subscribe.
+//! - **H3** — empty cache (Ok with count=0) emits a structured WARN +
+//!   Prom counter `tv_prev_oi_cache_empty_total` so the False-OK is
+//!   visible to the operator.
+//! - **H2** — `phase_code_to_str` returns "UNKNOWN" (not the previous
+//!   silent default-to-PREMARKET) for out-of-range codes; the
+//!   `tv_phase_code_unknown_total` counter increments per occurrence.
+//! - **Security HIGH** — `LoadError::HttpRequest` Display NO LONGER
+//!   embeds `reqwest::Error::Display` (which leaks the URL). The new
+//!   form emits `kind=` + `status=` only.
+
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let me = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    me.parent()
+        .expect("tickvault root")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+        .join("crates")
+}
+
+fn read(rel: &str) -> String {
+    let p = workspace_root().join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|err| panic!("read {p:?}: {err}"))
+}
+
+#[test]
+fn h4_main_rs_gates_mark_oi_cache_loaded_on_ok_only() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("oi_cache_load_succeeded"),
+        "main.rs must declare an oi_cache_load_succeeded flag from the load match (H4 fix)"
+    );
+    assert!(
+        src.contains("if oi_cache_load_succeeded {")
+            && src.contains("boot_ordering_gate.mark_oi_cache_loaded();"),
+        "main.rs must conditionally call mark_oi_cache_loaded ONLY when load succeeded — \
+         H4 fix: failure leaves the gate in AwaitingOiCache so try_authorize_subscribe refuses"
+    );
+}
+
+#[test]
+fn h4_main_rs_logs_load_failure_at_error_level_with_typed_code() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("tracing::error!"),
+        "main.rs must log prev_oi_cache load failure at ERROR level (H4 fix — Loki → Telegram)"
+    );
+    assert!(
+        src.contains("ErrorCode::PrevClose01IlpFailed"),
+        "main.rs must tag the prev_oi_cache load failure with a typed ErrorCode (H4 fix)"
+    );
+}
+
+#[test]
+fn h4_main_rs_emits_outcome_metric() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("tv_prev_oi_cache_load_total")
+            && src.contains("\"outcome\" => \"ok\"")
+            && src.contains("\"outcome\" => \"err\""),
+        "main.rs must emit tv_prev_oi_cache_load_total with both `outcome=ok` and `outcome=err` labels"
+    );
+}
+
+#[test]
+fn h3_main_rs_emits_empty_cache_diagnostic() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("tv_prev_oi_cache_empty_total"),
+        "main.rs must emit tv_prev_oi_cache_empty_total counter when count == 0 (H3 False-OK fix)"
+    );
+    assert!(
+        src.contains("prev_oi_cache loaded zero entries"),
+        "main.rs must emit a structured WARN log line when load succeeds but returns zero entries"
+    );
+}
+
+#[test]
+fn h2_phase_code_to_str_returns_unknown_for_out_of_range() {
+    let src = read("storage/src/tick_persistence.rs");
+    // The function body must explicitly return "UNKNOWN" on the
+    // catch-all arm — not "PREMARKET".
+    assert!(
+        src.contains("\"UNKNOWN\""),
+        "phase_code_to_str must return \"UNKNOWN\" for out-of-range codes (H2 drift hazard fix)"
+    );
+    // Confirm the producer-side counter exists.
+    assert!(
+        src.contains("tv_phase_code_unknown_total"),
+        "phase_code_to_str must increment tv_phase_code_unknown_total on the UNKNOWN arm"
+    );
+}
+
+#[test]
+fn security_h_load_error_http_request_does_not_embed_reqwest_display() {
+    let src = read("core/src/pipeline/prev_oi_cache.rs");
+    // The legacy form was `#[error("HTTP request to QuestDB failed: {0}")]`
+    // — that pattern interpolates `Display` of the inner `reqwest::Error`
+    // which can include the full URL. The fix uses `#[source]` and a
+    // custom format string with `kind=` + `status=` only.
+    assert!(
+        !src.contains("\"HTTP request to QuestDB failed: {0}\""),
+        "LoadError::HttpRequest must NOT use `{{0}}` interpolation \
+         (security fix: avoid leaking reqwest::Error URL to logs)"
+    );
+    assert!(
+        src.contains("HttpRequest(#[source] reqwest::Error)"),
+        "LoadError::HttpRequest must use #[source] for the inner error \
+         (security fix: separate machine-readable cause from human-readable Display)"
+    );
+}
+
+#[test]
+fn security_h_load_error_http_client_does_not_embed_reqwest_display() {
+    let src = read("core/src/pipeline/prev_oi_cache.rs");
+    assert!(
+        !src.contains("\"failed to build HTTP client: {0}\""),
+        "LoadError::HttpClient must NOT interpolate {{0}} (security fix)"
+    );
+    assert!(
+        src.contains("HttpClient(#[source] reqwest::Error)"),
+        "LoadError::HttpClient must use #[source]"
+    );
+}
+
+#[test]
+fn security_h_load_error_json_parse_does_not_embed_serde_display() {
+    let src = read("core/src/pipeline/prev_oi_cache.rs");
+    // serde_json::Error's Display can include the input snippet. For
+    // defence-in-depth we keep the cause via #[source] but don't
+    // interpolate {0}.
+    assert!(
+        !src.contains("\"failed to parse QuestDB response JSON: {0}\""),
+        "LoadError::JsonParse must NOT interpolate {{0}} (security fix)"
+    );
+    assert!(
+        src.contains("JsonParse(#[source] serde_json::Error)"),
+        "LoadError::JsonParse must use #[source]"
+    );
+}

--- a/crates/storage/src/tick_persistence.rs
+++ b/crates/storage/src/tick_persistence.rs
@@ -1327,9 +1327,21 @@ pub struct TickLifecycle {
 }
 
 /// Map `Phase::as u8` to the canonical SYMBOL string written into
-/// QuestDB. Bounded 5-entry dictionary. Unknown codes map to
-/// PREMARKET as a safe default — out-of-range values would indicate
-/// a producer bug rather than a routing decision.
+/// QuestDB. Bounded 6-entry dictionary including the explicit
+/// "UNKNOWN" sentinel.
+///
+/// Phase 2.8 H2 fix (hostile bug-hunt drift hazard): out-of-range
+/// codes return "UNKNOWN" — NOT "PREMARKET". The previous default-to-
+/// PREMARKET behavior silently mislabeled future Phase variants
+/// (e.g. a hypothetical `Phase::Halted = 5`) as PREMARKET, masking
+/// a producer bug as legitimate data. The "UNKNOWN" string is its
+/// own SYMBOL value so dashboards and audits can detect the drift
+/// immediately. Operators see "UNKNOWN" in the panel and trace the
+/// bug; they don't see "PREMARKET" and assume nothing's wrong.
+///
+/// A producer-side counter `tv_phase_code_unknown_total` is
+/// incremented on every UNKNOWN return so the drift surfaces in
+/// metrics + alerts independently of QuestDB.
 #[inline]
 fn phase_code_to_str(code: u8) -> &'static str {
     match code {
@@ -1338,7 +1350,14 @@ fn phase_code_to_str(code: u8) -> &'static str {
         2 => "OPEN",
         3 => "POSTAUCTION",
         4 => "CLOSED",
-        _ => "PREMARKET",
+        _ => {
+            // Increment a counter on the UNKNOWN path so the drift
+            // surfaces in metrics regardless of where the bad code
+            // came from. The counter creation is idempotent — first
+            // call registers, later calls just increment.
+            metrics::counter!("tv_phase_code_unknown_total").increment(1);
+            "UNKNOWN"
+        }
     }
 }
 
@@ -3528,14 +3547,23 @@ mod tests {
         assert_eq!(phase_code_to_str(4), "CLOSED");
     }
 
-    /// Phase 2 ratchet: out-of-range codes safely default to PREMARKET
-    /// rather than panic. A producer bug would surface as the safe
-    /// default in the SYMBOL dictionary.
+    /// Phase 2.8 H2 ratchet (drift hazard): out-of-range codes return
+    /// "UNKNOWN" — NOT "PREMARKET". The old default-to-PREMARKET
+    /// behavior silently mislabeled future variants (e.g. hypothetical
+    /// `Phase::Halted = 5`) as healthy PREMARKET, masking the bug.
+    /// "UNKNOWN" is its own SYMBOL string so dashboards + audits can
+    /// detect the drift; the producer-side
+    /// `tv_phase_code_unknown_total` counter increments on every
+    /// UNKNOWN return.
     #[test]
-    fn test_phase_code_to_str_unknown_defaults_premarket() {
-        assert_eq!(phase_code_to_str(5), "PREMARKET");
-        assert_eq!(phase_code_to_str(99), "PREMARKET");
-        assert_eq!(phase_code_to_str(255), "PREMARKET");
+    fn test_phase_code_to_str_unknown_returns_unknown_not_premarket() {
+        assert_eq!(
+            phase_code_to_str(5),
+            "UNKNOWN",
+            "code 5 must NOT silently map to PREMARKET — H2 fix"
+        );
+        assert_eq!(phase_code_to_str(99), "UNKNOWN");
+        assert_eq!(phase_code_to_str(255), "UNKNOWN");
     }
 
     /// Phase 2 ratchet: `TickLifecycle` defaults match the legacy


### PR DESCRIPTION
## Summary

**Phase 2.8 — 4 HIGH findings from the 3-agent adversarial review on Phase 2 production code.** All four are operator-visibility / silent-failure fixes — the production code already worked, but failures were hidden behind False-OK signals or untyped warnings.

## What changes

### H4 — `prev_oi_cache.load_from_questdb` failure no longer marks gate Ok

**Before:** the loader internally set `loaded=true` on the error path "so the boot gate doesn't block forever". Classic False-OK Rule 11 bug — operator never saw a signal that QuestDB candles_1d was unreachable; gate authorized subscribe with empty cache.

**After:** failure path no longer flips `loaded=true`. `main.rs` gates `mark_oi_cache_loaded()` on the `Ok` arm only. On `Err`: ERROR-level log with typed `code = ErrorCode::PrevClose01IlpFailed` (Loki → Telegram); gate stays in `AwaitingOiCache`; `try_authorize_subscribe()` refuses authorization. New Prom counter `tv_prev_oi_cache_load_total{outcome="ok"|"err"}`.

### H3 — empty cache (`Ok` with `count=0`) was silently producing 0% OI changes

**Before:** legitimate fresh-deploy state but indistinguishable from "everything moved exactly 0%" on dashboards.

**After:** new Prom counter `tv_prev_oi_cache_empty_total` increments. Structured WARN log line explains the cause. Dashboards can alert on increase rate.

### H2 — `phase_code_to_str` silent default to PREMARKET (drift hazard)

**Before:** out-of-range codes returned `"PREMARKET"`, silently mislabeling future Phase variants (e.g. hypothetical `Phase::Halted = 5`) as healthy.

**After:** returns `"UNKNOWN"` (its own SYMBOL string, visible in dashboards). Producer-side counter `tv_phase_code_unknown_total` increments per occurrence. Test renamed `test_phase_code_to_str_unknown_returns_unknown_not_premarket`.

### Security HIGH — `reqwest::Error` URL leak in `LoadError` Display

**Before:** `#[error("HTTP request to QuestDB failed: {0}")]` interpolates Display of `reqwest::Error` which includes the full URL with any query params. Internal QuestDB has no secrets in URL today, but the pattern is unsafe — if a future commit reuses this Display for an authenticated endpoint (Dhan REST, auth.dhan.co), bearer token in URL leaks into Loki + Telegram.

**After:** `LoadError::HttpRequest(#[source] reqwest::Error)` separates Display from cause. Display emits `kind=` (timeout/connect/request/body/decode/other) + `status=` only — never URL. Same fix on `HttpClient` + `JsonParse` variants. Source chain still available via `Error::source()`.

## Ratchets

8 source-scan tests in `crates/core/tests/phase2_8_high_findings_fixes.rs`:
- H4: gates mark on Ok only, ERROR with typed code, outcome metric
- H3: empty cache counter + structured WARN
- H2: returns UNKNOWN (not PREMARKET) for out-of-range
- Security: 3 LoadError variants don't embed `{0}` interpolation

## Honest 100% envelope (per plan §9)

100% inside the tested envelope, with ratcheted regression coverage:
- Every load-path outcome (Ok with entries, Ok with zero, Err) has a typed visibility signal
- `phase_code_to_str` UNKNOWN drift surfaces in metrics regardless of dashboard read
- LoadError Display does NOT embed reqwest URL (defence-in-depth for future authenticated endpoints)
- 8 source-scan ratchets fail the build on regression
- Existing 26 prev_oi_cache + 2 phase_code_to_str tests continue to pass

Beyond the envelope: H1 (BootOrderingGate informational; WS pool doesn't read `subscribe_allowed()`) is the most invasive remaining HIGH finding and ships in a separate sub-PR.

## Test plan

- [x] `cargo test -p tickvault-core --test phase2_8_high_findings_fixes` — 8/8 pass
- [x] `cargo test -p tickvault-core --lib prev_oi_cache` — 26/26 pass
- [x] `cargo test -p tickvault-storage --lib test_phase_code_to_str` — 2/2 pass
- [x] `cargo build -p tickvault-app` clean
- [x] `cargo fmt --workspace` clean

https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ)_