### PR TITLE
feat(storage,trading): #504b schema + Bar struct for 5 frozen-per-day fields (Wave-5 §K-L12)

### DIFF
--- a/crates/api/src/handlers/movers_v2.rs
+++ b/crates/api/src/handlers/movers_v2.rs
@@ -133,6 +133,11 @@ impl From<&tickvault_trading::candles::Bar> for MoversV2Bar {
             oi: bar.oi,
             tick_count: bar.tick_count,
             sealed: bar.sealed,
+            // L12 (Wave-5 #504b) added 5 frozen-per-day reference fields
+            // to `Bar`. Surfacing them on the wire `MoversV2Bar` is the
+            // job of #505 (read flip / `/api/movers/v2` response schema)
+            // — this PR keeps the response shape unchanged so /api/movers
+            // consumers see no behaviour change until the explicit cutover.
         }
     }
 }
@@ -342,6 +347,11 @@ mod tests {
             security_id,
             exchange_segment_code: segment_code,
             sealed: true,
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         }
     }
 

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -8882,6 +8882,10 @@ async fn run_candle_persistence_consumer(
                         c.gamma,
                         c.theta,
                         c.vega,
+                        // Wave-5 §K-L12 (#504b): % fields default to 0.0.
+                        0.0,
+                        0.0,
+                        0.0,
                     );
                 }
                 aggregator.clear_completed();
@@ -8926,6 +8930,10 @@ async fn run_candle_persistence_consumer(
                     c.gamma,
                     c.theta,
                     c.vega,
+                    // Wave-5 §K-L12 (#504b): % fields default to 0.0.
+                    0.0,
+                    0.0,
+                    0.0,
                 ) {
                     warn!(?err, "cold-path candle write failed");
                     break;

--- a/crates/core/src/pipeline/tick_processor.rs
+++ b/crates/core/src/pipeline/tick_processor.rs
@@ -1539,6 +1539,12 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                                 c.gamma,
                                 c.theta,
                                 c.vega,
+                                // Wave-5 §K-L12 (#504b): % fields default
+                                // to 0.0 — #504e wires the seal-time
+                                // stamping that fills them in.
+                                0.0,
+                                0.0,
+                                0.0,
                             ) {
                                 // Never break — remaining candles must still be processed.
                                 // Rate-limit: warn first 100, then every 1000th.
@@ -1629,6 +1635,10 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                     c.gamma,
                     c.theta,
                     c.vega,
+                    // Wave-5 §K-L12 (#504b): % fields default to 0.0.
+                    0.0,
+                    0.0,
+                    0.0,
                 ));
             }
             cw.flush_on_shutdown();

--- a/crates/storage/src/candle_persistence.rs
+++ b/crates/storage/src/candle_persistence.rs
@@ -377,6 +377,14 @@ const LIVE_CANDLE_RECONNECT_THROTTLE_SECS: u64 = 30;
 
 /// A buffered candle waiting to be written to QuestDB after recovery.
 /// Fixed-size, Copy — no allocation on push.
+///
+/// **Wave-5 §K-L12 (PR #504b)** added the 3 frozen-per-day % fields. They
+/// are NOT serialized to the on-disk spill (`serialize_candle` keeps the
+/// 76-byte record layout for backward compatibility with in-flight spill
+/// files at upgrade time). On deserialize they round-trip as `0.0`,
+/// which matches #504b's "ships the fields with default values"
+/// semantics — the actual seal-time stamping lands in #504e and can
+/// revisit the spill format if non-zero values need durability.
 #[derive(Clone, Copy)]
 struct BufferedCandle {
     security_id: u32,
@@ -393,6 +401,13 @@ struct BufferedCandle {
     gamma: f64,
     theta: f64,
     vega: f64,
+    /// Wave-5 §K-L12: change-vs-prev-day percentage. NOT persisted to spill.
+    close_pct_from_prev_day: f64,
+    /// Wave-5 §K-L12: OI change-vs-prev-day percentage. NOT persisted to spill.
+    oi_pct_from_prev_day: f64,
+    /// Wave-5 §K-L12: cumulative volume change-vs-prev-day percentage.
+    /// NOT persisted to spill.
+    volume_pct_from_prev_day: f64,
 }
 
 /// Fixed record size for disk-spilled candles: 76 bytes per candle (36 + 5×8 Greeks).
@@ -450,6 +465,12 @@ fn deserialize_candle(buf: &[u8; CANDLE_SPILL_RECORD_SIZE]) -> BufferedCandle {
         vega: f64::from_le_bytes([
             buf[68], buf[69], buf[70], buf[71], buf[72], buf[73], buf[74], buf[75],
         ]),
+        // L12 (Wave-5 #504b): NOT in the on-disk spill format (76 bytes
+        // preserved for backward compatibility). Round-trip as 0.0;
+        // #504e revisits if non-zero values need durability.
+        close_pct_from_prev_day: 0.0,
+        oi_pct_from_prev_day: 0.0,
+        volume_pct_from_prev_day: 0.0,
     }
 }
 
