### PR TITLE
feat(trading,common): #504d in-memory tick storage + IST 09:15 reset (Wave-5 §K-L9/L10)

### DIFF
--- a/config/base.toml
+++ b/config/base.toml
@@ -437,3 +437,12 @@ list = [
   "1h", "2h", "3h", "4h",
   "1d",
 ]
+
+# Wave-5 in-memory store §K-L10 (PR #504d) — runtime-tunable
+# per-instrument tick storage. The default `per_instrument_capacity`
+# (5_000) covers the busiest contract's daily tick count without
+# forcing a Vec realloc. Operators on lower-volume universes can
+# trim this to save RAM (Linux lazy-page allocation means reserved
+# but unused capacity does not count against RSS).
+[in_mem.tick_storage]
+per_instrument_capacity = 5000

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -644,6 +644,49 @@ async fn main() -> Result<()> {
         std::sync::Arc::new(subsystem_memory::SubsystemMemorySampler::new(
             std::sync::Arc::clone(&subsystem_memory_handles),
         ));
+
+    // L10 (Wave-5 #504d): construct the in-RAM tick ring. Per
+    // `[in_mem.tick_storage].per_instrument_capacity` config (default
+    // 5_000), each new (security_id, segment) key reserves that many
+    // tick slots on first push so steady-state pushes hit the
+    // no-realloc path.
+    let tick_storage = std::sync::Arc::new(tickvault_trading::in_mem::TickStorage::new(
+        config.in_mem.tick_storage.per_instrument_capacity,
+    ));
+
+    // L18 / #504a contract: register the `tick_storage` source closure
+    // with the subsystem_memory sampler. The sampler runs every 10s and
+    // calls `estimated_bytes()` to update
+    // `tv_subsystem_memory_estimated_bytes{component="tick_storage"}`.
+    {
+        let storage_for_sampler = std::sync::Arc::clone(&tick_storage);
+        if let Err(err) = subsystem_memory_sampler.register_source("tick_storage", move || {
+            // L18: lazy `len() x size_of` — NOT raw RSS. Reports actual
+            // resident bytes (Linux lazy-page allocation excludes
+            // reserved-but-unused Vec capacity).
+            #[allow(clippy::cast_precision_loss)]
+            // APPROVED: byte count fits f64 mantissa for any realistic universe
+            Some(storage_for_sampler.estimated_bytes() as f64)
+        }) {
+            tracing::error!(
+                err,
+                "L18 / #504a: failed to register tick_storage memory source — \
+                 component gauge will stay NaN; investigate the subsystem_memory \
+                 sampler state"
+            );
+        }
+    }
+
+    // L10 reset task: drain the tick ring at IST 09:15 daily so day-N
+    // ticks never bleed into day-(N+1)'s session. Sleep-based, not
+    // poll-based — audit-findings Rule 3 (market-hours-aware tokio task).
+    let _tick_storage_reset_join = {
+        let storage_for_reset = std::sync::Arc::clone(&tick_storage);
+        tokio::spawn(async move {
+            tickvault_trading::in_mem::run_tick_storage_daily_reset(storage_for_reset).await;
+        })
+    };
+
     let _subsystem_memory_sampler_join = std::sync::Arc::clone(&subsystem_memory_sampler).spawn();
 
     // -----------------------------------------------------------------------
@@ -2700,6 +2743,26 @@ async fn main() -> Result<()> {
         });
         info!(
             "29-tf candle cascade started: 1s engine + 28-TF fanout + supervisor + midnight rollover"
+        );
+    }
+
+    // L10 (Wave-5 #504d): tick_storage broadcast consumer. Subscribes
+    // to the same `tick_broadcast_sender` used by the cascade so every
+    // tick lands in the in-RAM ring without coupling the tick_processor
+    // hot path to TickStorage's lock latency.
+    {
+        let tick_storage_rx = tick_broadcast_sender.subscribe();
+        let storage_for_consumer = std::sync::Arc::clone(&tick_storage);
+        tokio::spawn(async move {
+            tickvault_trading::in_mem::run_tick_storage_consumer(
+                tick_storage_rx,
+                storage_for_consumer,
+            )
+            .await;
+        });
+        info!(
+            per_instrument_capacity = config.in_mem.tick_storage.per_instrument_capacity,
+            "L10 tick_storage broadcast consumer spawned + IST 09:15 reset task running"
         );
     }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -65,6 +65,52 @@ pub struct ApplicationConfig {
     /// engines per L7).
     #[serde(default)]
     pub engine: EngineConfig,
+    /// Wave-5 in-memory store §K-L10 (PR #504d) — runtime-tunable
+    /// per-instrument tick capacity for `TickStorage`. Default 5_000
+    /// covers the busiest contract's daily tick count without
+    /// triggering Vec realloc.
+    #[serde(default)]
+    pub in_mem: InMemConfig,
+}
+
+/// Container for the `[in_mem]` TOML section (Wave-5 §K-L10, PR #504d).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct InMemConfig {
+    #[serde(default)]
+    pub tick_storage: TickStorageConfig,
+}
+
+/// `[in_mem.tick_storage]` — runtime-tunable TickStorage settings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TickStorageConfig {
+    /// Pre-allocated `Vec<ParsedTick>` capacity per `(security_id,
+    /// exchange_segment)` key on first push. Sized to cover the
+    /// busiest contract's daily tick count without forcing a Vec
+    /// realloc (`tv_in_mem_tick_storage_realloc_total` increments on
+    /// overflow). Setting this to 0 falls back to the compile-time
+    /// default (`DEFAULT_PER_INSTRUMENT_CAPACITY = 5_000`) inside
+    /// `TickStorage::new` so a misconfigured TOML cannot trigger
+    /// 1-byte-realloc-per-tick.
+    #[serde(default = "TickStorageConfig::default_per_instrument_capacity")]
+    pub per_instrument_capacity: usize,
+}
+
+impl TickStorageConfig {
+    /// Default capacity = 5_000 per L10 sizing analysis (mirrors the
+    /// trading crate constant `DEFAULT_PER_INSTRUMENT_CAPACITY`).
+    /// Pinned by `test_tick_storage_default_per_instrument_capacity`.
+    #[must_use]
+    pub const fn default_per_instrument_capacity() -> usize {
+        5_000
+    }
+}
+
+impl Default for TickStorageConfig {
+    fn default() -> Self {
+        Self {
+            per_instrument_capacity: Self::default_per_instrument_capacity(),
+        }
+    }
 }
 
 /// Container for the `[engine.timeframes]` TOML section. L8 pins the
@@ -1869,6 +1915,7 @@ mod tests {
             depth_20: Depth20RootConfig::default(),
             depth_200: Depth200RootConfig::default(),
             engine: EngineConfig::default(),
+            in_mem: InMemConfig::default(),
         }
     }
 
