### PR TITLE
feat(app): Phase 2.12 — boot-mode visibility via Prometheus gauge (L1 fix)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1364,6 +1364,24 @@ async fn main() -> Result<()> {
                 .await;
             });
             info!("FAST BOOT COMPLETE — tick processor started, ticks flowing (in-memory)");
+            // Phase 2.12 (hostile L1 fix): emit a boot-mode gauge so
+            // operators can chart fast/slow boot history. Fast boot
+            // intentionally passes None for tick_enricher (recovery
+            // path, no enrichment) — the gauge value 0 makes the
+            // missing lifecycle columns visible vs slow boot's value 1.
+            metrics::gauge!(
+                "tv_lifecycle_enricher_attached",
+                "boot_mode" => "fast"
+            )
+            .set(0.0);
+            info!(
+                boot_mode = "fast",
+                enricher_attached = false,
+                "BOOT MODE: fast (recovery path) — lifecycle columns will NOT be \
+                 populated this session; volume_delta/prev_day_close/prev_day_oi/phase \
+                 default to 0/0.0/0/PREMARKET. Operator: this is the expected fast-boot \
+                 contract; full lifecycle attaches on the next slow-boot restart."
+            );
             Some(handle)
         } else {
             info!("tick processor skipped — no frame source available");
@@ -3459,6 +3477,27 @@ async fn main() -> Result<()> {
         });
         info!(
             "tick processor started (with candle aggregation + top movers + option movers + trading broadcast)"
+        );
+        // Phase 2.12 (hostile L1 fix): boot-mode gauge for slow boot.
+        // value=1 indicates the lifecycle enricher is attached and the
+        // 4 ticks-table lifecycle columns will be populated this
+        // session. Operators can chart the time series:
+        //   tv_lifecycle_enricher_attached{boot_mode="slow"} 1
+        // → operator sees mode-switch (fast↔slow) in Prometheus
+        // history independent of the boot log.
+        metrics::gauge!(
+            "tv_lifecycle_enricher_attached",
+            "boot_mode" => "slow"
+        )
+        .set(1.0);
+        info!(
+            boot_mode = "slow",
+            enricher_attached = true,
+            "BOOT MODE: slow (production path) — TickEnricher attached, \
+             prev_oi_cache loaded, BootOrderingGate authorized, midnight \
+             rollover + periodic refresh tasks spawned. Lifecycle columns \
+             (volume_delta, prev_day_close, prev_day_oi, phase) will be \
+             populated for every live tick this session."
         );
         // Pipeline-active wiring (slow boot): mirror the fast-boot flip
         // above so the System Overview "Pipeline Status" tile reads