@@ -531,7 +552,7 @@ impl LiveCandleWriter {
     ///
     /// # Performance
     /// O(1) — single ILP row append + conditional flush.
-    #[allow(clippy::too_many_arguments)] // APPROVED: ILP row requires all OHLCV+meta+Greeks columns
+    #[allow(clippy::too_many_arguments)] // APPROVED: ILP row requires all OHLCV+meta+Greeks+Wave5-pct columns
     pub fn append_candle(
         &mut self,
         security_id: u32,
@@ -548,6 +569,12 @@ impl LiveCandleWriter {
         gamma: f64,
         theta: f64,
         vega: f64,
+        // Wave-5 §K-L12 (PR #504b) — frozen-per-day % fields. Stamped at
+        // SEAL by `CandleEngine::seal_bar` (#504e). #504b ships them as
+        // `0.0` defaults; #504e wires the actual computation.
+        close_pct_from_prev_day: f64,
+        oi_pct_from_prev_day: f64,
+        volume_pct_from_prev_day: f64,
     ) -> Result<()> {
         // If disconnected, try reconnect (throttled) then buffer on failure.
         if self.sender.is_none() {
@@ -571,6 +598,9 @@ impl LiveCandleWriter {
                 gamma,
                 theta,
                 vega,
+                close_pct_from_prev_day,
+                oi_pct_from_prev_day,
+                volume_pct_from_prev_day,
             });
             return Ok(());
         }
@@ -595,6 +625,12 @@ impl LiveCandleWriter {
             .and_then(|b| b.column_f64("gamma", gamma))
             .and_then(|b| b.column_f64("theta", theta))
             .and_then(|b| b.column_f64("vega", vega))
+            // Wave-5 §K-L12 (#504b): emit the 3 new % columns. Values
+            // come from the caller; #504b passes 0.0 for all three.
+            // #504e wires the seal-time stamping that fills them in.
+            .and_then(|b| b.column_f64("close_pct_from_prev_day", close_pct_from_prev_day))
+            .and_then(|b| b.column_f64("oi_pct_from_prev_day", oi_pct_from_prev_day))
+            .and_then(|b| b.column_f64("volume_pct_from_prev_day", volume_pct_from_prev_day))
             .and_then(|b| b.at(ts_nanos))
         {
             warn!(?err, "live candle ILP buffer error — buffering candle");
@@ -613,6 +649,9 @@ impl LiveCandleWriter {
                 gamma,
                 theta,
                 vega,
+                close_pct_from_prev_day,
+                oi_pct_from_prev_day,
+                volume_pct_from_prev_day,
             };
             self.buffer_candle(candle);
             return Ok(());
@@ -634,6 +673,9 @@ impl LiveCandleWriter {
             gamma,
             theta,
             vega,
+            close_pct_from_prev_day,
+            oi_pct_from_prev_day,
+            volume_pct_from_prev_day,
         };
         self.in_flight.push(candle);
         self.pending_count = self.pending_count.saturating_add(1);
@@ -795,6 +837,13 @@ impl LiveCandleWriter {
             .and_then(|b| b.column_f64("gamma", c.gamma))
             .and_then(|b| b.column_f64("theta", c.theta))
             .and_then(|b| b.column_f64("vega", c.vega))
+            // Wave-5 §K-L12 (#504b): emit the 3 new % columns. On rescue
+            // ring drain the values are whatever the original write
+            // carried; on disk-spill drain they are 0.0 (the spill
+            // record format keeps 76 bytes for backward compatibility).
+            .and_then(|b| b.column_f64("close_pct_from_prev_day", c.close_pct_from_prev_day))
+            .and_then(|b| b.column_f64("oi_pct_from_prev_day", c.oi_pct_from_prev_day))
+            .and_then(|b| b.column_f64("volume_pct_from_prev_day", c.volume_pct_from_prev_day))
             .and_then(|b| b.at(ts_nanos))
             .context("build candle ILP row")?;
         Ok(())
@@ -1688,6 +1737,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         assert_eq!(writer.pending_count, 1);
@@ -1752,6 +1804,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         assert_eq!(writer.pending_count, 1);
@@ -1908,6 +1963,9 @@ mod tests {
             f64::NAN,
             f64::NAN,
             f64::NAN,
+            0.0,
+            0.0,
+            0.0,
         );
         assert!(
             result.is_ok(),
@@ -1949,6 +2007,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -2005,6 +2066,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -2028,6 +2092,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         // Ring buffer stays at capacity.
@@ -2098,6 +2165,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         assert_eq!(writer.pending_count, 1, "should be in ILP buffer");
@@ -2141,6 +2211,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
 
@@ -2168,6 +2241,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         assert_eq!(
@@ -2204,6 +2280,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let c2 = c; // Copy
         assert_eq!(c.security_id, c2.security_id, "BufferedCandle must be Copy");
@@ -2332,6 +2411,9 @@ mod tests {
                     gamma: f64::NAN,
                     theta: f64::NAN,
                     vega: f64::NAN,
+                    close_pct_from_prev_day: 0.0,
+                    oi_pct_from_prev_day: 0.0,
+                    volume_pct_from_prev_day: 0.0,
                 };
                 bw.write_all(&serialize_candle(&candle)).unwrap();
             }
@@ -2422,6 +2504,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         }
     }
 
@@ -2447,6 +2532,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
 
         let bytes = serialize_candle(&candle);
@@ -2492,6 +2580,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let restored_zero = deserialize_candle(&serialize_candle(&candle_zero));
         assert_eq!(restored_zero.security_id, 0);
@@ -2513,6 +2604,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let restored_max = deserialize_candle(&serialize_candle(&candle_max));
         assert_eq!(restored_max.security_id, u32::MAX);
@@ -2565,6 +2659,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -2600,6 +2697,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -2690,6 +2790,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -2953,6 +3056,9 @@ mod tests {
                     gamma: f64::NAN,
                     theta: f64::NAN,
                     vega: f64::NAN,
+                    close_pct_from_prev_day: 0.0,
+                    oi_pct_from_prev_day: 0.0,
+                    volume_pct_from_prev_day: 0.0,
                 };
                 bw.write_all(&serialize_candle(&candle)).unwrap();
             }
@@ -3128,6 +3234,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -3355,6 +3464,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         assert!(writer.pending_count > 0);
@@ -3499,6 +3611,9 @@ mod tests {
             f64::NAN,
             f64::NAN,
             f64::NAN,
+            0.0,
+            0.0,
+            0.0,
         );
         assert!(result.is_ok());
         assert_eq!(writer.buffered_candle_count(), 1);
@@ -3543,6 +3658,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -3594,6 +3712,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -3624,6 +3745,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         writer.force_flush_internal();
@@ -3680,6 +3804,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             });
         }
         assert_eq!(writer.buffered_candle_count(), CANDLE_BUFFER_CAPACITY);
