### PR TITLE
fix(app): bump MEMORY_RSS_ALERT_MB 512 → 1024 (1 GB) per operator directive

### DIFF
--- a/crates/app/src/infra.rs
+++ b/crates/app/src/infra.rs
@@ -535,7 +535,29 @@ pub async fn enforce_clock_skew_at_boot(
 pub const MIN_FREE_DISK_PERCENT: u64 = 5;
 
 /// Memory RSS threshold in MB before alerting.
-pub const MEMORY_RSS_ALERT_MB: u64 = 512;
+///
+/// **2026-05-05 bump (512 → 1024 MB / 1 GB):** the original 512 MB
+/// threshold was set before three memory-allocating commits landed:
+/// - PR #453 bumped the tick rescue ring 600K → 2M (+150 MB).
+/// - Phase 3.4 (PR #486) added the 28-engine `CascadeFanout`
+///   (28 papaya maps × 25K capacity ≈ +45 MB).
+/// - Phase 2 lifecycle stamping (Phase 2.x) added prev_oi_cache +
+///   prev_close_stamper (~+35 MB at full universe).
+///
+/// Plausible steady-state footprint post-PR #494 (Phase 4b deletion):
+/// rescue ring (~224 MB) + fanout (~45 MB) + 1s engine (~3 MB) +
+/// prev_oi/prev_close stampers (~35 MB) + WS/ILP buffers (~30 MB) +
+/// tokio/tracing/standard runtime (~100 MB) ≈ ~437 MB. With
+/// instrument-master CSV parse + papaya rehash bursts at boot,
+/// observed RSS lands at 550-650 MB on a healthy boot.
+///
+/// **1 GB headroom (operator directive 2026-05-05):** gives ~400 MB
+/// margin above observed steady-state for live-data growth across
+/// the full trading session (instrument churn, depth book growth,
+/// option chain refresh) without false-positive Telegram pages.
+/// Above 1 GB indicates a real leak or regression worth
+/// investigating — not normal operation.
+pub const MEMORY_RSS_ALERT_MB: u64 = 1024;
 
 /// Checks available disk space and returns the free percentage.
 ///
@@ -2159,7 +2181,11 @@ mod tests {
 
     #[test]
     fn test_memory_rss_threshold() {
-        assert_eq!(super::MEMORY_RSS_ALERT_MB, 512);
+        // 2026-05-05: bumped 512 → 1024 MB (1 GB) per operator
+        // directive. Gives ~400 MB margin above observed steady-state
+        // (~550-650 MB) for live-session growth. See
+        // `MEMORY_RSS_ALERT_MB` docstring for the footprint table.
+        assert_eq!(super::MEMORY_RSS_ALERT_MB, 1024);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Live operator alert** at 12:33 PM IST 2026-05-05:

> ⚠️ [HIGH] WARNING: HIGH MEMORY — RSS 580 MB exceeds threshold.

The 512 MB threshold was set before three memory-allocating commits landed:
1. **PR #453** bumped the tick rescue ring 600K → 2M ticks (~+150 MB)
2. **Phase 3.4 PR #486** added the 28-engine `CascadeFanout` (~+45 MB)
3. **Phase 2.x** added prev_oi_cache + prev_close_stamper (~+35 MB)

## Plausible steady-state footprint

| Component | Estimate |
|---|---:|
| Tick rescue ring (2M cap) | ~224 MB |
| CascadeFanout (28 maps × 25K) | ~45 MB |
| 1s engine map (papaya × 25K) | ~3 MB |
| prev_oi_cache + prev_close_stamper | ~35 MB |
| WS frame buffers + QuestDB ILP | ~30 MB |
| Tokio + tracing + standard runtime | ~100 MB |
| **Subtotal** | **~437 MB** |

Observed RSS lands at 550-650 MB with boot-time CSV parse + papaya rehash bursts.

**1 GB (1024 MB) threshold (operator directive 2026-05-05):** gives ~400 MB margin above observed steady-state for live-session growth (instrument churn, depth book growth, option chain refresh). Above 1 GB indicates a real leak / regression worth investigating — not normal operation.

## What lands (1 file, +28 -2 LoC)

`crates/app/src/infra.rs`:
- `MEMORY_RSS_ALERT_MB`: `512` → `1024`
- Docstring expanded with the 3-commit history + reasoning
- Test ratchet `test_memory_rss_threshold` updated

## Test plan

- [x] `cargo test -p tickvault-app --lib infra` — **103/103 pass**
- [x] `cargo fmt --check` — clean
- [x] `bash .claude/hooks/banned-pattern-scanner.sh` — clean

## Adjacent observation (out of scope)

Same operator screenshot showed `Tracking 11,034 instruments out of 25,000 max (44% full)` after 12:28 IST mid-market boot. Plan §1 expects ~24,310 (Phase 2 fully expanded). Boot was post-09:13 IST so Phase 2 didn't dispatch today. The MidMarket boot's live-tick ATM resolver should fill stock F&O ATM±25 within ~30s but apparently didn't. **Real subscription gap worth a separate investigation** — not introduced by the 29-tf plan; lives in older `boot_mode.rs` / `live_tick_atm_resolver.rs`.

https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ)_