### PR TITLE
perf(core): Phase 2.13 — remove dead ExchangeSegment::from_byte conversion (M2 fix)

### DIFF
--- a/crates/common/src/phase.rs
+++ b/crates/common/src/phase.rs
@@ -115,8 +115,34 @@ impl Phase {
 /// `_segment` is currently unused (NSE/BSE share boundaries today) but
 /// reserved so adding MCX commodity hours = extend the match without a
 /// signature change.
+///
+/// **Hot-path note:** when called from the tick enricher with a binary
+/// `exchange_segment_code` (u8), prefer `compute_phase_by_segment_code`
+/// to avoid the `ExchangeSegment::from_byte` enum conversion. Phase
+/// 2.13 fix (hot-path agent M2): the conversion was dead work since
+/// this function ignores the segment today.
 #[inline]
 pub fn compute_phase(now_ist_secs_of_day: u32, _segment: ExchangeSegment) -> Phase {
+    compute_phase_inner(now_ist_secs_of_day)
+}
+
+/// Hot-path-friendly variant: takes the binary segment code (u8) from
+/// `ParsedTick::exchange_segment_code` directly, avoiding the enum
+/// conversion. Behaviour is identical to `compute_phase` today
+/// (segment-agnostic). Phase 2.13 hot-path M2 fix.
+///
+/// `_segment_code` is reserved for future MCX commodity-hours support;
+/// for now it's ignored, matching `compute_phase`'s contract.
+#[inline]
+pub fn compute_phase_by_segment_code(now_ist_secs_of_day: u32, _segment_code: u8) -> Phase {
+    compute_phase_inner(now_ist_secs_of_day)
+}
+
+/// Shared boundary logic for both `compute_phase` and
+/// `compute_phase_by_segment_code`. Single source of truth — drift
+/// between the two public entry points is mechanically impossible.
+#[inline(always)]
+fn compute_phase_inner(now_ist_secs_of_day: u32) -> Phase {
     if now_ist_secs_of_day < TICK_PERSIST_START_SECS_OF_DAY_IST {
         Phase::Premarket
     } else if now_ist_secs_of_day < NSE_OPEN_SECS_OF_DAY_IST {
@@ -323,5 +349,60 @@ mod tests {
              updating QuestDB SYMBOL expectations and the matview rebuild \
              probe `views_missing_phase1_columns`"
         );
+    }
+
+    /// Phase 2.13 ratchet: name-matched explicit test for the new
+    /// `compute_phase_by_segment_code` public entry point. Verifies the
+    /// hot-path-friendly variant matches `compute_phase` for every IST
+    /// minute boundary across the day (1440 samples).
+    #[test]
+    fn test_compute_phase_by_segment_code_matches_legacy_compute_phase() {
+        // NSE_EQ binary code = 1 per Dhan annexure mapping.
+        for minute in 0..(24 * 60_u32) {
+            let secs = minute * 60;
+            let legacy = compute_phase(secs, ExchangeSegment::NseEquity);
+            let by_code = compute_phase_by_segment_code(secs, 1);
+            assert_eq!(legacy, by_code, "drift at minute {minute}");
+        }
+    }
+
+    /// Phase 2.13 ratchet: `compute_phase_by_segment_code` returns the
+    /// correct Phase for each canonical IST boundary.
+    #[test]
+    fn test_compute_phase_by_segment_code_boundaries_pinned() {
+        // 00:00 = PREMARKET
+        assert_eq!(compute_phase_by_segment_code(0, 1), Phase::Premarket);
+        // 09:00 = PREOPEN
+        assert_eq!(compute_phase_by_segment_code(9 * 3600, 1), Phase::Preopen);
+        // 09:15 = OPEN
+        assert_eq!(
+            compute_phase_by_segment_code(9 * 3600 + 15 * 60, 1),
+            Phase::Open
+        );
+        // 15:30 = POSTAUCTION
+        assert_eq!(
+            compute_phase_by_segment_code(15 * 3600 + 30 * 60, 1),
+            Phase::PostAuction
+        );
+        // 15:40 = CLOSED
+        assert_eq!(
+            compute_phase_by_segment_code(15 * 3600 + 40 * 60, 1),
+            Phase::Closed
+        );
+    }
+
+    /// Phase 2.13 ratchet: unknown segment codes (e.g. the gap at 6,
+    /// 99, 255) MUST NOT panic — they degrade to the segment-agnostic
+    /// behaviour matching `compute_phase`'s contract.
+    #[test]
+    fn test_compute_phase_by_segment_code_unknown_codes_do_not_panic() {
+        let secs_open = 9 * 3600 + 30 * 60;
+        for code in [6_u8, 99, 100, 200, 255] {
+            assert_eq!(
+                compute_phase_by_segment_code(secs_open, code),
+                Phase::Open,
+                "unknown code {code} must classify per the secs-of-day input only"
+            );
+        }
     }
 }

--- a/crates/core/src/pipeline/tick_enricher.rs
+++ b/crates/core/src/pipeline/tick_enricher.rs
@@ -38,9 +38,8 @@
 
 use tracing::info;
 
-use tickvault_common::phase::{Phase, compute_phase};
+use tickvault_common::phase::{Phase, compute_phase_by_segment_code};
 use tickvault_common::tick_types::ParsedTick;
-use tickvault_common::types::ExchangeSegment;
 
 use crate::pipeline::prev_day_close_stamper::PrevDayCloseStamper;
 use crate::pipeline::prev_oi_cache::PrevOiCache;
@@ -141,9 +140,11 @@ impl TickEnricher {
         // Previous-day OI (boot-loaded; defaults to 0 if missing).
         let prev_day_oi = self.prev_oi_cache.get(sid, seg).unwrap_or(0);
 
-        // Trading-day phase (pure-fn classifier).
-        let segment_enum = ExchangeSegment::from_byte(seg).unwrap_or(ExchangeSegment::IdxI);
-        let phase = compute_phase(now_ist_secs_of_day, segment_enum);
+        // Trading-day phase (pure-fn classifier). Phase 2.13 hot-path
+        // M2 fix: use the segment-code variant directly to skip the
+        // dead `ExchangeSegment::from_byte().unwrap_or(IdxI)` conversion
+        // (the enum result was ignored by compute_phase anyway).
+        let phase = compute_phase_by_segment_code(now_ist_secs_of_day, seg);
 
         EnrichedTick {
             tick,

--- a/crates/core/tests/phase2_13_segment_conversion_removed.rs
+++ b/crates/core/tests/phase2_13_segment_conversion_removed.rs
@@ -1,0 +1,127 @@
+//! Phase 2.13 — hot-path agent M2 fix: dead `ExchangeSegment::from_byte`
+//! conversion removed from the per-tick enrichment path.
+//!
+//! What was wasted: `compute_phase` ignores its `_segment` parameter
+//! today (NSE/BSE share boundaries; reserved for future MCX support).
+//! The enricher converted `tick.exchange_segment_code: u8` →
+//! `ExchangeSegment` enum (via `from_byte`) → passed it to
+//! `compute_phase` which immediately threw it away. At 25K tps that's
+//! 25,000 pointless conversions per second.
+//!
+//! The fix: new `compute_phase_by_segment_code(secs, code: u8)`
+//! variant takes the binary code directly. Behaviour identical to
+//! `compute_phase` today (via shared `compute_phase_inner`). Drift
+//! between the two entry points is mechanically impossible because
+//! they share the same private inner function.
+//!
+//! ## Hot-path impact
+//!
+//! Removes one match-on-int + one Option::unwrap_or per tick.
+//! ~3-5 ns saved per tick × 25,000 tps = ~100µs/sec total.
+//! Modest but free — the conversion was producing nothing.
+
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let me = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    me.parent()
+        .expect("tickvault root")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+        .join("crates")
+}
+
+fn read(rel: &str) -> String {
+    let p = workspace_root().join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|err| panic!("read {p:?}: {err}"))
+}
+
+#[test]
+fn phase2_13_compute_phase_by_segment_code_exists() {
+    let src = read("common/src/phase.rs");
+    assert!(
+        src.contains("pub fn compute_phase_by_segment_code"),
+        "phase.rs must export pub fn compute_phase_by_segment_code (Phase 2.13 hot-path M2 fix)"
+    );
+}
+
+#[test]
+fn phase2_13_shared_inner_function_avoids_drift() {
+    let src = read("common/src/phase.rs");
+    assert!(
+        src.contains("fn compute_phase_inner"),
+        "phase.rs must use a shared `compute_phase_inner` so both public entry points cannot drift"
+    );
+}
+
+#[test]
+fn phase2_13_tick_enricher_no_longer_calls_from_byte() {
+    let src = read("core/src/pipeline/tick_enricher.rs");
+    assert!(
+        !src.contains("ExchangeSegment::from_byte(seg)"),
+        "tick_enricher must NOT call ExchangeSegment::from_byte(seg) on the hot path \
+         after Phase 2.13 (dead conversion — compute_phase ignores the result)"
+    );
+}
+
+#[test]
+fn phase2_13_tick_enricher_uses_segment_code_variant() {
+    let src = read("core/src/pipeline/tick_enricher.rs");
+    assert!(
+        src.contains("compute_phase_by_segment_code(now_ist_secs_of_day, seg)"),
+        "tick_enricher must call compute_phase_by_segment_code(secs, seg) directly \
+         (Phase 2.13 hot-path M2 fix)"
+    );
+}
+
+#[test]
+fn phase2_13_exchange_segment_import_removed_from_enricher() {
+    let src = read("core/src/pipeline/tick_enricher.rs");
+    // The enricher no longer needs `ExchangeSegment` — confirm the
+    // import is gone (defence-in-depth: an unused import would still
+    // compile but signals dead code).
+    assert!(
+        !src.contains("use tickvault_common::types::ExchangeSegment;"),
+        "tick_enricher must NOT import ExchangeSegment after Phase 2.13 — unused"
+    );
+}
+
+/// Behaviour parity: the new `compute_phase_by_segment_code` produces
+/// the same Phase as the legacy `compute_phase` for every minute of
+/// the IST day. Defence-in-depth against future drift.
+#[test]
+fn phase2_13_segment_code_variant_matches_legacy_compute_phase() {
+    use tickvault_common::phase::{compute_phase, compute_phase_by_segment_code};
+    use tickvault_common::types::ExchangeSegment;
+
+    // Sweep every IST minute. For each segment-code/enum pair, the
+    // two functions MUST return identical Phase.
+    for minute in 0..(24 * 60_u32) {
+        let secs = minute * 60;
+        let legacy = compute_phase(secs, ExchangeSegment::NseEquity);
+        let by_code = compute_phase_by_segment_code(secs, 1); // NSE_EQ = 1
+        assert_eq!(
+            legacy, by_code,
+            "compute_phase vs compute_phase_by_segment_code mismatch at minute {minute}"
+        );
+    }
+}
+
+/// Edge case: passing an unknown segment code (e.g. 99, the gap at 6,
+/// 255) to `compute_phase_by_segment_code` must NOT panic and must
+/// return the same Phase as the segment-agnostic logic.
+#[test]
+fn phase2_13_unknown_segment_code_does_not_panic() {
+    use tickvault_common::phase::{Phase, compute_phase_by_segment_code};
+
+    let secs_open = 9 * 3600 + 30 * 60; // 09:30 IST = OPEN
+    for unknown_code in [6_u8, 99, 100, 255] {
+        let phase = compute_phase_by_segment_code(secs_open, unknown_code);
+        assert_eq!(
+            phase,
+            Phase::Open,
+            "unknown segment_code {unknown_code} must not affect phase classification"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 2.13 — Hot-path agent M2 fix.** Removes the dead `ExchangeSegment::from_byte()` conversion from the per-tick enrichment path.

## What was wasted

`compute_phase` ignores its `_segment` parameter today (NSE/BSE share boundaries; reserved for future MCX support). The enricher converted `tick.exchange_segment_code: u8` → `ExchangeSegment` enum (via `from_byte`) → passed it to `compute_phase` which immediately threw it away. **At 25K tps that's 25,000 pointless conversions per second.**

## The fix

- New `pub fn compute_phase_by_segment_code(secs, code: u8) -> Phase` in `phase.rs`
- Both public entry points delegate to a private `compute_phase_inner(secs)` so drift between them is mechanically impossible
- `tick_enricher.rs` calls the new variant directly:
  - **Before:** `compute_phase(secs, ExchangeSegment::from_byte(seg).unwrap_or(IdxI))`
  - **After:** `compute_phase_by_segment_code(secs, seg)`
- Removed unused `ExchangeSegment` import from tick_enricher

## Hot-path impact

- Removes 1 match-on-int + 1 `Option::unwrap_or` per tick
- ~3-5 ns saved per tick × 25,000 tps = ~100µs/sec total
- Modest but free — the conversion was producing nothing

## Ratchets

7 source-scan tests in `crates/core/tests/phase2_13_segment_conversion_removed.rs` + 3 unit tests in `phase::tests`:
- New entry point exists with correct signature
- Shared `compute_phase_inner` prevents drift
- Enricher no longer calls `from_byte`
- Enricher uses new variant
- `ExchangeSegment` import removed
- 1440-minute IST sweep proves byte-equal Phase output between old + new
- Unknown segment codes (6, 99, 255) don't panic
- Boundary phases pinned for new variant
- Behaviour parity verified at every IST minute

## Honest 100% envelope (per plan §9)

100% inside the tested envelope:
- Old + new functions produce byte-equal Phase values across 1440-minute IST day sweep
- Every IST boundary pinned for the new variant
- Unknown segment codes can't panic (defence-in-depth)
- Behavioural change is provably zero — only the conversion overhead is removed

Beyond the envelope: zero behavioural change in production, microoptimization with provably identical semantics.

## Test plan

- [x] `cargo test -p tickvault-common --lib phase` — **20/20 pass** (3 new ratchets)
- [x] `cargo test -p tickvault-core --test phase2_13_segment_conversion_removed` — **7/7 pass**
- [x] `cargo build -p tickvault-core` clean
- [x] `cargo fmt --workspace` clean

https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ)_