@@ -3745,6 +3872,9 @@ mod tests {
                     gamma: f64::NAN,
                     theta: f64::NAN,
                     vega: f64::NAN,
+                    close_pct_from_prev_day: 0.0,
+                    oi_pct_from_prev_day: 0.0,
+                    volume_pct_from_prev_day: 0.0,
                 };
                 use std::io::Write as _;
                 file.write_all(&serialize_candle(&candle)).unwrap();
@@ -3874,6 +4004,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -3919,6 +4052,9 @@ mod tests {
                 f64::NAN,
                 f64::NAN,
                 f64::NAN,
+                0.0,
+                0.0,
+                0.0,
             )
             .unwrap();
         assert!(writer.pending_count > 0);
@@ -4173,6 +4309,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -4225,6 +4364,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -4713,6 +4855,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let buf = serialize_candle(&candle);
         let restored = deserialize_candle(&buf);
@@ -4741,6 +4886,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let buf = serialize_candle(&candle);
         let restored = deserialize_candle(&buf);
@@ -4772,6 +4920,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let buf = serialize_candle(&candle);
         assert_eq!(buf.len(), CANDLE_SPILL_RECORD_SIZE);
@@ -4962,6 +5113,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let copied = candle;
         assert_eq!(copied.security_id, 42);
@@ -4992,6 +5146,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         assert_eq!(candle.security_id, 0);
         assert_eq!(candle.timestamp_secs, 0);
@@ -5075,6 +5232,9 @@ mod tests {
             f64::NAN,
             f64::NAN,
             f64::NAN,
+            0.0,
+            0.0,
+            0.0,
         );
         assert!(
             result.is_ok(),
@@ -5124,6 +5284,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }
@@ -5688,6 +5851,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         writer.in_flight.push(c);
         writer.pending_count = 1;
@@ -5736,6 +5902,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         writer.in_flight.push(c);
         writer.pending_count = 1;
@@ -5791,6 +5960,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             });
         }
         assert_eq!(writer.candle_buffer.len(), 5);
@@ -5844,6 +6016,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             });
         }
 
@@ -5880,6 +6055,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             });
         }
 
@@ -5934,6 +6112,9 @@ mod tests {
                     gamma: f64::NAN,
                     theta: f64::NAN,
                     vega: f64::NAN,
+                    close_pct_from_prev_day: 0.0,
+                    oi_pct_from_prev_day: 0.0,
+                    volume_pct_from_prev_day: 0.0,
                 };
                 let record = serialize_candle(&c);
                 use std::io::Write as _;
@@ -6040,6 +6221,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             };
             let record = serialize_candle(&c);
             std::fs::write(&spill_path, record).unwrap();
@@ -6086,6 +6270,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             };
             let record = serialize_candle(&c);
             std::fs::write(&spill_path, record).unwrap();
@@ -6187,6 +6374,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             };
             let record = serialize_candle(&c);
             std::fs::write(&stale_path, record).unwrap();
@@ -6273,6 +6463,9 @@ mod tests {
                 gamma: f64::NAN,
                 theta: f64::NAN,
                 vega: f64::NAN,
+                close_pct_from_prev_day: 0.0,
+                oi_pct_from_prev_day: 0.0,
+                volume_pct_from_prev_day: 0.0,
             });
         }
 
@@ -6342,6 +6535,9 @@ mod tests {
             gamma: f64::NAN,
             theta: f64::NAN,
             vega: f64::NAN,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         }
     }
 
@@ -6372,6 +6568,9 @@ mod tests {
                     f64::NAN,
                     f64::NAN,
                     f64::NAN,
+                    0.0,
+                    0.0,
+                    0.0,
                 )
                 .unwrap();
         }

--- a/crates/storage/src/materialized_views.rs
+++ b/crates/storage/src/materialized_views.rs
@@ -58,6 +58,12 @@ const DEDUP_KEY_CANDLES_1S: &str = "security_id, segment";
 ///
 /// This is the base table that all materialized views aggregate from.
 /// Built by Rust's `CandleAggregator` → ILP flush.
+///
+/// **Wave-5 in-memory store §K-L12 (PR #504b)** added the three % fields
+/// `close_pct_from_prev_day`, `oi_pct_from_prev_day`,
+/// `volume_pct_from_prev_day`. They sit empty after #504b — #504e wires
+/// the seal-time stamping that populates them. Idempotent ALTER for
+/// existing deployments lives in `CANDLES_1S_WAVE5_PCT_COLUMNS`.
 const CANDLES_1S_CREATE_DDL: &str = "\
     CREATE TABLE IF NOT EXISTS candles_1s (\
         segment SYMBOL,\
@@ -78,6 +84,9 @@ const CANDLES_1S_CREATE_DDL: &str = "\
         prev_day_close DOUBLE,\
         prev_day_oi LONG,\
         phase SYMBOL,\
+        close_pct_from_prev_day DOUBLE,\
+        oi_pct_from_prev_day DOUBLE,\
+        volume_pct_from_prev_day DOUBLE,\
         ts TIMESTAMP\
     ) TIMESTAMP(ts) PARTITION BY DAY WAL\
 ";
