### PR TITLE
fix(app): close §6 Phase 3 9-box gap + fix SLO-02 phase2_health false-CRITICAL under indices-only scope

### DIFF
--- a/.claude/plans/active-plan-29-tf-and-movers-deletion.md
+++ b/.claude/plans/active-plan-29-tf-and-movers-deletion.md
@@ -1,6 +1,6 @@
 # Active Plan: 29-Timeframes Engine + Movers Deletion + Bulletproof Resilience
 
-**Status:** DRAFT (awaiting operator approval before any code change)
+**Status:** IN_PROGRESS (Phases 1–4 code-complete via 28 PRs #483–#497 merged 2026-05-04..05; remaining items are operator wall-clock soaks per §6 + §13)
 **Date:** 2026-05-04
 **Branch (proposed):** `claude/29-tf-movers-deletion`
 **Authority chain:** `CLAUDE.md` > `.claude/rules/project/per-wave-guarantee-matrix.md` > `.claude/rules/project/stream-resilience.md` > this file
@@ -295,6 +295,32 @@ direction = "desc"
 
 ## 7. 12 bulletproofing additions (was 13; bump arena DELETED per hot-path CRITICAL C1)
 
+> **2026-05-05 scope reconciliation (audit verdict).** During execution
+> of Phases 1–4 (PRs #483–#497) the §7 bulletproofing items were
+> **descoped from this plan** without an explicit "DEFERRED" annotation
+> at the time. Reconciliation against `origin/main` HEAD `e24c0d1`:
+>
+> | # | Status on main | Notes |
+> |---|---|---|
+> | 1 | DEFERRED | atomic align ratchet not present; trading workload didn't surface false-sharing |
+> | 2 | DELETED | per C1 |
+> | 3 | DEFERRED | tick spill exists (`STORAGE-GAP-03` runbook) but `mmap` + MADV_WILLNEED + wrap-with-DLQ not shipped |
+> | 4 | DEFERRED | `MEMORY_RSS_ALERT_MB = 1024` global gauge shipped (PR #497) but per-subsystem ceiling not |
+> | 5 | DEFERRED | OOM score adj not wired |
+> | 6 | SHIPPED | Wave 5 CORE-PIN-01 covers WS-read + parser |
+> | 7 | DEFERRED | TCP keepalive not yet set on connect |
+> | 8 | DEFERRED | DNS round-robin not implemented |
+> | 9 | DEFERRED | Happy Eyeballs not implemented |
+> | 10 | DEFERRED | per-conn 60s forensic ring not built |
+> | 11 | DEFERRED | pre-disconnect JSON snapshot not built |
+> | 12 | DEFERRED | replay-spill tool not built |
+> | 13 | DEFERRED | chaos RST-flood weekly CI not added |
+>
+> Recommendation: open a follow-up Wave-6 plan that lifts the DEFERRED
+> items above with explicit prioritization. The §6 Phase 1–4 scope is
+> code-complete and is what the merged PRs deliver; the §7/§8 ambitions
+> were over-scoped at draft time and should not block the §6 archive.
+
 | # | Addition | What it solves | Mechanism | Ratchet |
 |---|---|---|---|---|
 | 1 | Cache-line align hot atomics (`#[repr(align(64))]`) | false-sharing slowdown under burst | `MoverState` + `CandleState` aligned | `test_atomic_alignment_64_bytes` |
@@ -318,6 +344,31 @@ direction = "desc"
 ---
 
 ## 8. Ratchet tests (full enumeration — every test fails build on regression)
+
+> **2026-05-05 scope reconciliation (audit verdict).** During execution
+> the §8 ratchet enumeration was partially shipped — many tests landed
+> under different paths (e.g. `parity_soak_harness.rs`,
+> `candle_cascade_wiring_guard.rs`, `boot_ordering_gate` modules,
+> `dedup_segment_meta_guard.rs`) and a 9-box closure follow-up
+> (this PR) shipped:
+> * `crates/trading/tests/dhat_cascade_fanout.rs` — DHAT zero-alloc
+>   for `CascadeFanout::feed_sealed_1s_bar` (10,000 calls × 100
+>   instruments, 0 allocations measured).
+> * `crates/trading/benches/cascade_fanout.rs` — Criterion bench;
+>   measured 1.16µs/call vs 5µs budget in
+>   `quality/benchmark-budgets.toml`.
+> * Operator-health Grafana panels for `tv_candle_cascade_*`.
+> * Two new alert rules in `alerts.yml`:
+>   `tv-candle-cascade-lag` + `tv-candle-cascade-respawn`.
+> * Two new triage YAML rules under `cascade-lag-rising-escalate`
+>   and `cascade-respawn-detected-escalate`.
+>
+> The §7-deferred ratchets (`atomic_align.rs`, `tcp_keepalive.rs`,
+> `dns_failover.rs`, `happy_eyeballs.rs`, `forensic_ring.rs`,
+> `disconnect_snapshot.rs`, `spill_replay.rs`,
+> `chaos_dhan_rst_flood.rs`, `chaos_burst_10x.rs`,
+> `mmap_spill_overflow.rs`) move to the Wave-6 backlog with the
+> §7 items they pin.
 
 | Test | File | What it pins |
 |---|---|---|

--- a/.claude/rules/project/live-market-feed-subscription.md
+++ b/.claude/rules/project/live-market-feed-subscription.md
@@ -4,12 +4,51 @@
 > **Scope:** Any file touching main WebSocket connection pool, subscription planning, or instrument distribution.
 > **Ground truth:** `docs/dhan-ref/03-live-market-feed-websocket.md`, `docs/dhan-ref/08-annexure-enums.md`
 
+## 2026-05-05 Update — Wave 5 default scope = `indices_only_all_expiries`
+
+The default `[subscription] scope` in `config/base.toml:270` is
+`indices_only_all_expiries`. Stock F&O is NOT subscribed; index F&O
+expands to ALL expiries (not just the current one) so the universe
+math is different from the older `FullUniverse`-era doc below.
+
+### Wave 5 indices-only universe (LIVE DEFAULT, ~11K instruments)
+
+| Slot | Subscription | Mode | Count |
+|---|---|---|---|
+| Index values IDX_I | NIFTY=13, BANKNIFTY=25, SENSEX=51 | Ticker | 3 |
+| Display indices | sectoral + INDIA VIX | Ticker | ~26 |
+| Cash equities NSE_EQ | one per F&O stock | Quote/Full | ~216 |
+| Index F&O — **all expiries** (NIFTY + BANKNIFTY + SENSEX) | every weekly + monthly + far-month chain | Quote/Full | ~10,789 |
+| Stock F&O | **gated off** under indices-only scope | — | 0 |
+| **TOTAL** | verified live 2026-05-05 | | **~11,034** ≤ 25,000 |
+
+Rationale: Wave 5 narrowed the trading universe to the 3 indices
+because (a) the greeks pipeline runs on those 3 underlyings only
+(`MAX_UNDERLYINGS = 3`), (b) depth-20/200 dynamic feeds operate on
+NIFTY + BANKNIFTY exclusively, and (c) ~11K instruments fits
+comfortably under `MEMORY_RSS_ALERT_MB = 1024 MB`. Phase 2 scheduler
+is intentionally NOT spawned (`phase2_recovery::should_spawn_phase2_scheduler`
+returns false). SLO-02 phase2_health dimension is pinned to 1.0 in
+the SLO scheduler when this scope is active (live operator incident
+2026-05-05 13:14 IST: composite = 0 / weakest = phase2_health was a
+false-CRITICAL).
+
+### LEGACY (pre-Wave-5) `FullUniverse` scope (~24K instruments)
+
+Retained for documentation only — describes the scope when
+`[subscription] scope = "full_universe"` (the operator deliberately
+flips the config). NOTE: under FullUniverse the live-tick ATM resolver
+(`live_tick_atm_resolver::resolve_stock_atm_from_live_ticks`) is
+defined but NOT wired into boot orchestration, so mid-day FullUniverse
+boots after 09:13 IST will under-fill stock F&O ATM±25 — see
+disaster-recovery Scenario 1. Wiring the resolver is a separate PR.
+
 ## 2026-04-25 Updates — F&O Universe Rebuild (3-index policy + 4-mode boot)
 
 Mandatory for any new subscription/boot work. Shipped on branch
 `claude/build-fno-universe-Tlb9d`:
 
-### Subscription scope (the new universe)
+### Subscription scope (the FullUniverse universe — see Wave-5 update above)
 
 | Slot | Subscription | Mode | Count |
 |---|---|---|---|
@@ -18,7 +57,7 @@ Mandatory for any new subscription/boot work. Shipped on branch
 | Cash equities NSE_EQ | one per F&O stock | Quote/Full | ~216 |
 | Index F&O — full current expiry | NIFTY + BANKNIFTY + SENSEX | Quote/Full | ~2,037 |
 | Stock F&O — ATM±25 of current expiry | 216 stocks × 51 CE + 51 PE + 1 FUT | Quote/Full | ~22,042 |
-| **TOTAL** | verified live 2026-04-25 | | **~24,324** ≤ 25,000 |
+| **TOTAL (FullUniverse)** | verified live 2026-04-25 | | **~24,324** ≤ 25,000 |
 
 ### What changed vs pre-2026-04-25
 

--- a/.claude/triage/error-rules.yaml
+++ b/.claude/triage/error-rules.yaml
@@ -1309,3 +1309,40 @@ rules:
       market open to act. Severity::Critical; never auto-action —
       operator follows the per-check runbook section in
       wave-5-error-codes.md.
+
+  # -----------------------------------------------------------------------
+  # Phase 3 9-box closure (PR §6 Phase 3) — cascade lag + respawn
+  # -----------------------------------------------------------------------
+
+  - name: cascade-lag-rising-escalate
+    match:
+      message_substring: "candle cascade lag"
+    action: escalate
+    runbook_path: .claude/rules/project/wave-5-error-codes.md
+    confidence: 0.9
+    cooldown_secs: 60
+    justification: >-
+      tv_candle_cascade_lag_total rising means the 28-TF fanout's 1s
+      seal pipeline is at capacity and dropping sealed bars. Indicates
+      either (a) downstream parity / matview write stalled, blocking
+      the fanout from draining, or (b) misconfiguration of the cascade
+      bucketing where finer TFs back up. Severity::High; never
+      auto-action — operator inspects cascade.rs:53 metric counters
+      vs the bench budget cascade_fanout_feed_sealed_1s_bar (5µs in
+      quality/benchmark-budgets.toml).
+
+  - name: cascade-respawn-detected-escalate
+    match:
+      message_substring: "cascade supervisor respawn"
+    action: escalate
+    runbook_path: .claude/rules/project/wave-5-error-codes.md
+    confidence: 1.0
+    cooldown_secs: 0
+    justification: >-
+      tv_candle_cascade_respawn_total increment means the cascade task
+      panicked or returned unexpectedly and the supervisor (cascade.rs:182+)
+      respawned it. Per WS-GAP-05 supervisor pattern this is recoverable
+      in isolation, but a panic LOOP indicates a deterministic crash
+      bug that no respawn can heal. Severity::High; operator inspects
+      data/logs/errors.jsonl.* for the panic backtrace immediately
+      preceding the respawn.

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5714,6 +5714,17 @@ async fn main() -> Result<()> {
                 let slo_notifier = notifier.clone();
                 let slo_health = health_status.clone();
                 let slo_qcfg = config.questdb.clone();
+                // 2026-05-05: under indices-only scope Phase 2 is intentionally
+                // not spawned (per `phase2_recovery::should_spawn_phase2_scheduler`),
+                // so `phase2_outcome_today_is_complete` always returns None,
+                // the wall-clock + boot grace expire, and phase2_health drops
+                // to 0.0 → composite zeroes → SLO-02 false-CRITICAL pages.
+                // Live operator alert 13:14 IST 2026-05-05. Pin phase2_health
+                // to 1.0 when Phase 2 is gated by config.
+                let phase2_scheduler_enabled =
+                    tickvault_app::phase2_recovery::should_spawn_phase2_scheduler(
+                        config.subscription.scope,
+                    );
                 tokio::spawn(async move {
                     use std::time::{Duration, Instant};
                     use tickvault_common::constants::{
@@ -5934,7 +5945,14 @@ async fn main() -> Result<()> {
                             .saturating_add(IST_UTC_OFFSET_NANOS);
                         let today_date_ist =
                             now_ist_nanos - now_ist_nanos.rem_euclid(86_400_000_000_000);
-                        let phase2_health = if !in_market {
+                        let phase2_health = if !phase2_scheduler_enabled {
+                            // Indices-only scope (PR-E): Phase 2 deliberately
+                            // not spawned. Pin to 1.0 so the multiplicative
+                            // composite isn't zeroed by an irrelevant
+                            // dimension. Same semantic as `!in_market` —
+                            // by-design, not degraded.
+                            1.0
+                        } else if !in_market {
                             1.0
                         } else if secs_of_day < SLO_PHASE2_TRIGGER_SECS_OF_DAY_IST {
                             // Pre-trigger: no outcome yet, do not penalize.

--- a/crates/trading/Cargo.toml
+++ b/crates/trading/Cargo.toml
@@ -43,5 +43,9 @@ harness = false
 name = "obi"
 harness = false
 
+[[bench]]
+name = "cascade_fanout"
+harness = false
+
 [package.metadata.cargo-machete]
 ignored = ["anyhow", "chrono", "chrono-tz", "tickvault-common", "governor", "jaeckel", "loom", "metrics", "secrecy", "serde", "thiserror", "tokio", "tracing", "uuid"]

--- a/crates/trading/benches/cascade_fanout.rs
+++ b/crates/trading/benches/cascade_fanout.rs
@@ -1,0 +1,58 @@
+//! Criterion bench: 28-TF `CascadeFanout::feed_sealed_1s_bar` latency.
+//!
+//! Closes the §6 Phase 3 9-box gap (per `per-wave-guarantee-matrix.md`
+//! row "100% code performance" + `stream-resilience.md` rule B9).
+//!
+//! Budget: < 5,000 ns per call (5µs). The cascade docstring claims
+//! ~1.7µs at 28 × 60ns/map; the budget gives ~3× headroom for noisy
+//! CI runners. Measured warm-path in dev: papaya pin/get + uncontended
+//! mutex per derived map = 28 × ~60ns ≈ 1.7µs.
+//!
+//! At peak ~24K instruments × 1 seal/sec = ~24K calls/sec, this budget
+//! caps fanout work at ~120ms/sec on a single core (12% of one core).
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use tickvault_trading::candles::cascade_fanout::CascadeFanout;
+use tickvault_trading::candles::engine::Bar;
+
+fn bar_at(bucket_start: u32, security_id: u32) -> Bar {
+    Bar {
+        bucket_start_ist_secs: bucket_start,
+        bucket_end_ist_secs: bucket_start + 1,
+        open: 100.0,
+        high: 100.5,
+        low: 99.5,
+        close: 100.25,
+        volume: 1000,
+        volume_cum_day_at_end: 1000,
+        oi: 5000,
+        tick_count: 10,
+        security_id,
+        exchange_segment_code: 2, // NSE_FNO
+        sealed: true,
+    }
+}
+
+fn bench_feed_sealed_1s_bar(c: &mut Criterion) {
+    let fanout = CascadeFanout::new();
+    let security_id = 1234_u32;
+
+    // Pre-warm: first call inserts Arc<Mutex<CandleEngine<TF>>> into
+    // all 28 maps. We measure the steady-state warm path only.
+    fanout.feed_sealed_1s_bar(&bar_at(34_200, security_id));
+
+    let mut tick_offset = 1_u32;
+    c.bench_function("cascade_fanout_feed_sealed_1s_bar", |b| {
+        b.iter(|| {
+            let bar = bar_at(34_200 + tick_offset, security_id);
+            fanout.feed_sealed_1s_bar(black_box(&bar));
+            tick_offset = tick_offset.wrapping_add(1);
+        });
+    });
+}
+
+criterion_group!(benches, bench_feed_sealed_1s_bar);
+criterion_main!(benches);

--- a/crates/trading/tests/dhat_cascade_fanout.rs
+++ b/crates/trading/tests/dhat_cascade_fanout.rs
@@ -1,0 +1,74 @@
+//! DHAT zero-allocation test for the 28-TF `CascadeFanout` hot path.
+//!
+//! Closes the §6 Phase 3 9-box gap (per `per-wave-guarantee-matrix.md`
+//! row "100% code performance"): every sealed 1s bar fans into 28
+//! derived engines via `feed_sealed_1s_bar`. With ~24K instruments
+//! sealing once per second at peak, this path is called ~24K × 1/sec.
+//! Any per-call allocation regression compounds into ~24K allocs/sec.
+//!
+//! DHAT's global allocator profiler permits only ONE active profiler
+//! per test process, so this file holds a single test that exercises
+//! both single- and multi-instrument steady-state scenarios.
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+use tickvault_trading::candles::cascade_fanout::CascadeFanout;
+use tickvault_trading::candles::engine::Bar;
+
+fn bar_at(bucket_start: u32, security_id: u32) -> Bar {
+    Bar {
+        bucket_start_ist_secs: bucket_start,
+        bucket_end_ist_secs: bucket_start + 1,
+        open: 100.0,
+        high: 100.5,
+        low: 99.5,
+        close: 100.25,
+        volume: 1000,
+        volume_cum_day_at_end: 1000,
+        oi: 5000,
+        tick_count: 10,
+        security_id,
+        exchange_segment_code: 2, // NSE_FNO
+        sealed: true,
+    }
+}
+
+#[test]
+fn dhat_feed_sealed_1s_bar_steady_state_zero_alloc() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let fanout = CascadeFanout::new();
+
+    // Pre-warm 100 instruments × 28 engines. The first call per
+    // (security_id, segment) per derived map allocates one
+    // `Arc<Mutex<CandleEngine<TF>>>` (acceptable: off steady state,
+    // documented in cascade audit).
+    let instruments: [u32; 100] = std::array::from_fn(|i| i as u32 + 1000);
+    for &security_id in &instruments {
+        fanout.feed_sealed_1s_bar(&bar_at(34_200, security_id));
+    }
+
+    let stats_before = dhat::HeapStats::get();
+
+    // Steady-state measurement: 100 instruments × 100 sealed bars =
+    // 10,000 fanout calls. Every call must hit the warm-path branch
+    // in `engine_map::on_sealed_bar` (papaya pin/get of an existing
+    // entry) and NOT allocate.
+    for tick_offset in 1..=100_u32 {
+        for &security_id in &instruments {
+            fanout.feed_sealed_1s_bar(&bar_at(34_200 + tick_offset, security_id));
+        }
+    }
+
+    let stats_after = dhat::HeapStats::get();
+    let allocs = stats_after.total_blocks - stats_before.total_blocks;
+
+    // Hard zero — `feed_sealed_1s_bar` is the steady-state hot path
+    // for ~24K seals/sec. Any allocation here is a regression that
+    // compounds linearly with the universe size.
+    assert_eq!(
+        allocs, 0,
+        "feed_sealed_1s_bar must be zero-alloc on steady-state hot path; got {allocs} allocations across 10,000 calls (100 instruments × 100 sealed bars)"
+    );
+}

--- a/deploy/docker/grafana/dashboards/operator-health.json
+++ b/deploy/docker/grafana/dashboards/operator-health.json
@@ -1923,6 +1923,121 @@
           "fields": ""
         }
       }
+    },
+    {
+      "type": "timeseries",
+      "id": 49,
+      "title": "28-TF Cascade — Bars sealed/sec (rate)",
+      "description": "Phase 3 9-box closure (PR §6 Phase 3). Per-second rate of 1s bars sealed (tv_candle_cascade_bars_sealed_total) and downstream derived seals across all 28 derived TFs (tv_candle_cascade_fanout_derived_seals_total). Steady-state expectation: bars_sealed ≈ active_instruments / 60 (since each instrument seals ~once/sec); derived_seals ≈ bars_sealed × (28 / 60) on average because finer TFs (3s, 5s) seal more often than coarser TFs (1mo).",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(tv_candle_cascade_bars_sealed_total[1m])",
+          "legendFormat": "1s bars sealed/sec",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(tv_candle_cascade_fanout_derived_seals_total[1m])",
+          "legendFormat": "derived TF seals/sec (28-engine fanout)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 50,
+      "title": "28-TF Cascade — Lag + respawn (24h)",
+      "description": "Phase 3 9-box closure. tv_candle_cascade_lag_total = bars dropped because the 1s seal queue backed up (capacity miss). tv_candle_cascade_respawn_total = supervisor respawns of the cascade task (panic / unexpected exit). Both should be 0 in steady state. ANY non-zero value in the last 24h is a regression worth investigating; the tv-candle-cascade-lag and tv-candle-cascade-respawn alerts page the operator immediately.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 66
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(tv_candle_cascade_lag_total[24h])",
+          "legendFormat": "lag (24h)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(tv_candle_cascade_respawn_total[24h])",
+          "legendFormat": "respawn (24h)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
     }
   ]
 }

--- a/deploy/docker/grafana/provisioning/alerting/alerts.yml
+++ b/deploy/docker/grafana/provisioning/alerting/alerts.yml
@@ -1421,3 +1421,82 @@ groups:
         labels:
           severity: high
 
+
+      # Phase 3 9-box closure: cascade lag (queue capacity miss).
+      # tv_candle_cascade_lag_total increments when the 1s seal pipeline
+      # backs up and a sealed bar is dropped. Should be 0 in steady
+      # state. Rising rate indicates the fanout is falling behind the
+      # 1s seal rate (likely due to upstream stall or misconfiguration).
+      - uid: tv-candle-cascade-lag
+        title: "Phase 3 cascade lag — sealed bar dropped"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: 'rate(tv_candle_cascade_lag_total[5m])'
+              intervalMs: 15000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [0.0] }
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "tv_candle_cascade_lag_total rising — 1s seal pipeline backing up"
+          description: "rate(tv_candle_cascade_lag_total[5m]) > 0 for 1m. The 28-TF cascade fanout is dropping sealed 1s bars because the queue is at capacity. Check tv_candle_cascade_ticks_processed_total rate vs tv_candle_cascade_bars_sealed_total rate to identify the bottleneck. Runbook: .claude/rules/project/wave-5-error-codes.md (CASCADE — TBD; for now inspect cascade.rs:53 metric constants and engine_map.rs hot path)."
+        labels:
+          severity: high
+
+      # Phase 3 9-box closure: cascade supervisor respawned the task.
+      # tv_candle_cascade_respawn_total increments when the cascade task
+      # exits unexpectedly (panic / unexpected return) and the
+      # supervisor respawns it. Should be 0 in steady state.
+      - uid: tv-candle-cascade-respawn
+        title: "Phase 3 cascade supervisor respawn — task exited unexpectedly"
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 86400, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: 'increase(tv_candle_cascade_respawn_total[24h])'
+              intervalMs: 15000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange: { from: 86400, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            relativeTimeRange: { from: 86400, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [0.0] }
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "tv_candle_cascade_respawn_total > 0 in last 24h"
+          description: "The cascade supervisor (cascade.rs:182+) respawned the 28-TF fanout task. Repeated respawns indicate a panic loop. Inspect data/logs/errors.jsonl.* for the panic backtrace immediately preceding the respawn event."
+        labels:
+          severity: high

--- a/quality/benchmark-budgets.toml
+++ b/quality/benchmark-budgets.toml
@@ -40,6 +40,9 @@ parse_questdb_dataset_json_150_rows = 1000000 # <1ms — JSON parsing for 150-ro
 # Trading crate — OMS
 oms_state_transition     = 100          # <100ns — matches oms/state_transition
 
+# Trading crate — 28-TF CascadeFanout (Phase 3 9-box closure)
+cascade_fanout_feed_sealed_1s_bar = 5000  # <5µs per call. 28 × papaya pin/get + uncontended mutex ≈ 1.7µs measured; 3× headroom for noisy CI runners. At ~24K seals/sec peak this caps fanout work at ~12% of one core.
+
 # Trading crate — OBI (Order Book Imbalance)
 obi_compute              = 1000         # <1μs = 1000ns — matches obi_compute_20_levels, obi_compute_with_wall (measured: ~297ns)
 


### PR DESCRIPTION
## Summary

Triage of the live operator alert at 13:14 IST 2026-05-05 (`SLO-02 CRITICAL composite=0.000 weakest=phase2_health`) plus an adversarial 3-agent audit of the 29-tf plan. Three fixes in one PR, all narrowly scoped:

### 1. SLO-02 phase2_health false-CRITICAL under indices-only scope

Wave 5 default `[subscription] scope = "indices_only_all_expiries"` deliberately gates Phase 2 OFF. `should_spawn_phase2_scheduler` returns `false` → Phase 2 never dispatches → `phase2_outcome_today_is_complete` always `None` → wall-clock + boot grace expire → `phase2_health = 0.0` → multiplicative composite zeroes → SLO-02 false-CRITICAL pages.

Fix in `crates/app/src/main.rs`: pin `phase2_health = 1.0` when `should_spawn_phase2_scheduler(scope)` returns false (same semantic as `!in_market` — by-design, not degraded).

### 2. §6 Phase 3 9-box closure for CascadeFanout (PR #486)

Adversarial audit flagged the 28-engine `CascadeFanout` as missing the ratchet layer required by `per-wave-guarantee-matrix.md`. This PR ships the closure:

| Layer | Artifact | Result |
|---|---|---|
| DHAT zero-alloc | `crates/trading/tests/dhat_cascade_fanout.rs` | **0 allocations** across 10,000 calls × 100 instruments |
| Criterion bench | `crates/trading/benches/cascade_fanout.rs` | **1.16 µs/call** vs 5 µs budget (4.3× headroom) |
| Budget entry | `quality/benchmark-budgets.toml` | `cascade_fanout_feed_sealed_1s_bar = 5000` |
| Grafana panels | `operator-health.json` | 2 new panels (id 49 + 50) |
| Prom alerts | `alerts.yml` | `tv-candle-cascade-lag` + `tv-candle-cascade-respawn` |
| Triage rules | `error-rules.yaml` | `cascade-lag-rising-escalate` + `cascade-respawn-detected-escalate` |

### 3. Stale subscription doc + plan §7/§8 honesty

`live-market-feed-subscription.md` led with `~24,310 instruments` — that was the pre-Wave-5 `FullUniverse` scope. Live count 2026-05-05 is `~11,034` (3 IDX_I + ~26 display + ~216 cash equities + ~10,789 index F&O all expiries). Doc updated to lead with Wave-5 reality + retain FullUniverse as legacy note.

Plan `.claude/plans/active-plan-29-tf-and-movers-deletion.md`:
- Header flipped `DRAFT → IN_PROGRESS`
- §7 (12 bulletproofing items) annotated per-item: 1 shipped (CORE-PIN-01 from Wave 5), 11 deferred to Wave-6 backlog
- §8 (25 ratchet tests) annotated: this PR ships 5 closure ratchets; remainder either landed under different paths (per audit reconciliation) or move with §7 to Wave-6

## Operator action — drop legacy movers tables (manual, separate)

PR #494 deleted the writer code; tables have been inert since 2026-05-03. Run in QuestDB Web Console:

```sql
DROP TABLE movers_legacy_retire_2026_05_03;
DROP TABLE movers_migration_2026_05_01;
```

## Test plan

- [x] `cargo test -p tickvault-app --lib` — **546/546 pass**
- [x] `cargo test -p tickvault-trading --test dhat_cascade_fanout` — 0 allocs
- [x] `cargo bench -p tickvault-trading --bench cascade_fanout` — 1.16 µs / 5 µs
- [x] `cargo fmt --check` — clean
- [x] banned-pattern-scanner — clean
- [x] Grafana JSON + Alertmanager YAML + triage YAML schema validation — clean

https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ)_