--- a/crates/core/tests/phase2_12_boot_mode_visibility.rs
+++ b/crates/core/tests/phase2_12_boot_mode_visibility.rs
@@ -1,0 +1,118 @@
+//! Phase 2.12 — hostile bug-hunt L1 fix: fast/slow boot mode
+//! visibility via Prometheus gauge.
+//!
+//! What was missing: fast boot passes `None` for `tick_enricher` (no
+//! lifecycle column population — recovery path). Slow boot passes
+//! `Some(enricher)` (full lifecycle population). If an operator
+//! switches between modes via process restart, the change was only
+//! visible in the boot log lines — not in Prometheus history,
+//! not in dashboards.
+//!
+//! The fix: emit `tv_lifecycle_enricher_attached{boot_mode="fast"|"slow"}`
+//! gauge at boot:
+//!   - fast boot: value 0.0 (lifecycle columns NOT populated)
+//!   - slow boot: value 1.0 (lifecycle columns populated)
+//!
+//! Operators can:
+//!   - Chart `tv_lifecycle_enricher_attached` over time to see mode
+//!     transitions
+//!   - Alert on transitions: a fast boot during business hours is a
+//!     warning signal (recovery mode active)
+//!   - Correlate with QuestDB column population — value=0 + 0 lifecycle
+//!     rows is the expected fast-boot contract; value=1 + 0 lifecycle
+//!     rows is a real bug
+//!
+//! Plus structured INFO log lines at both sites for human readability.
+
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let me = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    me.parent()
+        .expect("tickvault root")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+        .join("crates")
+}
+
+fn read(rel: &str) -> String {
+    let p = workspace_root().join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|err| panic!("read {p:?}: {err}"))
+}
+
+#[test]
+fn phase2_12_main_rs_emits_lifecycle_enricher_attached_gauge() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("tv_lifecycle_enricher_attached"),
+        "main.rs must emit tv_lifecycle_enricher_attached gauge at both boot sites"
+    );
+}
+
+#[test]
+fn phase2_12_fast_boot_sets_gauge_to_zero() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("\"boot_mode\" => \"fast\"") && src.contains(".set(0.0)"),
+        "fast boot must set gauge to 0.0 with boot_mode=fast label"
+    );
+}
+
+#[test]
+fn phase2_12_slow_boot_sets_gauge_to_one() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("\"boot_mode\" => \"slow\"") && src.contains(".set(1.0)"),
+        "slow boot must set gauge to 1.0 with boot_mode=slow label"
+    );
+}
+
+#[test]
+fn phase2_12_fast_boot_logs_enricher_attached_false() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("boot_mode = \"fast\"") && src.contains("enricher_attached = false"),
+        "fast boot must log structured boot_mode=fast + enricher_attached=false"
+    );
+}
+
+#[test]
+fn phase2_12_slow_boot_logs_enricher_attached_true() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("boot_mode = \"slow\"") && src.contains("enricher_attached = true"),
+        "slow boot must log structured boot_mode=slow + enricher_attached=true"
+    );
+}
+
+#[test]
+fn phase2_12_fast_boot_log_explains_lifecycle_columns_will_not_be_populated() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("lifecycle columns will NOT be")
+            || src.contains("lifecycle columns will not be populated"),
+        "fast boot log must clearly state that lifecycle columns will NOT be populated \
+         (operator-visible context for the recovery path)"
+    );
+}
+
+#[test]
+fn phase2_12_slow_boot_log_lists_attached_subsystems() {
+    let src = read("app/src/main.rs");
+    // Slow boot's structured log line names the subsystems that get
+    // wired in: TickEnricher, prev_oi_cache, BootOrderingGate,
+    // midnight rollover, periodic refresh.
+    assert!(
+        src.contains("TickEnricher attached"),
+        "slow boot log must mention TickEnricher attached"
+    );
+    assert!(
+        src.contains("prev_oi_cache loaded"),
+        "slow boot log must mention prev_oi_cache loaded"
+    );
+    assert!(
+        src.contains("BootOrderingGate authorized"),
+        "slow boot log must mention BootOrderingGate authorized"
+    );
+}


### PR DESCRIPTION
## Summary

**Phase 2.12 — L1 fix from the hostile bug-hunt review.** Adds Prometheus visibility for fast/slow boot mode + lifecycle enricher attachment state.

## What was missing

Fast boot passes `None` for `tick_enricher` (recovery path, no lifecycle column population). Slow boot passes `Some(enricher)` (production path, full population). If an operator switches between modes via process restart, the change was only visible in the boot log lines — not in Prometheus history, not in dashboards.

## The fix

`tv_lifecycle_enricher_attached{boot_mode="fast"|"slow"}` gauge emitted at both boot completion sites:
- Fast boot: value `0.0` (lifecycle columns NOT populated)
- Slow boot: value `1.0` (lifecycle columns populated)

Plus structured INFO log lines at both sites with explicit context:
- Fast: "lifecycle columns will NOT be populated this session"
- Slow: "TickEnricher attached, prev_oi_cache loaded, BootOrderingGate authorized..."

## Operator-visible improvements

- Chart `tv_lifecycle_enricher_attached` over time → see mode transitions
- Alert on transitions: a fast boot during business hours = warning signal
- Correlate with QuestDB column population:
  - `value=0 + 0 lifecycle rows` = expected fast-boot contract
  - `value=1 + 0 lifecycle rows` = real bug

## Ratchets

7 source-scan tests in `crates/core/tests/phase2_12_boot_mode_visibility.rs`:
- Gauge name + both labels
- Fast boot value 0.0
- Slow boot value 1.0
- Both log structures (`boot_mode=` + `enricher_attached=`)
- Fast boot log explains lifecycle absence
- Slow boot log lists attached subsystems

## Honest 100% envelope (per plan §9)

100% inside the tested envelope:
- Both gauge values pinned by source-scan ratchets
- Both log structures pinned
- Test count baseline updated for Phase 2.10's legitimate test rename

Beyond the envelope: operator dashboards now see mode-switch contract clearly visible in Prometheus.

## Test plan

- [x] `cargo test -p tickvault-core --test phase2_12_boot_mode_visibility` — **7/7 pass**
- [x] `cargo build -p tickvault-app` clean
- [x] `cargo fmt --workspace` clean

https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ)_