@@ -98,6 +107,30 @@ const CANDLES_1S_PHASE1_LIFECYCLE_COLUMNS: &[(&str, &str)] = &[
     ("prev_day_close", "DOUBLE"),
     ("prev_day_oi", "LONG"),
     ("phase", "SYMBOL"),
+];
+
+/// Wave-5 in-memory store §K-L12 — 3 frozen-per-day **% fields** added to
+/// `candles_1s` by PR #504b.
+///
+/// Same idempotent ALTER pattern as `CANDLES_1S_PHASE1_LIFECYCLE_COLUMNS`
+/// (sub-millisecond cost on existing deployments because `ALTER TABLE
+/// ADD COLUMN IF NOT EXISTS` is a no-op when the column already exists).
+///
+/// **Why these are NEW columns even though `prev_day_close` /
+/// `prev_day_oi` already exist:** the % fields cache the value of
+/// `(close - prev_day_close) / prev_day_close * 100` (and the OI / volume
+/// analogues) at SEAL time per L13, so consumers can sort by `oi_pct`
+/// without recomputing for every read on the hot path. `previous_close`
+/// and `prev_day_oi` carry the absolute baselines; the 3 columns below
+/// carry the change-vs-baseline percentages.
+///
+/// Matches the 3 new fields on `tickvault_trading::candles::Bar` shipped
+/// in this PR. The producer (`CandleAggregator` / `seal_bar`) wires the
+/// stamping in PR #504e per L13.
+const CANDLES_1S_WAVE5_PCT_COLUMNS: &[(&str, &str)] = &[
+    ("close_pct_from_prev_day", "DOUBLE"),
+    ("oi_pct_from_prev_day", "DOUBLE"),
+    ("volume_pct_from_prev_day", "DOUBLE"),
 ];
 
 // ---------------------------------------------------------------------------
@@ -423,12 +456,21 @@ fn build_view_sql(def: &ViewDef) -> String {
     };
 
     // Phase 1 lifecycle columns (29-timeframes engine plan): every matview
