### PR TITLE
fix(storage): volume_nse_audit DDL 400 — add `ts` to DEDUP UPSERT KEYS per QuestDB constraint

### DIFF
--- a/crates/storage/src/volume_nse_audit_persistence.rs
+++ b/crates/storage/src/volume_nse_audit_persistence.rs
@@ -28,11 +28,19 @@ use tickvault_common::sanitize::sanitize_audit_string;
 pub const QUESTDB_TABLE_VOLUME_NSE_AUDIT: &str = "volume_nse_audit";
 
 /// DEDUP UPSERT KEY for `volume_nse_audit` — composite
-/// `(trading_date_ist, security_id, segment)` per Wave 5 plan §"Item 26
+/// `(ts, trading_date_ist, security_id, segment)` per Wave 5 plan §"Item 26
 /// L2 NSE bhavcopy — verified implementation recipe". Includes `segment`
 /// so the `dedup_segment_meta_guard.rs` meta-guard is satisfied
 /// (I-P1-11 + STORAGE-GAP-01).
-pub const DEDUP_KEY_VOLUME_NSE_AUDIT: &str = "trading_date_ist, security_id, segment";
+///
+/// 2026-05-05 fix: QuestDB requires the designated timestamp column
+/// (`ts`) to appear in `DEDUP UPSERT KEYS`. Without it, the CREATE TABLE
+/// DDL returns 400 Bad Request and the table is never created. Live
+/// evidence: boot log 2026-05-05 14:04:20.067 IST. Same pattern as
+/// every other working audit table in the workspace
+/// (`depth_rebalance_audit`, `phase2_audit`, etc.) — they all include
+/// `ts` in their DEDUP KEYS.
+pub const DEDUP_KEY_VOLUME_NSE_AUDIT: &str = "ts, trading_date_ist, security_id, segment";
 
 /// HTTP timeout for DDL probes + INSERT round-trips.
 const QUESTDB_DDL_TIMEOUT_SECS: u64 = 10;
@@ -167,6 +175,20 @@ mod tests {
         assert!(DEDUP_KEY_VOLUME_NSE_AUDIT.contains("security_id"));
         assert!(DEDUP_KEY_VOLUME_NSE_AUDIT.contains("segment"));
         assert!(DEDUP_KEY_VOLUME_NSE_AUDIT.contains("trading_date_ist"));
+    }
+
+    /// 2026-05-05 regression: QuestDB requires the designated timestamp
+    /// column (`ts`) to appear in `DEDUP UPSERT KEYS`. Without it, the
+    /// CREATE TABLE DDL returns 400 Bad Request. Live evidence: boot log
+    /// 2026-05-05 14:04:20.067 IST `DDL non-2xx — table=volume_nse_audit,
+    /// status=400 Bad Request`. Pin `ts` in the key to prevent regression.
+    #[test]
+    fn test_dedup_key_volume_nse_audit_includes_ts_per_questdb_constraint() {
+        assert!(
+            DEDUP_KEY_VOLUME_NSE_AUDIT.starts_with("ts"),
+            "QuestDB requires designated timestamp `ts` to appear in DEDUP UPSERT KEYS — \
+             without it, CREATE TABLE returns 400. Got: {DEDUP_KEY_VOLUME_NSE_AUDIT}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Live operator boot log at 2026-05-05 14:04:20.067 IST: `WARN DDL non-2xx — table=volume_nse_audit, status=400 Bad Request`. The audit table never gets created, so the 16:30 IST bhavcopy cross-check has nowhere to land verdict rows.

## Root cause

`DEDUP_KEY_VOLUME_NSE_AUDIT` was missing the designated timestamp column `ts`. **QuestDB requires the designated timestamp to appear in `DEDUP UPSERT KEYS`** — otherwise CREATE TABLE returns 400.

Verified against every other working audit table: all include `ts` in their key.

## Fix

```rust
pub const DEDUP_KEY_VOLUME_NSE_AUDIT: &str = "ts, trading_date_ist, security_id, segment";
```

Preserves I-P1-11 + STORAGE-GAP-01 (segment still in key for cross-segment uniqueness).

## Ratchet

`test_dedup_key_volume_nse_audit_includes_ts_per_questdb_constraint` pins the fix.

## Test plan

- [x] `cargo test -p tickvault-storage --lib volume_nse_audit` — **8/8 pass**
- [x] `cargo check -p tickvault-storage` — clean
- [x] `cargo fmt --check` — clean
- [x] banned-pattern-scanner — clean

## Closes the 4-bug operator-log diagnosis

| # | Bug | Status |
|---|---|---|
| 1 | WS deferred-mode watchdog reconnect storm | ✅ PR #499 MERGED |
| 2 | PREVOI-01 unzip Broken pipe | ✅ PR #501 MERGED |
| 3 | DEPTH-DYN-V2-01 cohort SQL 400 | ✅ PR #500 MERGED |
| 4 | volume_nse_audit DDL 400 | ✅ this PR |

https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011mB4pSgCxkn5qr5KoNBJyJ)_