@@ -2554,6 +2601,23 @@ mod tests {
         let engine = EngineConfig::default();
         assert_eq!(engine.timeframes.list.len(), 21);
         assert!(!engine.timeframes.contains_seconds_tf());
+    }
+
+    // --- Wave-5 §K-L10 (PR #504d) ratchets ---------------------------
+
+    #[test]
+    fn test_tick_storage_default_per_instrument_capacity_is_5k() {
+        // L10 + sizing analysis pin: 5_000 covers the busiest contract.
+        // Drift requires plan amend.
+        let cfg = TickStorageConfig::default();
+        assert_eq!(cfg.per_instrument_capacity, 5_000);
+        assert_eq!(TickStorageConfig::default_per_instrument_capacity(), 5_000);
+    }
+
+    #[test]
+    fn test_in_mem_config_default_inherits_l10_tick_storage() {
+        let cfg = InMemConfig::default();
+        assert_eq!(cfg.tick_storage.per_instrument_capacity, 5_000);
     }
 
     #[test]

--- a/crates/trading/src/in_mem/consumer.rs
+++ b/crates/trading/src/in_mem/consumer.rs
@@ -148,6 +148,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_run_tick_storage_consumer_explicit_name_match() {
+        let (tx, rx) = broadcast::channel::<ParsedTick>(4);
+        let storage = Arc::new(TickStorage::default());
+        drop(tx);
+        run_tick_storage_consumer(rx, storage).await;
+    }
+
+    #[tokio::test]
     async fn test_consumer_exits_cleanly_on_closed_channel() {
         // Sender dropped before any tick → task exits without
         // emitting the false-OK "task active" line (Rule 11).

--- a/crates/trading/src/in_mem/consumer.rs
+++ b/crates/trading/src/in_mem/consumer.rs
@@ -1,0 +1,160 @@
+//! Broadcast consumer task that pushes every tick into [`TickStorage`].
+//!
+//! Subscribes to the same `tokio::sync::broadcast::Sender<ParsedTick>`
+//! that fans the live tick stream to existing consumers (the 1s
+//! candle cascade, persistence pipeline, etc.). Each `recv().await`
+//! pushes the tick into the in-RAM ring.
+//!
+//! ## Why a broadcast consumer (not a tick_processor parameter)
+//!
+//! The existing `cascade::run_cascade_1s` already uses this pattern:
+//! every downstream component that needs the live tick stream
+//! subscribes via its own broadcast Receiver, decoupling the
+//! tick_processor's hot loop from any individual consumer's latency
+//! profile. Adding a `tick_storage.push(&tick)` call inline in
+//! tick_processor.rs would couple that hot path to the storage's lock
+//! latency; the broadcast pattern keeps the hot path lean.
+//!
+//! ## Lag handling
+//!
+//! `broadcast::Receiver::recv` returns `Err(Lagged(n))` when the
+//! consumer is slower than the broadcast capacity. The
+//! `tv_in_mem_tick_storage_lag_total` counter increments by `n`; the
+//! `error!` path is coalesced so a single backpressure event doesn't
+//! flood Telegram.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use metrics::counter;
+use tokio::sync::broadcast::{self, error::RecvError};
+use tracing::{error, info};
+
+use tickvault_common::tick_types::ParsedTick;
+
+use crate::in_mem::tick_storage::TickStorage;
+
+/// Coalesce window for `error!` on broadcast lag (matches the cascade
+/// task's discipline). `error!` fires AT MOST once per N seconds even
+/// under sustained lag, so Telegram doesn't flood. Counter still
+/// increments on every Lagged event for accurate operator dashboards.
+const LAG_ERROR_COALESCE_SECS: u64 = 60;
+
+/// Runs until the broadcast sender is dropped. The caller spawns this
+/// via `tokio::spawn(...)` and stores the `JoinHandle` for shutdown
+/// observability.
+///
+/// **First-tick log**: emits `info!` only after the FIRST successful
+/// `recv()` — an immediate-close broadcast (sender dropped before any
+/// tick) does NOT spam a "task active" line. Mirrors the cascade
+/// task's audit-Rule-11 discipline (no false-OK signals).
+pub async fn run_tick_storage_consumer(
+    mut rx: broadcast::Receiver<ParsedTick>,
+    storage: Arc<TickStorage>,
+) {
+    let mut first_tick_seen = false;
+    let mut last_lag_log: Option<Instant> = None;
+    loop {
+        match rx.recv().await {
+            Ok(tick) => {
+                if !first_tick_seen {
+                    first_tick_seen = true;
+                    info!(
+                        instruments = storage.len_instruments(),
+                        "tick_storage consumer task active — first tick observed"
+                    );
+                }
+                if !storage.push(tick) {
+                    // `push` already increments
+                    // `tv_in_mem_tick_storage_pushes_dropped_total{reason}`
+                    // and only returns false on Mutex poison (extremely
+                    // unlikely; no panic-able code in the critical
+                    // section). Continue the loop — next push targets
+                    // the same `Arc<Mutex>` and will succeed.
+                    counter!("tv_in_mem_tick_storage_consumer_drops_total").increment(1);
+                }
+            }
+            Err(RecvError::Lagged(n)) => {
+                counter!("tv_in_mem_tick_storage_lag_total").increment(n);
+                let should_log = match last_lag_log {
+                    None => true,
+                    Some(prev) => prev.elapsed() >= Duration::from_secs(LAG_ERROR_COALESCE_SECS),
+                };
+                if should_log {
+                    last_lag_log = Some(Instant::now());
+                    // Audit-findings Rule 5: ERROR (not WARN) so
+                    // Telegram surfaces sustained lag.
+                    error!(
+                        lagged_count = n,
+                        coalesce_window_secs = LAG_ERROR_COALESCE_SECS,
+                        "tick_storage consumer broadcast lag"
+                    );
+                }
+            }
+            Err(RecvError::Closed) => {
+                info!("tick_storage consumer broadcast closed — shutting down task");
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tick(security_id: u32, segment: u8, ltp: f32) -> ParsedTick {
+        ParsedTick {
+            security_id,
+            exchange_segment_code: segment,
+            last_traded_price: ltp,
+            ..ParsedTick::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_consumer_receives_and_pushes_one_tick() {
+        let (tx, rx) = broadcast::channel(16);
+        let storage = Arc::new(TickStorage::default());
+        let storage_clone = Arc::clone(&storage);
+        let join = tokio::spawn(async move {
+            run_tick_storage_consumer(rx, storage_clone).await;
+        });
+        // Send one tick, then close the channel.
+        tx.send(make_tick(1234, 1, 100.0))
+            .expect("broadcast send during test");
+        drop(tx);
+        // Task exits when sender is dropped.
+        join.await.expect("consumer task join");
+        assert_eq!(storage.len_total(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_consumer_handles_multiple_instruments() {
+        let (tx, rx) = broadcast::channel(16);
+        let storage = Arc::new(TickStorage::default());
+        let storage_clone = Arc::clone(&storage);
+        let join = tokio::spawn(async move {
+            run_tick_storage_consumer(rx, storage_clone).await;
+        });
+        for i in 0..5 {
+            tx.send(make_tick(1234, 1, i as f32)).expect("send");
+            tx.send(make_tick(5678, 2, i as f32)).expect("send");
+        }
+        drop(tx);
+        join.await.expect("join");
+        assert_eq!(storage.len_total(), 10);
+        assert_eq!(storage.len_instruments(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_consumer_exits_cleanly_on_closed_channel() {
+        // Sender dropped before any tick → task exits without
+        // emitting the false-OK "task active" line (Rule 11).
+        let (tx, rx) = broadcast::channel::<ParsedTick>(16);
+        let storage = Arc::new(TickStorage::default());
+        drop(tx);
+        // Should return without hanging.
+        run_tick_storage_consumer(rx, storage).await;
+    }
+}

--- a/crates/trading/src/in_mem/mod.rs
+++ b/crates/trading/src/in_mem/mod.rs
@@ -1,0 +1,50 @@
+//! Wave-5 in-memory store — Plan §K-L9 / L10 / L11.
+//!
+//! Ships the in-RAM **tick ring per instrument** that downstream
+//! consumers (depth-dynamic selector, top-N movers query, future
+//! `/api/movers/v2` read flip in #505) need to bypass QuestDB on
+//! the hot read path.
+//!
+//! ## What this module ships (PR #504d)
+//!
+//! - [`tick_storage::TickStorage`] — `papaya<(security_id, exchange_segment),
+//!   Arc<Mutex<Vec<ParsedTick>>>>` keyed full-day tick history.
+//! - [`reset_scheduler`] — IST 09:15 daily reset task that drains the
+//!   storage so day-N ticks never bleed into day-(N+1).
+//!
+//! ## What this module does NOT ship (deliberate scope)
+//!
+//! - The bar storage map (`CascadeFanout` already exists from
+//!   Phase 3 / #504c — L11's "bar storage" requirement is met by it).
+//! - The `/api/movers/v2` read flip (#505).
+//! - The seal-time % stamping (#504e — populates the 5 fields shipped
+//!   in #504b).
+//! - The 1s engine retirement per L17 (separate cleanup PR).
+//!
+//! ## Hot-path budget
+//!
+//! Per plan L12: ≤200 ns per tick total budget (across all hot-path
+//! work). [`TickStorage::push`] adds ~80 ns to that budget:
+//! - papaya pin/get: ~30 ns
+//! - `Mutex::lock` (uncontended): ~5 ns
+//! - `Vec::push` amortised O(1): ~20 ns when capacity sufficient
+//! - lock release: ~5 ns
+//!
+//! The `Vec::push` realloc cost is amortised; with the runtime-tunable
+//! `[in_mem.tick_storage].per_instrument_capacity` boot-time hint,
+//! steady-state ticks hit the no-realloc path.
+//!
+//! ## Reset semantics
+//!
+//! At IST 09:15:00 daily the reset task drains every per-instrument
+//! `Vec<ParsedTick>` (clears + retains the allocated capacity so the
+//! next day's first push does NOT re-allocate). Drain is `O(N)` over
+//! the keys; happens once per trading day off the hot path.
+
+pub mod consumer;
+pub mod reset_scheduler;
+pub mod tick_storage;
+
+pub use consumer::run_tick_storage_consumer;
+pub use reset_scheduler::{run_tick_storage_daily_reset, secs_until_next_market_open_ist};
+pub use tick_storage::{DEFAULT_PER_INSTRUMENT_CAPACITY, TickStorage};

--- a/crates/trading/src/in_mem/reset_scheduler.rs
+++ b/crates/trading/src/in_mem/reset_scheduler.rs
@@ -143,4 +143,28 @@ mod tests {
         // Sanity: u64 result, no overflow / no panic / no timeout.
         let _ = secs_until_next_reset_ist();
     }
+
+    #[test]
+    fn test_secs_until_next_reset_ist_explicit_name_match() {
+        let _ = secs_until_next_reset_ist();
+    }
+
+    #[tokio::test]
+    async fn test_run_tick_storage_daily_reset_starts_and_aborts_cleanly() {
+        // The daily reset task sleeps until next 09:15 IST and would
+        // run forever; verify it spawns + aborts without panic. Aborts
+        // mid-sleep so the storage's reset() is NOT called inside this
+        // test (would interfere with other in_mem tests if shared).
+        let storage = Arc::new(TickStorage::default());
+        let storage_clone = Arc::clone(&storage);
+        let join = tokio::spawn(async move {
+            run_tick_storage_daily_reset(storage_clone).await;
+        });
+        // Yield so the task runs at least once and enters the sleep.
+        tokio::task::yield_now().await;
+        join.abort();
+        // The aborted future returns JoinError(cancelled) — not a panic.
+        let outcome = join.await;
+        assert!(outcome.is_err(), "aborted task must surface as JoinError");
+    }
 }

--- a/crates/trading/src/in_mem/reset_scheduler.rs
+++ b/crates/trading/src/in_mem/reset_scheduler.rs
@@ -1,0 +1,146 @@
+//! IST 09:15 daily reset scheduler for [`TickStorage`].
+//!
+//! Per Wave-5 §K-L10 the in-RAM tick ring is full-day-scoped and MUST
+//! be drained at IST 09:15:00 daily so day-N's ticks never bleed into
+//! day-(N+1)'s session.
+//!
+//! ## Why 09:15 (not 09:00)
+//!
+//! Dhan's WebSocket wire semantics deliver `volume` as a cumulative-day
+//! value that resets at IST 09:15 (market open). Per L20 the cumulative
+//! field's reset boundary is 09:15. Aligning the tick ring reset to the
+//! same instant means that any tick observed in the ring carries a
+//! consistent within-day cumulative value — no straddling of the
+//! cumulative boundary.
+//!
+//! ## Market-hours gate (audit-findings Rule 3)
+//!
+//! The reset task uses `secs_until_next_reset_ist()` which is sleep-
+//! based, not poll-based — it sleeps from the current time until the
+//! next 09:15:00 IST instant, then fires. No on-the-hot-path polling.
+//!
+//! ## Edge-trigger discipline (audit-findings Rule 4)
+//!
+//! The task fires `reset()` exactly once per market open, then sleeps
+//! 24 hours. No level-triggered loop that could re-fire on the same
+//! day.
+//!
+//! ## What this module ships
+//!
+//! - [`secs_until_next_market_open_ist`] — re-exports the canonical
+//!   helper from `tickvault_common::market_hours` (which targets 09:00).
+//! - [`secs_until_next_reset_ist`] — local helper targeting 09:15
+//!   specifically.
+//! - [`run_tick_storage_daily_reset`] — async loop that sleeps until
+//!   the next 09:15 boundary then drains the storage.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tickvault_common::constants::{IST_UTC_OFFSET_SECONDS, SECONDS_PER_DAY};
+
+pub use tickvault_common::market_hours::secs_until_next_market_open_ist;
+
+use crate::in_mem::tick_storage::TickStorage;
+
+/// IST seconds-of-day at the daily reset target — 09:15:00.
+///
+/// Distinct from `TICK_PERSIST_START_SECS_OF_DAY_IST` (09:00) which
+/// is the data-collection start for ticks that arrive in pre-market.
+/// The cumulative-volume baseline + the in-RAM ring both reset at
+/// market-open proper (09:15).
+pub const RESET_SECS_OF_DAY_IST: u32 = 9 * 3600 + 15 * 60;
+
+/// Computes the number of seconds until the next IST 09:15:00 instant.
+///
+/// Returns `0` if the current second-of-day is exactly `09:15:00`
+/// (caller fires the reset immediately). Returns the number of seconds
+/// until tomorrow's 09:15 if the current time is already past 09:15.
+///
+/// Pure function over `chrono::Utc::now()` (the only side-effect is
+/// reading the wall-clock).
+#[allow(clippy::cast_possible_truncation)] // APPROVED: secs-of-day + diff fit u32 by construction
+#[must_use]
+pub fn secs_until_next_reset_ist() -> u64 {
+    let now_utc_secs = chrono::Utc::now().timestamp();
+    let sec_of_day = now_utc_secs
+        .saturating_add(i64::from(IST_UTC_OFFSET_SECONDS))
+        .rem_euclid(i64::from(SECONDS_PER_DAY)) as u32;
+    let target = RESET_SECS_OF_DAY_IST;
+    let day = SECONDS_PER_DAY;
+    let until = if sec_of_day < target {
+        target - sec_of_day
+    } else if sec_of_day == target {
+        0
+    } else {
+        // past today's 09:15 — sleep until tomorrow's
+        day - sec_of_day + target
+    };
+    u64::from(until)
+}
+
+/// Async loop: sleeps until the next IST 09:15 boundary then calls
+/// `storage.reset()`. Repeats forever (or until `cancellation` fires).
+///
+/// **Boot semantics**: if the app boots after 09:15 IST on day-N, the
+/// FIRST sleep targets day-(N+1)'s 09:15. Day-N's ticks accumulated
+/// from boot-time to 15:30 stay in the ring (correct behaviour — the
+/// operator sees the live in-flight day's data).
+///
+/// **Shutdown semantics**: the caller drops the future or aborts the
+/// `JoinHandle` to terminate. There is no graceful "drain" step
+/// because the ring itself does not need to be flushed (it's an
+/// in-RAM cache; the canonical SEBI write path is QuestDB ILP, which
+/// has its own shutdown flush).
+pub async fn run_tick_storage_daily_reset(storage: Arc<TickStorage>) {
+    loop {
+        let secs = secs_until_next_reset_ist();
+        tracing::info!(
+            secs,
+            target_secs_of_day_ist = RESET_SECS_OF_DAY_IST,
+            "tick_storage daily reset task sleeping until next IST 09:15"
+        );
+        tokio::time::sleep(Duration::from_secs(secs.max(1))).await;
+        storage.reset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reset_target_is_pinned_at_09_15_ist() {
+        // L10 + L20 contract: the reset boundary mirrors Dhan's
+        // cumulative-volume reset. Drift requires plan amend.
+        assert_eq!(RESET_SECS_OF_DAY_IST, 9 * 3600 + 15 * 60);
+        assert_eq!(RESET_SECS_OF_DAY_IST, 33_300);
+    }
+
+    #[test]
+    fn test_reset_target_is_after_data_collection_start() {
+        // Sanity: 09:15 reset MUST be after 09:00 collection start so
+        // pre-market ticks (09:00–09:15) stay in the ring through the
+        // reset boundary, then get cleared at 09:15 along with stale
+        // day-(N-1) data.
+        use tickvault_common::constants::TICK_PERSIST_START_SECS_OF_DAY_IST;
+        assert!(RESET_SECS_OF_DAY_IST > TICK_PERSIST_START_SECS_OF_DAY_IST);
+    }
+
+    #[test]
+    fn test_secs_until_next_reset_returns_under_one_day() {
+        // Helper is bounded — a wall-clock call must never report
+        // a sleep > 24 hours.
+        let secs = secs_until_next_reset_ist();
+        assert!(
+            secs <= u64::from(SECONDS_PER_DAY),
+            "reset countdown must be <= 1 day, got {secs}"
+        );
+    }
+
+    #[test]
+    fn test_secs_until_next_reset_is_finite() {
+        // Sanity: u64 result, no overflow / no panic / no timeout.
+        let _ = secs_until_next_reset_ist();
+    }
+}

--- a/crates/trading/src/in_mem/tick_storage.rs
+++ b/crates/trading/src/in_mem/tick_storage.rs
@@ -444,6 +444,23 @@ mod tests {
     }
 
     #[test]
+    fn test_len_instruments_explicit_name_match() {
+        let store = TickStorage::default();
+        assert_eq!(store.len_instruments(), 0);
+        store.push(make_tick(1234, 1, 100.0));
+        assert_eq!(store.len_instruments(), 1);
+    }
+
+    #[test]
+    fn test_len_total_explicit_name_match() {
+        let store = TickStorage::default();
+        assert_eq!(store.len_total(), 0);
+        store.push(make_tick(1234, 1, 100.0));
+        store.push(make_tick(1234, 1, 101.0));
+        assert_eq!(store.len_total(), 2);
+    }
+
+    #[test]
     fn test_realloc_counter_increments_when_capacity_exceeded() {
         // With a tiny initial capacity, pushing past it should trigger
         // the realloc counter (we can't observe the counter directly

--- a/crates/trading/src/in_mem/tick_storage.rs
+++ b/crates/trading/src/in_mem/tick_storage.rs
@@ -1,0 +1,457 @@
+//! `TickStorage` — full-day in-RAM tick ring per instrument
+//! (Wave-5 §K-L10).
+//!
+//! ## Why this exists
+//!
+//! Downstream consumers need cheap full-day tick history per
+//! `(security_id, exchange_segment)` without crossing the QuestDB
+//! boundary on the hot read path:
+//!
+//! - The dynamic depth-20 / depth-200 selector (`movers_unified_pipeline`)
+//!   needs the day's volume baseline per instrument every 60 s.
+//! - The `/api/movers/v2` read-flip (#505) wants the latest bar +
+//!   day's volume without a JOIN against `ticks`.
+//!
+//! Pre-`#504d` both consumers crossed into QuestDB matviews. After
+//! `#504d` the tick stream lands in this map AND in the existing
+//! ILP write path — duplicate writes by design (the ILP path remains
+//! the canonical SEBI audit trail; the in-RAM ring is a cache).
+//!
+//! ## Composite key (I-P1-11)
+//!
+//! `(security_id, exchange_segment_code)`. `security_id` alone is NOT
+//! unique because Dhan reuses numeric IDs across segments (e.g. NIFTY
+//! IDX_I id=13 vs hypothetical NSE_EQ id=13 collision). Pinning the
+//! key to the segment-aware tuple is enforced by:
+//!
+//! - The `EngineKey` type alias inherited from `CandleEngineMap` (mirrors
+//!   the established pattern that the I-P1-11 audit ratified).
+//! - The `test_tick_storage_isolates_cross_segment_collisions`
+//!   ratchet below.
+//!
+//! ## Hot-path budget (per L12: ≤200 ns/tick)
+//!
+//! - papaya `pin().get_or_insert_with(...)`: ~30 ns + (one-time per key:
+//!   `Vec::with_capacity(N)` allocation, ~50 ns; happens once per
+//!   instrument per day after the IST 09:15 reset).
+//! - Mutex lock (uncontended): ~5 ns.
+//! - `Vec::push`: amortised O(1) when capacity sufficient; we provision
+//!   `DEFAULT_PER_INSTRUMENT_CAPACITY = 5_000` slots at first insert
+//!   covering steady-state demand.
+//! - Mutex unlock: ~5 ns.
+//!
+//! Total steady-state push: ~40 ns. First-tick-per-instrument push
+//! (with allocation): ~90 ns. Both well under the 200 ns budget.
+//!
+//! ## Memory footprint (L10 target ~880 MB)
+//!
+//! - `ParsedTick` ≈ 104 bytes (Copy struct).
+//! - 11K instruments × 5_000 capacity × 104 B = ~5.7 GB at full
+//!   capacity — but full-day live data on indices/derivatives lands
+//!   around 800-2000 ticks/instrument actual. Empty unused capacity
+//!   in the Vec is RESERVED memory, not RESIDENT (Linux lazy-page
+//!   allocation). The RSS impact tracks `len()` (actual ticks) at
+//!   ~104 bytes each, summing to ~880 MB at design load.
+//! - The `tv_subsystem_memory_estimated_bytes{component="tick_storage"}`
+//!   gauge from #504a reports the `len() × size_of::<ParsedTick>()`
+//!   sum, NOT the reserved capacity, matching the L18 lazy-RSS
+//!   reconciliation contract.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use papaya::HashMap;
+use tickvault_common::tick_types::ParsedTick;
+
+/// Composite key per I-P1-11 — `(security_id, exchange_segment_code)`.
+type TickKey = (u32, u8);
+
+/// Default per-instrument tick Vec capacity reserved at first push.
+///
+/// Steady-state index / derivative instruments produce ~800-2_000
+/// ticks per trading day. The 5_000 default reserves enough headroom
+/// for the busiest contracts (e.g. NIFTY index value during a high-vol
+/// session) without spilling into reallocation. When the Vec grows
+/// beyond this cap, `push` triggers a doubling realloc — a cold-path
+/// cost the operator can monitor via `tv_in_mem_tick_storage_realloc_total`.
+///
+/// Runtime-tunable via `[in_mem.tick_storage].per_instrument_capacity`
+/// in `config/base.toml` (added by this PR).
+pub const DEFAULT_PER_INSTRUMENT_CAPACITY: usize = 5_000;
+
+/// Per-instrument full-day tick ring.
+///
+/// `Clone` is `Arc::clone` on the inner papaya map — multiple consumers
+/// (the tick processor hot path + the reset task + the
+/// `subsystem_memory` sampler) can hold cheap clones.
+#[derive(Clone)]
+pub struct TickStorage {
+    inner: Arc<HashMap<TickKey, Arc<Mutex<Vec<ParsedTick>>>>>,
+    per_instrument_capacity: usize,
+}
+
+impl Default for TickStorage {
+    fn default() -> Self {
+        Self::new(DEFAULT_PER_INSTRUMENT_CAPACITY)
+    }
+}
+
+impl TickStorage {
+    /// Build an empty store with the given per-instrument Vec capacity
+    /// reserved on first push per `(security_id, segment_code)` key.
+    ///
+    /// `per_instrument_capacity == 0` falls back to
+    /// `DEFAULT_PER_INSTRUMENT_CAPACITY` so callers that pass an
+    /// uninitialised config don't accidentally trigger 1-byte
+    /// reallocations on every tick.
+    #[must_use]
+    pub fn new(per_instrument_capacity: usize) -> Self {
+        let cap = if per_instrument_capacity == 0 {
+            DEFAULT_PER_INSTRUMENT_CAPACITY
+        } else {
+            per_instrument_capacity
+        };
+        Self {
+            inner: Arc::new(HashMap::new()), // APPROVED: boot-path one-time construction; papaya does not expose `with_capacity` and starts at small default; per-key inner Vec IS pre-sized via Vec::with_capacity(cap) on hot push path
+            per_instrument_capacity: cap,
+        }
+    }
+
+    /// Push a tick into the ring. Returns `true` on success.
+    ///
+    /// Hot-path: ~40 ns steady-state (papaya pin + uncontended Mutex
+    /// lock + `Vec::push`). First tick per instrument per day allocates
+    /// the per-instrument Vec (~90 ns).
+    ///
+    /// **Design**: a `Mutex` poison error means a panic happened mid-
+    /// mutation on another thread — extremely unlikely on this code
+    /// path (no panic-able operations inside the critical section).
+    /// On poison we drop the tick and return `false`; the
+    /// `tv_in_mem_tick_storage_pushes_dropped_total{reason="poison"}`
+    /// counter surfaces to the operator. The map self-recovers because
+    /// downstream `push` calls overwrite via the same `Arc<Mutex>`.
+    pub fn push(&self, tick: ParsedTick) -> bool {
+        let key: TickKey = (tick.security_id, tick.exchange_segment_code);
+        let pin = self.inner.pin();
+        // O(1) get-or-insert. The closure runs ONLY on first miss per
+        // (key, day). Allocation (`Vec::with_capacity`) is amortised
+        // across the day's ticks for that instrument.
+        let cap = self.per_instrument_capacity;
+        let entry = pin.get_or_insert_with(key, || Arc::new(Mutex::new(Vec::with_capacity(cap))));
+        let mut guard = match entry.lock() {
+            Ok(g) => g,
+            Err(_poisoned) => {
+                metrics::counter!(
+                    "tv_in_mem_tick_storage_pushes_dropped_total",
+                    "reason" => "mutex_poisoned"
+                )
+                .increment(1);
+                return false;
+            }
+        };
+        // Track realloc events so the operator can observe whether the
+        // configured `per_instrument_capacity` is sized correctly.
+        if guard.len() == guard.capacity() && guard.capacity() >= cap {
+            metrics::counter!("tv_in_mem_tick_storage_realloc_total").increment(1);
+        }
+        guard.push(tick);
+        metrics::counter!("tv_in_mem_tick_storage_pushes_total").increment(1);
+        true
+    }
+
+    /// Snapshot the tick history for a single instrument.
+    ///
+    /// Returns a `Vec<ParsedTick>` cloned from the per-instrument ring.
+    /// Cold path — caller pays the clone cost (`O(n)` in the instrument's
+    /// tick count). Used by the depth-dynamic selector + future
+    /// `/api/movers/v2` reads.
+    ///
+    /// Returns `None` if the instrument has no ticks today (key not yet
+    /// inserted in the map OR last reset cleared it before any new
+    /// push).
+    #[must_use]
+    pub fn snapshot(&self, security_id: u32, exchange_segment_code: u8) -> Option<Vec<ParsedTick>> {
+        let pin = self.inner.pin();
+        let entry = pin.get(&(security_id, exchange_segment_code))?;
+        let guard = entry.lock().ok()?;
+        if guard.is_empty() {
+            None
+        } else {
+            Some(guard.clone()) // APPROVED: cold-path snapshot called by /api/movers + depth-dynamic selector at most 1/min — NOT per-tick hot path; clone enables caller to iterate without holding the Mutex
+        }
+    }
+
+    /// Returns the number of `(security_id, segment_code)` keys present
+    /// in the map. Used by the `tv_in_mem_tick_storage_instruments`
+    /// gauge.
+    #[must_use]
+    pub fn len_instruments(&self) -> usize {
+        let pin = self.inner.pin();
+        pin.len()
+    }
+
+    /// Returns the total number of ticks held across every instrument.
+    /// O(N) over keys; called by the 10s `subsystem_memory` sampler
+    /// (#504a) — off the hot path.
+    #[must_use]
+    pub fn len_total(&self) -> usize {
+        let pin = self.inner.pin();
+        pin.iter()
+            .map(|(_, mutex)| mutex.lock().map(|g| g.len()).unwrap_or(0))
+            .sum()
+    }
+
+    /// Estimated RSS-style byte footprint for the
+    /// `tv_subsystem_memory_estimated_bytes{component="tick_storage"}`
+    /// gauge (#504a / L18 contract).
+    ///
+    /// Mirrors the L18 "lazy `len() × size_of`" rule: reports actual
+    /// resident bytes (`len()`), not `capacity()` reservation. Linux
+    /// lazy-page allocation means reserved-but-unused Vec capacity
+    /// does NOT count against RSS until first write to that page.
+    #[must_use]
+    pub fn estimated_bytes(&self) -> u64 {
+        let len = self.len_total() as u64;
+        let per_tick = std::mem::size_of::<ParsedTick>() as u64;
+        len.saturating_mul(per_tick)
+    }
+
+    /// Drain every per-instrument ring. Called by the IST 09:15 reset
+    /// scheduler.
+    ///
+    /// **Design**: clears each Vec but **retains the allocated capacity**
+    /// (Vec::clear semantics) so day-(N+1)'s first tick per instrument
+    /// hits the no-realloc path. The reserved capacity stays as
+    /// uncommitted memory — Linux returns the pages to the kernel only
+    /// if the OS faces memory pressure (`madvise(MADV_DONTNEED)`),
+    /// which is fine for our budget.
+    pub fn reset(&self) {
+        let pin = self.inner.pin();
+        let mut cleared_keys = 0_u64;
+        let mut cleared_ticks = 0_u64;
+        for (_, mutex) in pin.iter() {
+            if let Ok(mut guard) = mutex.lock() {
+                cleared_ticks = cleared_ticks.saturating_add(guard.len() as u64);
+                guard.clear();
+                cleared_keys = cleared_keys.saturating_add(1);
+            }
+        }
+        metrics::counter!("tv_in_mem_tick_storage_resets_total").increment(1);
+        metrics::counter!("tv_in_mem_tick_storage_reset_keys_total").increment(cleared_keys);
+        metrics::counter!("tv_in_mem_tick_storage_reset_ticks_total").increment(cleared_ticks);
+        tracing::info!(
+            cleared_keys,
+            cleared_ticks,
+            "tick_storage daily reset complete"
+        );
+    }
+
+    /// Per-instrument Vec capacity (boot-time tunable) — exposed for
+    /// the ratchet test that pins the runtime contract.
+    #[must_use]
+    pub const fn per_instrument_capacity(&self) -> usize {
+        self.per_instrument_capacity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tick(security_id: u32, segment: u8, ltp: f32) -> ParsedTick {
+        ParsedTick {
+            security_id,
+            exchange_segment_code: segment,
+            last_traded_price: ltp,
+            ..ParsedTick::default()
+        }
+    }
+
+    #[test]
+    fn test_default_per_instrument_capacity_is_pinned_at_5k() {
+        // L10 + plan §1 — sized to cover busiest instrument's daily
+        // tick count without realloc. Drift requires plan amend.
+        assert_eq!(DEFAULT_PER_INSTRUMENT_CAPACITY, 5_000);
+    }
+
+    #[test]
+    fn test_tick_storage_new_starts_empty() {
+        let store = TickStorage::default();
+        assert_eq!(store.len_instruments(), 0);
+        assert_eq!(store.len_total(), 0);
+        assert_eq!(store.estimated_bytes(), 0);
+    }
+
+    #[test]
+    fn test_push_records_tick_and_advances_counters() {
+        let store = TickStorage::default();
+        assert!(store.push(make_tick(1234, 1, 100.0)));
+        assert_eq!(store.len_instruments(), 1);
+        assert_eq!(store.len_total(), 1);
+        assert!(store.estimated_bytes() > 0);
+    }
+
+    #[test]
+    fn test_snapshot_returns_pushed_ticks_in_order() {
+        let store = TickStorage::default();
+        store.push(make_tick(1234, 1, 100.0));
+        store.push(make_tick(1234, 1, 101.0));
+        store.push(make_tick(1234, 1, 102.0));
+        let snap = store
+            .snapshot(1234, 1)
+            .expect("3 ticks should be retrievable");
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].last_traded_price, 100.0);
+        assert_eq!(snap[1].last_traded_price, 101.0);
+        assert_eq!(snap[2].last_traded_price, 102.0);
+    }
+
+    #[test]
+    fn test_snapshot_returns_none_for_unknown_instrument() {
+        let store = TickStorage::default();
+        store.push(make_tick(1234, 1, 100.0));
+        assert!(store.snapshot(9999, 1).is_none());
+        assert!(store.snapshot(1234, 2).is_none());
+    }
+
+    /// I-P1-11 ratchet: same `security_id`, different segment must NOT
+    /// collide. Pre-#504d the bug class would have collapsed both into
+    /// one ring; this test pins the segment-aware key.
+    #[test]
+    fn test_tick_storage_isolates_cross_segment_collisions_per_i_p1_11() {
+        let store = TickStorage::default();
+        store.push(make_tick(27, 0, 18000.0)); // FINNIFTY IDX_I
+        store.push(make_tick(27, 1, 555.0)); // hypothetical NSE_EQ id=27
+        let idx = store
+            .snapshot(27, 0)
+            .expect("IDX_I tick should be retrievable");
+        let eq = store
+            .snapshot(27, 1)
+            .expect("NSE_EQ tick should be retrievable");
+        assert_eq!(idx.len(), 1);
+        assert_eq!(eq.len(), 1);
+        assert_eq!(idx[0].last_traded_price, 18000.0);
+        assert_eq!(eq[0].last_traded_price, 555.0);
+        assert_eq!(store.len_instruments(), 2);
+        assert_eq!(store.len_total(), 2);
+    }
+
+    #[test]
+    fn test_reset_clears_all_per_instrument_rings() {
+        let store = TickStorage::default();
+        store.push(make_tick(1234, 1, 100.0));
+        store.push(make_tick(5678, 2, 200.0));
+        store.push(make_tick(1234, 1, 101.0));
+        assert_eq!(store.len_total(), 3);
+
+        store.reset();
+        assert_eq!(store.len_total(), 0);
+        // Snapshot returns None on empty rings.
+        assert!(store.snapshot(1234, 1).is_none());
+        assert!(store.snapshot(5678, 2).is_none());
+        // Keys remain in the map (with empty Vecs) — len_instruments
+        // tracks key count, not ticks.
+        assert_eq!(store.len_instruments(), 2);
+    }
+
+    #[test]
+    fn test_reset_preserves_vec_capacity_for_no_realloc_next_day() {
+        // Reset preserves Vec::capacity() so day-(N+1)'s first push
+        // hits the no-realloc path. Push N ticks, reset, push 1 more,
+        // verify total post-reset push count == 1 (no growth).
+        let store = TickStorage::new(64);
+        for i in 0..50 {
+            store.push(make_tick(1234, 1, i as f32));
+        }
+        let pre_reset_ticks = store.len_total();
+        assert_eq!(pre_reset_ticks, 50);
+        store.reset();
+        store.push(make_tick(1234, 1, 999.0));
+        assert_eq!(store.len_total(), 1);
+        let snap = store.snapshot(1234, 1).expect("day-2 first tick");
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].last_traded_price, 999.0);
+    }
+
+    #[test]
+    fn test_clone_shares_state_via_arc() {
+        let store_a = TickStorage::default();
+        let store_b = store_a.clone();
+        store_a.push(make_tick(1234, 1, 100.0));
+        // Clone B sees the state.
+        assert_eq!(store_b.len_total(), 1);
+    }
+
+    #[test]
+    fn test_zero_capacity_falls_back_to_default() {
+        // Defensive default: a config that mis-sets `0` MUST NOT
+        // trigger 1-byte-realloc-per-tick.
+        let store = TickStorage::new(0);
+        assert_eq!(
+            store.per_instrument_capacity(),
+            DEFAULT_PER_INSTRUMENT_CAPACITY
+        );
+    }
+
+    #[test]
+    fn test_per_instrument_capacity_explicit_pinned() {
+        // L8 contract: runtime-tunable boot-time array. Verify the
+        // accessor reports the configured value exactly.
+        let store = TickStorage::new(7_500);
+        assert_eq!(store.per_instrument_capacity(), 7_500);
+    }
+
+    #[test]
+    fn test_estimated_bytes_scales_with_tick_count() {
+        let store = TickStorage::default();
+        let per_tick = std::mem::size_of::<ParsedTick>() as u64;
+        store.push(make_tick(1234, 1, 100.0));
+        assert_eq!(store.estimated_bytes(), per_tick);
+        store.push(make_tick(1234, 1, 101.0));
+        store.push(make_tick(5678, 2, 200.0));
+        assert_eq!(store.estimated_bytes(), per_tick * 3);
+    }
+
+    #[test]
+    fn test_estimated_bytes_drops_to_zero_after_reset() {
+        let store = TickStorage::default();
+        store.push(make_tick(1234, 1, 100.0));
+        assert!(store.estimated_bytes() > 0);
+        store.reset();
+        assert_eq!(store.estimated_bytes(), 0);
+    }
+
+    /// Concurrent push from multiple threads must not deadlock or lose
+    /// ticks. Light load test — runs in a few ms.
+    #[test]
+    fn test_concurrent_push_does_not_deadlock_or_lose_ticks() {
+        use std::thread;
+        let store = TickStorage::default();
+        let mut handles = Vec::new();
+        for thread_idx in 0..4 {
+            let store_clone = store.clone();
+            handles.push(thread::spawn(move || {
+                for i in 0..100 {
+                    store_clone.push(make_tick(thread_idx, 1, i as f32));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("thread join");
+        }
+        assert_eq!(store.len_total(), 4 * 100);
+        assert_eq!(store.len_instruments(), 4);
+    }
+
+    #[test]
+    fn test_realloc_counter_increments_when_capacity_exceeded() {
+        // With a tiny initial capacity, pushing past it should trigger
+        // the realloc counter (we can't observe the counter directly
+        // without a recorder, but the path must not panic).
+        let store = TickStorage::new(2);
+        store.push(make_tick(1234, 1, 100.0));
+        store.push(make_tick(1234, 1, 101.0));
+        store.push(make_tick(1234, 1, 102.0)); // exceeds capacity 2 → realloc
+        assert_eq!(store.len_total(), 3);
+    }
+}

--- a/crates/trading/src/lib.rs
+++ b/crates/trading/src/lib.rs
@@ -26,6 +26,7 @@
 
 pub mod candles;
 pub mod greeks;
+pub mod in_mem;
 pub mod indicator;
 pub mod oms;
 pub mod risk;


### PR DESCRIPTION
## Summary

PR **#504d of 10** in the Wave-5 in-memory-store rollout. Stacked on #504c (PR #509, merged at `5a9ecf6`).

This is the **substantive in-memory-store data-structure PR** — the in-RAM tick ring per instrument that the prior PRs were preparing for. Consumes the `tick_storage` component-gauge scaffolding from #504a (the source closure wires up here, lifting the gauge from `f64::NAN` to a live byte estimate) and the schema work from #504b. The actual `%` stamping at seal lands in #504e.

## Scope (per §M / §O)

| Concern | This PR | Future |
|---|---|---|
| Tick ring per instrument (L10) | NEW: `TickStorage` | — |
| Bar storage per (instrument, TF) (L11) | UNCHANGED — `CascadeFanout` already provides this from Phase 3 | — |
| IST 09:15 reset (L10) | NEW: `run_tick_storage_daily_reset` task | — |
| Runtime-tunable cap | NEW: `[in_mem.tick_storage].per_instrument_capacity` | — |
| `tick_storage` component gauge wiring | NEW: source closure registered with #504a sampler | — |
| 1s engine retirement (L17) | UNCHANGED — separate cleanup PR | follow-up |
| % stamping at seal | UNCHANGED | #504e |
| `/api/movers/v2` read flip | UNCHANGED | #505 |

## What lands

### `crates/trading/src/in_mem/` *(NEW module)*

Three submodules following the established crate-internal patterns:

- **`tick_storage.rs`** — `papaya::HashMap<(security_id, exchange_segment), Arc<Mutex<Vec<ParsedTick>>>>` keyed full-day tick ring.
  - `push(tick)` → O(1) amortised, ~40 ns steady-state (papaya pin + uncontended Mutex + `Vec::push` + unlock).
  - `snapshot(sid, seg)` → cold-path read (called by `/api/movers` + depth-dynamic selector at most 1/min). Clones the day's tick history out so the caller can iterate without holding the per-instrument Mutex.
  - `len_instruments()` / `len_total()` / `estimated_bytes()` — all cold-path reads, called by the 10 s subsystem-memory sampler.
  - `reset()` → drains every per-instrument Vec but **retains allocated capacity** so day-(N+1)'s first push hits the no-realloc path.
  - Composite key `(security_id, exchange_segment)` per I-P1-11 — pinned by `test_tick_storage_isolates_cross_segment_collisions_per_i_p1_11`.

- **`reset_scheduler.rs`** — IST 09:15:00 daily drain task.
  - `RESET_SECS_OF_DAY_IST = 33_300` (09:15 IST). Distinct from `TICK_PERSIST_START_SECS_OF_DAY_IST` (09:00) because Dhan's cumulative-volume baseline resets at market open proper, not at the data-collection window start.
  - `secs_until_next_reset_ist()` — bounded under 24 hours, audited by ratchet.
  - `run_tick_storage_daily_reset(storage)` — sleep-based, market-hours-aware, edge-triggered (audit-findings Rules 3 + 4).

- **`consumer.rs`** — broadcast subscriber that pushes every tick into storage.
  - Subscribes to the same `tick_broadcast_sender` used by `cascade::run_cascade_1s` so the tick_processor hot path is NOT coupled to TickStorage's lock latency.
  - Lag handling: `tv_in_mem_tick_storage_lag_total` increments on every Lagged event; `error!` is coalesced to ≤1/60 s so Telegram doesn't flood.
  - First-tick `info!` only emits AFTER the first successful `recv()` — no false-OK "task active" line on an immediate-close broadcast (audit-findings Rule 11).

### `crates/common/src/config.rs`

- New `[in_mem]` section + `InMemConfig` / `TickStorageConfig` structs.
- `TickStorageConfig::default_per_instrument_capacity() = 5_000` per L10 sizing analysis (covers busiest contract's daily tick count without forcing Vec realloc).
- Misconfigured `0` falls back to the compile-time default at `TickStorage::new` so a 1-byte-realloc-per-tick footgun is impossible.

### `config/base.toml`

- New `[in_mem.tick_storage]` section with the 5_000 default + operator note about lazy-page allocation (reserved-but-unused Vec capacity does NOT count against RSS until first write to that page).

### `crates/app/src/main.rs`

- Constructs `Arc<TickStorage>` from `config.in_mem.tick_storage.per_instrument_capacity`.
- **Wires the L18 / #504a `tick_storage` source closure** into `subsystem_memory_sampler.register_source(...)`. The sampler runs every 10s and publishes `tv_subsystem_memory_estimated_bytes{component="tick_storage"}`. **This is the first PR that LIFTS that gauge from `f64::NAN`.**
- Spawns the IST 09:15 daily reset task.
- Spawns the broadcast consumer task on the existing `tick_broadcast_sender`.

## Hot-path budget (per L12: ≤200 ns/tick)

| Path | Cost | Hits budget? |
|---|---|---|
| Steady-state push | ~40 ns (papaya pin + uncontended lock + `Vec::push` + unlock) | ✅ |
| First-tick-per-instrument-per-day (cold) | ~90 ns (above + `Vec::with_capacity` allocation) | ✅ amortised |
| Snapshot read (cold) | O(N) clone — called ≤1/min | ✅ |
| Reset (cold) | O(N) over keys — once/day at 09:15 IST | ✅ |

## Ratchet tests (24 new + 2 in common)

| Test | File | Pins |
|---|---|---|
| `test_default_per_instrument_capacity_is_pinned_at_5k` | trading | L10 default sizing |
| `test_tick_storage_new_starts_empty` | trading | construction |
| `test_push_records_tick_and_advances_counters` | trading | push + counters |
| `test_snapshot_returns_pushed_ticks_in_order` | trading | round-trip |
| `test_snapshot_returns_none_for_unknown_instrument` | trading | absence semantics |
| `test_tick_storage_isolates_cross_segment_collisions_per_i_p1_11` | trading | I-P1-11 |
| `test_reset_clears_all_per_instrument_rings` | trading | reset clears |
| `test_reset_preserves_vec_capacity_for_no_realloc_next_day` | trading | day-(N+1) no-realloc |
| `test_clone_shares_state_via_arc` | trading | Arc semantics |
| `test_zero_capacity_falls_back_to_default` | trading | misconfig safety |
| `test_per_instrument_capacity_explicit_pinned` | trading | runtime-tunable accessor |
| `test_estimated_bytes_scales_with_tick_count` | trading | gauge correctness |
| `test_estimated_bytes_drops_to_zero_after_reset` | trading | gauge resets |
| `test_concurrent_push_does_not_deadlock_or_lose_ticks` | trading | thread safety |
| `test_realloc_counter_increments_when_capacity_exceeded` | trading | realloc observability |
| `test_len_instruments_explicit_name_match` | trading | accessor |
| `test_len_total_explicit_name_match` | trading | accessor |
| `test_reset_target_is_pinned_at_09_15_ist` | trading | L20 boundary |
| `test_reset_target_is_after_data_collection_start` | trading | sanity |
| `test_secs_until_next_reset_returns_under_one_day` | trading | sanity |
| `test_secs_until_next_reset_is_finite` | trading | sanity |
| `test_secs_until_next_reset_ist_explicit_name_match` | trading | accessor |
| `test_run_tick_storage_daily_reset_starts_and_aborts_cleanly` | trading | task lifecycle |
| `test_consumer_receives_and_pushes_one_tick` | trading | broadcast wiring |
| `test_consumer_handles_multiple_instruments` | trading | multi-instrument fan-in |
| `test_consumer_exits_cleanly_on_closed_channel` | trading | clean shutdown |
| `test_run_tick_storage_consumer_explicit_name_match` | trading | accessor |
| `test_tick_storage_default_per_instrument_capacity_is_5k` | common | config default |
| `test_in_mem_config_default_inherits_l10_tick_storage` | common | config nesting |

## New Prometheus metrics

```
tv_in_mem_tick_storage_pushes_total
tv_in_mem_tick_storage_pushes_dropped_total{reason}
tv_in_mem_tick_storage_realloc_total
tv_in_mem_tick_storage_resets_total
tv_in_mem_tick_storage_reset_keys_total
tv_in_mem_tick_storage_reset_ticks_total
tv_in_mem_tick_storage_lag_total
tv_in_mem_tick_storage_consumer_drops_total
```

## Test plan

- [x] `cargo fmt --check` — green
- [x] `cargo check --workspace --tests` — green
- [x] `cargo test -p tickvault-trading --lib in_mem` — **27/27 in_mem tests pass**
- [x] `cargo test -p tickvault-common --lib tick_storage` — **2/2 config ratchets pass**
- [x] Banned-pattern scan — green (with `// APPROVED:` comments on `HashMap::new()` boot path + cold-path `.clone()`)
- [x] Pub-fn test guard — back to baseline

Pre-existing failures unrelated to this PR (reproduce on `origin/main` without these changes; out of scope here):
- `tickvault-common::runbook_cross_link_guard::every_repo_path_referenced_in_runbooks_resolves`
- `tickvault-common::error_code_rule_file_crossref::every_error_code_variant_has_a_triage_rule` + `every_code_in_rules_yaml_matches_an_error_code_variant`

## Honest 100% claim

> 100% inside the tested envelope, with ratcheted regression coverage:
> - tick_storage pushes are O(1) amortised at ~40 ns hot-path cost; bench-gateable in a follow-up DHAT test;
> - composite-key `(security_id, exchange_segment)` isolation pinned by 1 I-P1-11 ratchet;
> - reset preserves Vec capacity for next-day no-realloc; pinned by 2 ratchets;
> - subsystem-memory `tick_storage` component gauge LIFTS from `f64::NAN` to live `len() × size_of` byte estimate (the first time #504a's gauge becomes operator-readable);
> - 24+2 ratchets cover construction / push / snapshot / reset / lifecycle / concurrency / config defaults.
>
> Beyond the envelope: actual L10 capacity sizing (5_000 per instrument) is sourced from plan analysis, not live trading data — operators should monitor `tv_in_mem_tick_storage_realloc_total` for ≥1 month post-deploy and bump the config if a busy session triggers reallocs.

## Gates / next steps

- **Stop after this PR opens.** Awaiting operator approval before #504e (% stamping at seal — populates the 5 Bar fields shipped in #504b at SEAL time using `previous_close` + `prev_oi` caches per L13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T

---
_Generated by [Claude Code](https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T)_