-    // projects the 4 new columns via `last(...)` so the cum-day volume,
-    // frozen prev-day-close/OI and phase are visible at every TF without
-    // a JOIN. Source must be a base table or matview that already carries
-    // these columns — `CANDLES_1S_PHASE1_LIFECYCLE_COLUMNS` declares them
-    // on `candles_1s`, and rebuilding the matview chain in dependency
-    // order propagates them through every downstream view.
+    // projects the 4 lifecycle columns via `last(...)` so the cum-day
+    // volume, frozen prev-day-close/OI and phase are visible at every TF
+    // without a JOIN.
+    //
+    // Wave-5 §K-L12 (PR #504b): 3 additional `last(...)` projections for
+    // the change-vs-prev-day percentages (`close_pct_from_prev_day`,
+    // `oi_pct_from_prev_day`, `volume_pct_from_prev_day`). They sit empty
+    // until the producer (`CandleAggregator` seal-time stamping) lands
+    // in #504e per L13.
+    //
+    // Source must be a base table or matview that already carries
+    // these columns — `CANDLES_1S_PHASE1_LIFECYCLE_COLUMNS` +
+    // `CANDLES_1S_WAVE5_PCT_COLUMNS` declare them on `candles_1s`, and
+    // rebuilding the matview chain in dependency order propagates them
+    // through every downstream view.
     format!(
         "CREATE MATERIALIZED VIEW IF NOT EXISTS {name} AS \
          SELECT ts, security_id, segment, \
@@ -440,7 +482,10 @@ fn build_view_sql(def: &ViewDef) -> String {
          last(volume_cum_day_at_end) AS volume_cum_day_at_end, \
          last(prev_day_close) AS prev_day_close, \
          last(prev_day_oi) AS prev_day_oi, \
-         last(phase) AS phase \
+         last(phase) AS phase, \
+         last(close_pct_from_prev_day) AS close_pct_from_prev_day, \
+         last(oi_pct_from_prev_day) AS oi_pct_from_prev_day, \
+         last(volume_pct_from_prev_day) AS volume_pct_from_prev_day \
          FROM {source} \
          SAMPLE BY {interval} \
          ALIGN TO CALENDAR WITH OFFSET '{offset}'",
@@ -510,6 +555,13 @@ pub async fn ensure_candle_views(questdb_config: &QuestDbConfig) {
     // them — Phase 1 only widens the schema.
     ensure_phase1_lifecycle_columns_on_table(&client, &base_url, QUESTDB_TABLE_CANDLES_1S).await;
 
+    // Step 3c: Add Wave-5 % fields to candles_1s (in-memory store §K-L12,
+    // PR #504b). Same idempotent ALTER pattern. The 3 columns
+    // `close_pct_from_prev_day`, `oi_pct_from_prev_day`,
+    // `volume_pct_from_prev_day` sit empty until #504e wires the
+    // seal-time stamping per L13.
+    ensure_wave5_pct_columns_on_table(&client, &base_url, QUESTDB_TABLE_CANDLES_1S).await;
+
     // Step 4: Drop materialized views if they lack required columns OR if any
     // expected view is missing entirely from the catalogue.
     //
@@ -531,11 +583,12 @@ pub async fn ensure_candle_views(questdb_config: &QuestDbConfig) {
         || views_missing_phase1_columns(&client, &base_url).await
         || base_missing_phase1_columns(&client, &base_url).await
         || any_view_missing_or_lacks_iv(&client, &base_url).await
+        || views_missing_wave5_pct_columns(&client, &base_url).await
     {
         info!(
             "materialized views or candles_1s base lack Greeks / Phase 1 \
-             lifecycle columns, OR one or more of the 28 expected views is \
-             missing/orphan — dropping all views for clean recreation"
+             lifecycle / Wave-5 % columns, OR one or more of the 28 expected \
+             views is missing/orphan — dropping all views for clean recreation"
         );
         drop_all_views(&client, &base_url).await;
     }
@@ -710,6 +763,38 @@ async fn ensure_phase1_lifecycle_columns_on_table(
     );
 }
 
+/// Adds the 3 Wave-5 % fields (`close_pct_from_prev_day`,
+/// `oi_pct_from_prev_day`, `volume_pct_from_prev_day`) to a table if
+/// they are missing.
+///
+/// Same idempotent ALTER pattern as `ensure_phase1_lifecycle_columns_on_table`.
+/// The columns are seeded empty by #504b — the producer that populates
+/// them at SEAL time lands in #504e per L13.
+///
+/// Mechanical contract: the 3 column names + DOUBLE type pinned by
+/// `test_candles_1s_wave5_pct_columns_pinned_to_locked_schema` so a
+/// regression cannot drift them.
+async fn ensure_wave5_pct_columns_on_table(
+    client: &reqwest::Client,
+    base_url: &str,
+    table_name: &str,
+) {
+    for (col, ty) in CANDLES_1S_WAVE5_PCT_COLUMNS {
+        let alter_sql = format!("ALTER TABLE \"{table_name}\" ADD COLUMN \"{col}\" {ty}");
+        drop(
+            client
+                .get(base_url)
+                .query(&[("query", &alter_sql)])
+                .send()
+                .await,
+        );
+    }
+    info!(
+        table = table_name,
+        "Wave-5 % columns ensured (idempotent ADD COLUMN)"
+    );
+}
+
 /// Checks whether the `candles_1s` BASE TABLE is missing the Phase 1
 /// lifecycle column `phase` (29-timeframes engine plan).
 ///
@@ -773,6 +858,37 @@ async fn views_missing_phase1_columns(client: &reqwest::Client, base_url: &str) 
                 // token so we don't accidentally match `phase` substrings
                 // elsewhere in the response.
                 if !body.contains("\"phase\"") {
+                    return true;
+                }
+            }
+            false
+        }
+        Err(_) => false,
+    }
+}
+
+/// Wave-5 §K-L12 (PR #504b): checks whether existing materialized views
+/// are missing the new `close_pct_from_prev_day` column.
+///
+/// Mirrors `views_missing_phase1_columns` — probes `candles_5s` (the
+/// first downstream view) and treats absence of any one of the 3 new
+/// % columns as a "needs recreate" signal. We probe the first column
+/// only because all 3 are added together in `build_view_sql`.
+///
+/// Returns `true` when matviews need recreation. Failed probe → `false`
+/// (Step 5's `CREATE ... IF NOT EXISTS` handles missing views directly).
+async fn views_missing_wave5_pct_columns(client: &reqwest::Client, base_url: &str) -> bool {
+    let probe_sql = "SHOW COLUMNS FROM candles_5s";
+    match client
+        .get(base_url)
+        .query(&[("query", probe_sql)])
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() {
+                let body = response.text().await.unwrap_or_default();
+                if !body.contains("\"close_pct_from_prev_day\"") {
                     return true;
                 }
             }
@@ -1459,6 +1575,60 @@ mod tests {
                 "view {} must project last(phase)",
                 def.name
             );
+        }
+    }
+
+    // --- Wave-5 §K-L12 (PR #504b) ratchets -----------------------------
+
+    /// PR #504b ratchet: the 3 % columns MUST appear in the CREATE DDL
+    /// so greenfield deployments include them without needing the
+    /// brownfield ALTER pass.
+    #[test]
+    fn test_candles_1s_ddl_has_wave5_pct_columns() {
+        for (col, ty) in CANDLES_1S_WAVE5_PCT_COLUMNS {
+            let needle = format!("{col} {ty}");
+            assert!(
+                CANDLES_1S_CREATE_DDL.contains(&needle),
+                "candles_1s DDL must declare `{needle}` (Wave-5 §K-L12 / #504b)"
+            );
+        }
+    }
+
+    /// PR #504b ratchet: the constant array pins the exact 3 columns +
+    /// types so a future commit cannot silently drop one or change a
+    /// type.
+    #[test]
+    fn test_candles_1s_wave5_pct_columns_pinned_to_locked_schema() {
+        let pairs: Vec<(&str, &str)> = CANDLES_1S_WAVE5_PCT_COLUMNS.to_vec();
+        assert_eq!(
+            pairs,
+            vec![
+                ("close_pct_from_prev_day", "DOUBLE"),
+                ("oi_pct_from_prev_day", "DOUBLE"),
+                ("volume_pct_from_prev_day", "DOUBLE"),
+            ],
+            "CANDLES_1S_WAVE5_PCT_COLUMNS pinned to the L12 locked list — \
+             drift between the brownfield ALTER and the greenfield CREATE \
+             produces silently divergent schemas across deployments."
+        );
+    }
+
+    /// PR #504b ratchet: every materialized view MUST project the 3 new
+    /// % columns via `last(...)`. Without this, downstream SELECTs
+    /// (`/api/movers` after #505) cannot sort by `oi_pct_from_prev_day`
+    /// at any TF other than `1s`.
+    #[test]
+    fn test_build_view_sql_projects_wave5_pct_columns() {
+        for def in VIEW_DEFS {
+            let sql = build_view_sql(def);
+            for (col, _ty) in CANDLES_1S_WAVE5_PCT_COLUMNS {
+                let needle = format!("last({col}) AS {col}");
+                assert!(
+                    sql.contains(&needle),
+                    "view {name} must project `{needle}` (#504b)",
+                    name = def.name,
+                );
+            }
         }
     }
 

--- a/crates/storage/tests/candle_resilience.rs
+++ b/crates/storage/tests/candle_resilience.rs
@@ -63,6 +63,9 @@ fn test_candle_writer_cold_start_buffers_candles() {
                 0.0,               // gamma
                 0.0,               // theta
                 0.0,               // vega
+                0.0,
+                0.0,
+                0.0,
             )
             .expect("append_candle must not fail even when disconnected");
     }
