### PR TITLE
fix(storage): Phase 2.14 — DLQ reason tightened to &amp;&#39;static str (security MEDIUM)

### DIFF
--- a/crates/core/tests/phase2_14_dlq_reason_static.rs
+++ b/crates/core/tests/phase2_14_dlq_reason_static.rs
@@ -1,0 +1,64 @@
+//! Phase 2.14 — security MEDIUM fix: DLQ writer's `reason` field
+//! tightened to `&'static str`.
+//!
+//! What was at risk: the security review noted that the NDJSON DLQ
+//! writer accepts `reason: &str`. Today all callers use string literals
+//! (`"spill_open_failed"`, `"spill_write_failed"`, test fixtures), so
+//! injection is not active. But if a future caller passes a runtime
+//! string containing `"` or `\`, the NDJSON line would be malformed
+//! and unparseable during audit recovery.
+//!
+//! The fix: change the signature to `reason: &'static str`. The type
+//! system rejects any runtime string at the call site at compile time.
+//! This is a no-op runtime change but a hard compile-time contract.
+//!
+//! All current callers use string literals (which are `&'static str`),
+//! so the change is backward compatible and required no call-site
+//! updates.
+
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let me = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    me.parent()
+        .expect("tickvault root")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+        .join("crates")
+}
+
+fn read(rel: &str) -> String {
+    let p = workspace_root().join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|err| panic!("read {p:?}: {err}"))
+}
+
+#[test]
+fn phase2_14_write_to_dlq_signature_is_static_str() {
+    let src = read("storage/src/tick_persistence.rs");
+    assert!(
+        src.contains("fn write_to_dlq(&mut self, tick: &ParsedTick, reason: &'static str)"),
+        "write_to_dlq must accept `reason: &'static str` (Phase 2.14 security MEDIUM fix)"
+    );
+}
+
+#[test]
+fn phase2_14_legacy_str_signature_removed() {
+    let src = read("storage/src/tick_persistence.rs");
+    // The pre-Phase-2.14 signature `reason: &str` (without 'static) must
+    // not exist. Defence-in-depth: a future commit cannot revert the
+    // hardening without tripping this ratchet.
+    assert!(
+        !src.contains("fn write_to_dlq(&mut self, tick: &ParsedTick, reason: &str)"),
+        "write_to_dlq must NOT accept the legacy `reason: &str` (without 'static lifetime)"
+    );
+}
+
+#[test]
+fn phase2_14_doc_comment_explains_security_rationale() {
+    let src = read("storage/src/tick_persistence.rs");
+    assert!(
+        src.contains("Phase 2.14 security MEDIUM fix"),
+        "write_to_dlq doc comment must explain the security rationale"
+    );
+}

--- a/crates/storage/src/tick_persistence.rs
+++ b/crates/storage/src/tick_persistence.rs
@@ -680,8 +680,14 @@ impl TickPersistenceWriter {
     /// - Fields: `ts_ms`, `reason`, `security_id`, `segment`, `ltt`, `ltp`,
     ///   `ltq`, `volume`, `atp`, `buy_qty`, `sell_qty`, `open`, `close`,
     ///   `high`, `low`, `oi`.
+    /// Phase 2.14 security MEDIUM fix: `reason` MUST be `&'static str`
+    /// (compile-time literal). The type system rejects any runtime
+    /// string at the call site, so the NDJSON line cannot carry
+    /// unescaped `"` or `\` chars that would corrupt the audit log
+    /// during recovery. All current callers use literals — this is a
+    /// no-op runtime change that hardens the compile-time contract.
     #[rustfmt::skip]
-    fn write_to_dlq(&mut self, tick: &ParsedTick, reason: &str) {
+    fn write_to_dlq(&mut self, tick: &ParsedTick, reason: &'static str) {
         // Lazy-open DLQ file on first failure.
         if self.dlq_writer.is_none() && let Err(err) = self.open_dlq_file() {
             error!(?err, security_id = tick.security_id, reason, "CRITICAL: DLQ open failed — tick PERMANENTLY LOST");


### PR DESCRIPTION
## Summary

**Phase 2.14 — Security MEDIUM fix from the agent review on Phase 2.** Tightens the DLQ writer's `reason` parameter from `&str` to `&'static str` so the type system rejects any runtime string at compile time.

## What was at risk

The security review noted:

> "DLQ NDJSON writer builds a JSON line via manual format!. The `reason` parameter is a `&str` literal supplied by internal callers — all are static strings, so there is no injection path today. Currently safe. However, the `reason` field is not validated or sanitized; if a future caller passes a runtime string containing `"` or `\`, the NDJSON line would be malformed and unparseable during audit recovery. This is a latent data-integrity risk rather than an active injection vector."

## The fix

Change `write_to_dlq` signature from `reason: &str` to `reason: &'static str`. The type system rejects any runtime string at the call site at compile time. Today all callers use string literals (which are `&'static str` by default), so the change is **backward compatible** and required ZERO call-site updates.

## Ratchets

3 source-scan tests in `crates/core/tests/phase2_14_dlq_reason_static.rs`:
- `phase2_14_write_to_dlq_signature_is_static_str` — pin the new signature
- `phase2_14_legacy_str_signature_removed` — defence-in-depth: forbid the old `&str` form
- `phase2_14_doc_comment_explains_security_rationale` — operator visibility

## Honest 100% envelope (per plan §9)

100% inside the tested envelope:
- Signature pinned by source-scan
- Legacy form explicitly forbidden
- All 4 existing DLQ unit tests pass unchanged
- All current callers continue to work (string literals satisfy `&'static str`)

Beyond the envelope: future authenticated endpoints that might leak runtime strings into the DLQ are now compile-time-rejected.

## Test plan

- [x] `cargo test -p tickvault-storage --lib test_dlq` — **4/4 pass** (unchanged)
- [x] `cargo test -p tickvault-core --test phase2_14_dlq_reason_static` — **3/3 pass**
- [x] `cargo build -p tickvault-storage` clean
- [x] `cargo fmt --workspace` clean

https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ)_