@@ -97,6 +100,9 @@ fn test_candle_writer_cold_start_zero_drops() {
                 0.01,
                 -0.03,
                 0.15,
+                0.0,
+                0.0,
+                0.0,
             )
             .expect("append must not fail");
     }
@@ -139,6 +145,9 @@ fn test_recovery_ordering_ring_before_spill() {
                 0.0,
                 0.0,
                 0.0,
+                0.0,
+                0.0,
+                0.0,
             )
             .expect("append must not fail");
     }
@@ -158,6 +167,9 @@ fn test_recovery_ordering_ring_before_spill() {
                 100.0 + i as f32,
                 1000,
                 10,
+                0.0,
+                0.0,
+                0.0,
                 0.0,
                 0.0,
                 0.0,
@@ -213,6 +225,9 @@ fn test_reconnect_revalidates_schema() {
             0.0,
             0.0,
             0.0,
+            0.0,
+            0.0,
+            0.0,
         )
         .expect("append must succeed on disconnected writer");
 
@@ -250,6 +265,9 @@ fn test_disconnected_writer_fresh_buffer_does_not_corrupt() {
                     100.5,
                     1000,
                     10,
+                    0.0,
+                    0.0,
+                    0.0,
                     0.0,
                     0.0,
                     0.0,

--- a/crates/trading/benches/cascade_fanout.rs
+++ b/crates/trading/benches/cascade_fanout.rs
@@ -33,6 +33,11 @@ fn bar_at(bucket_start: u32, security_id: u32) -> Bar {
         security_id,
         exchange_segment_code: 2, // NSE_FNO
         sealed: true,
+        prev_day_close: 0.0,
+        prev_day_oi: 0,
+        close_pct_from_prev_day: 0.0,
+        oi_pct_from_prev_day: 0.0,
+        volume_pct_from_prev_day: 0.0,
     }
 }
 

--- a/crates/trading/src/candles/cascade_fanout.rs
+++ b/crates/trading/src/candles/cascade_fanout.rs
@@ -582,6 +582,11 @@ mod tests {
             security_id,
             exchange_segment_code: segment_code,
             sealed: true,
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         }
     }
 

--- a/crates/trading/src/candles/engine.rs
+++ b/crates/trading/src/candles/engine.rs
@@ -80,6 +80,39 @@ pub struct Bar {
     /// `true` once the bar has been sealed (the next tick crossed a
     /// boundary). A non-sealed bar is the open bar still accumulating.
     pub sealed: bool,
+    // -----------------------------------------------------------------
+    // Wave-5 in-memory store §K-L12 — frozen-per-day reference fields.
+    //
+    // Source-of-truth: `previous_close` cache (PR #466) +
+    // `prev_oi_loader` (PR #454). Sourced once per (security_id, segment)
+    // at boot, frozen for the trading day, copied into every Bar at seal
+    // so /api/movers can compute % vs prev day without an additional JOIN.
+    //
+    // PR #504b ships the fields with default `0.0` / `0` values. The
+    // populator (boot-time copy from `previous_close` + `prev_oi_loader`
+    // caches into the engine's per-instrument context) lands in #504d
+    // alongside the in-memory store wiring. The % computation at seal
+    // (close_pct, oi_pct, volume_pct) lands in #504e per L13.
+    /// Previous trading day's close price for this `(security_id,
+    /// exchange_segment)`. Frozen at IST 00:00 by the bhavcopy loader.
+    /// `0.0` until the boot wiring in #504d populates the cache.
+    pub prev_day_close: f64,
+    /// Previous trading day's last open interest (only meaningful for
+    /// derivatives — `0` for IDX_I and equities). Frozen at IST 00:00.
+    /// `0` until the boot wiring in #504d populates the cache.
+    pub prev_day_oi: i64,
+    /// `(close - prev_day_close) / prev_day_close * 100`. Stamped at
+    /// SEAL only per L13 (NOT per tick); on-demand `~50 µs` scan
+    /// computes "right now" % between seals. `0.0` until #504e populates.
+    pub close_pct_from_prev_day: f64,
+    /// `(oi - prev_day_oi) / prev_day_oi * 100`. Same SEAL-only stamping
+    /// as `close_pct_from_prev_day`. `0.0` until #504e populates.
+    pub oi_pct_from_prev_day: f64,
+    /// `(volume_cum_day_at_end - prev_day_total_volume) / prev_day_total_volume
+    /// * 100`. Note: the prev-day volume baseline source is
+    /// `previous_close::prev_day_total_volume` (PR #466), distinct from
+    /// `prev_day_oi`. Stamped at SEAL only. `0.0` until #504e populates.
+    pub volume_pct_from_prev_day: f64,
 }
 
 impl Bar {
@@ -106,6 +139,13 @@ impl Bar {
             security_id,
             exchange_segment_code,
             sealed: false,
+            // L12 Wave-5: defaults until #504d wires the source caches
+            // and #504e stamps the % values at seal.
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         }
     }
 }
@@ -633,6 +673,59 @@ mod tests {
         }
     }
 
+    // -- Wave-5 §K-L12 (PR #504b) Bar-struct-shape ratchets ---------------
+
+    /// PR #504b ratchet: a fresh-open `Bar` must have all 5 Wave-5 fields
+    /// initialized to zero. Anyone who removes the field from
+    /// `Bar::new_open_at` would otherwise leave them un-initialized
+    /// (or worse, accidentally re-purpose them).
+    #[test]
+    fn test_bar_new_open_at_zero_inits_wave5_pct_fields() {
+        let b = Bar::new_open_at(0, 60, 1, 1);
+        assert_eq!(b.prev_day_close, 0.0);
+        assert_eq!(b.prev_day_oi, 0);
+        assert_eq!(b.close_pct_from_prev_day, 0.0);
+        assert_eq!(b.oi_pct_from_prev_day, 0.0);
+        assert_eq!(b.volume_pct_from_prev_day, 0.0);
+    }
+
+    /// PR #504b ratchet: the new % fields are `f64` (not `f32`) — keeps
+    /// parity with the QuestDB DDL (`DOUBLE`) and the matview
+    /// `last(...)` projection types. A drift to `f32` would silently
+    /// degrade precision on the wire.
+    ///
+    /// Compile-time check: passes a `f64` constant through the field.
+    /// If the field type ever changes, this fails to compile (or
+    /// triggers a noisy lossy-conversion warning).
+    #[test]
+    fn test_bar_wave5_pct_fields_are_f64() {
+        let b = Bar {
+            bucket_start_ist_secs: 0,
+            bucket_end_ist_secs: 60,
+            open: 0.0,
+            high: 0.0,
+            low: 0.0,
+            close: 0.0,
+            volume: 0,
+            volume_cum_day_at_end: 0,
+            oi: 0,
+            tick_count: 0,
+            security_id: 1,
+            exchange_segment_code: 1,
+            sealed: false,
+            prev_day_close: 1.234_567_890_123_456_e10,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 1.234_567_890_123_456_e10,
+            oi_pct_from_prev_day: 1.234_567_890_123_456_e10,
+            volume_pct_from_prev_day: 1.234_567_890_123_456_e10,
+        };
+        // f64 retains the magnitude precisely; f32 would silently round.
+        assert!((b.prev_day_close - 1.234_567_890_123_456_e10).abs() < 1.0);
+        assert!((b.close_pct_from_prev_day - 1.234_567_890_123_456_e10).abs() < 1.0);
+        assert!((b.oi_pct_from_prev_day - 1.234_567_890_123_456_e10).abs() < 1.0);
+        assert!((b.volume_pct_from_prev_day - 1.234_567_890_123_456_e10).abs() < 1.0);
+    }
+
     #[test]
     fn test_tf_secs_constants_are_correct() {
         assert_eq!(Tf1s::SECS, 1);
@@ -865,6 +958,11 @@ mod tests {
             security_id: 1234,
             exchange_segment_code: 1,
             sealed: true,
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let result = e.on_sealed_bar(&input);
         assert!(result.is_none());
@@ -891,6 +989,11 @@ mod tests {
             security_id: 1234,
             exchange_segment_code: 1,
             sealed: true,
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         e.on_sealed_bar(&bar1);
         bar1.bucket_start_ist_secs = 1010;
@@ -928,6 +1031,11 @@ mod tests {
             security_id: 1234,
             exchange_segment_code: 1,
             sealed: true,
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         e.on_sealed_bar(&bar1);
         // Bucket [960, 1020). Now feed a bar at 1020 — different bucket.
@@ -945,6 +1053,11 @@ mod tests {
             security_id: 1234,
             exchange_segment_code: 1,
             sealed: true,
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         };
         let sealed = e
             .on_sealed_bar(&bar2)

--- a/crates/trading/src/candles/parity.rs
+++ b/crates/trading/src/candles/parity.rs
@@ -252,6 +252,11 @@ mod tests {
             security_id,
             exchange_segment_code: segment_code,
             sealed: true,
+            prev_day_close: 0.0,
+            prev_day_oi: 0,
+            close_pct_from_prev_day: 0.0,
+            oi_pct_from_prev_day: 0.0,
+            volume_pct_from_prev_day: 0.0,
         }
     }
 

--- a/crates/trading/tests/dhat_cascade_fanout.rs
+++ b/crates/trading/tests/dhat_cascade_fanout.rs
@@ -31,6 +31,11 @@ fn bar_at(bucket_start: u32, security_id: u32) -> Bar {
         security_id,
         exchange_segment_code: 2, // NSE_FNO
         sealed: true,
+        prev_day_close: 0.0,
+        prev_day_oi: 0,
+        close_pct_from_prev_day: 0.0,
+        oi_pct_from_prev_day: 0.0,
+        volume_pct_from_prev_day: 0.0,
     }
 }
 

--- a/crates/trading/tests/parity_soak_harness.rs
+++ b/crates/trading/tests/parity_soak_harness.rs
@@ -55,6 +55,11 @@ fn synthetic_bar(
         security_id,
         exchange_segment_code: segment_code,
         sealed: true,
+        prev_day_close: 0.0,
+        prev_day_oi: 0,
+        close_pct_from_prev_day: 0.0,
+        oi_pct_from_prev_day: 0.0,
+        volume_pct_from_prev_day: 0.0,
     }
 }
 


### PR DESCRIPTION
## Summary

PR **#504b of 10** in the Wave-5 in-memory-store rollout (`§M / §O` in `.claude/plans/active-plan-in-memory-store-aws-instance.md`). Stacked on top of **#504a** (PR #507, merged at `de6f7ff`).

This PR ships the **schema + struct delta** required by the in-memory store. The actual % computation at SEAL time lands in #504e; the in-memory store wiring lands in #504d. #504b is a pure scaffold that:
- widens `tickvault_trading::candles::Bar` with 5 new frozen-per-day reference fields,
- widens the `candles_1s` schema with 3 new `DOUBLE` columns + projects them through every materialized view,
- extends the live ILP writer to emit the 3 new columns on every write + every rescue-ring drain.

## Plan reconciliation (5 fields vs 3 columns)

The plan §K-L12 lists "5 new fields": `cumulative_volume`, `close_pct_from_prev_day`, `prev_day_oi`, `oi_pct_from_prev_day`, `volume_pct_from_prev_day`. After harmonising with the existing schema (PR #466 + #486) this maps to:

| Plan name | Bar struct | candles_1s schema | This PR |
|---|---|---|---|
| `cumulative_volume` | already exists as `volume_cum_day_at_end` | already exists as `volume_cum_day_at_end LONG` | no change |
| `prev_day_close` | NEW field | already exists | Bar adds field |
| `prev_day_oi` | NEW field | already exists | Bar adds field |
| `close_pct_from_prev_day` | NEW field | NEW column `DOUBLE` | both |
| `oi_pct_from_prev_day` | NEW field | NEW column `DOUBLE` | both |
| `volume_pct_from_prev_day` | NEW field | NEW column `DOUBLE` | both |

**Net: 5 new Bar fields, 3 new schema columns.** No rename, no duplicate column.

## What lands

| File | Change |
|---|---|
| `crates/trading/src/candles/engine.rs` | `Bar` struct gains 5 fields; `Bar::new_open_at` defaults them to `0.0`/`0`; 4 in-file Bar literals updated; +2 ratchet tests |
| `crates/trading/src/candles/parity.rs`, `cascade_fanout.rs`, benches/`cascade_fanout.rs`, tests/`parity_soak_harness.rs`, tests/`dhat_cascade_fanout.rs` | Bar literal sites updated (1 each) |
| `crates/api/src/handlers/movers_v2.rs` | `From<&Bar> for MoversV2Bar` keeps wire shape unchanged (response-shape change is #505's job) |
| `crates/storage/src/materialized_views.rs` | `CANDLES_1S_CREATE_DDL` adds 3 new `DOUBLE` columns; new `CANDLES_1S_WAVE5_PCT_COLUMNS` constant; new `ensure_wave5_pct_columns_on_table` helper; `build_view_sql` projects 3 new `last(...)` columns; new `views_missing_wave5_pct_columns` probe wired into the drop-and-recreate OR chain; +3 ratchet tests |
| `crates/storage/src/candle_persistence.rs` | `BufferedCandle` struct gains 3 f64 fields (NOT serialized to disk-spill — round-trip as 0.0); `LiveCandlePersistenceWriter::append_candle` signature extended 14→17 params; `build_candle_row` (rescue-ring drain) emits 3 new columns; 38 in-file BufferedCandle literals + 25 in-file `append_candle` invocations updated by walk-paren script |
| `crates/storage/tests/candle_resilience.rs` | 6 test invocations updated |
| `crates/core/src/pipeline/tick_processor.rs` | 2 caller sites pass `0.0, 0.0, 0.0` |
| `crates/app/src/main.rs` | 2 caller sites pass `0.0, 0.0, 0.0` |

## Ratchet tests (5 new)

| Test | Crate | Pins |
|---|---|---|
| `test_candles_1s_ddl_has_wave5_pct_columns` | storage | 3 columns appear in greenfield `CREATE TABLE` |
| `test_candles_1s_wave5_pct_columns_pinned_to_locked_schema` | storage | constant array exact-match `[("close_pct_from_prev_day","DOUBLE"), ...]` |
| `test_build_view_sql_projects_wave5_pct_columns` | storage | 28 matviews each project `last(<col>) AS <col>` for all 3 cols |
| `test_bar_new_open_at_zero_inits_wave5_pct_fields` | trading | fresh-open Bar zero-inits all 5 new fields |
| `test_bar_wave5_pct_fields_are_f64` | trading | new % fields are `f64` (parity with `DOUBLE` schema) |

## Test plan

- [x] `cargo fmt --check` — green
- [x] `cargo check --workspace --tests` — green
- [x] `cargo test -p tickvault-storage --lib --tests --no-fail-fast` — **1589 lib pass + integration suites green** (only pre-existing `per_item_guarantee_matrix_guard::test_every_wave_5_item_carries_guarantee_matrix` failure, reproduces on `origin/main`)
- [x] `cargo test -p tickvault-trading --lib --tests --no-fail-fast` — 1312 lib + 1785 total green
- [x] `cargo test -p tickvault-storage --lib wave5` — 3/3 new ratchets green
- [x] `cargo test -p tickvault-trading --lib wave5` — 2/2 new ratchets green

## Brownfield self-heal contract

The new `views_missing_wave5_pct_columns` probe lives in the same OR-chain as the Greeks / Phase 1 / orphan-state probes. On boot, if any of the 28 matviews is missing `close_pct_from_prev_day`, **all 28 matviews are dropped and recreated** with the new schema. Same pattern that shipped Greeks columns (PR #486-era) and Phase 1 lifecycle (Phase 2 wiring).

## Disk-spill compat

The on-disk candle spill format keeps **76 bytes per record** for backward compatibility with in-flight spill files at upgrade time. The 3 new % fields are NOT persisted to disk; on disk-spill recovery they round-trip as `0.0`. Matches #504b's "all defaults" semantics. #504e revisits if non-zero values need durability.

## Honest 100% claim

> 100% inside the tested envelope, with ratcheted regression coverage:
> - 5 new Bar fields are zero-initialised at every seal site;
> - 3 new schema columns appear in greenfield CREATE + brownfield ALTER + every matview's `last(...)` projection;
> - the drop-and-recreate probe fires on any deployment where `candles_5s` lacks `close_pct_from_prev_day`;
> - the ILP writer emits the 3 new columns on every live write + every rescue-ring drain.
>
> Beyond the envelope: the on-disk spill format does NOT carry the new fields (76-byte record preserved). On disk-spill recovery, all 3 fields round-trip as `0.0` — semantically correct for #504b since the producer (`#504e`) hasn't shipped yet.

## Gates / next steps

- **Stop after this PR opens.** Awaiting operator approval before #504c (TF list config — drop seconds engines, runtime-tunable `[engine.timeframes].list`).
- The fields populate to non-zero in #504e once the seal-time stamping wires up `previous_close` + `prev_oi_loader` caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T

---
_Generated by [Claude Code](https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T)_