### PR TITLE
fix(app): subsystem_memory test asserts 21 TFs after PR #517 reduced to 9

### DIFF
--- a/crates/app/src/subsystem_memory.rs
+++ b/crates/app/src/subsystem_memory.rs
@@ -449,12 +449,22 @@ mod tests {
     // ownership / type shape, not the wire-level emit.
 
     #[test]
-    fn handles_register_initializes_all_21_tf_eviction_counters() {
+    fn handles_register_initializes_all_9_tf_eviction_counters() {
+        // PR #517 (Wave-5 TF reduction, 2026-05-08) reduced the
+        // operator-facing TF set from 21 → 9. The assertion mirrors
+        // `Tf::ALL.len()` so any future symmetric resize (per
+        // `tf_symmetry_guard`) doesn't silently drift.
         let h = SubsystemMemoryHandles::register();
         assert_eq!(
             h.eviction_counters.len(),
-            21,
+            Tf::ALL.len(),
             "BUG-L13: every TF must be pre-warmed at boot"
+        );
+        assert_eq!(
+            Tf::ALL.len(),
+            9,
+            "PR #517 pinned the operator-facing TF count at 9; \
+             a drift here is a `tf_symmetry_guard` regression."
         );
         for tf in Tf::ALL {
             assert!(


### PR DESCRIPTION
## Summary

Hotfix for a test that PR #517 (Wave-5 TF reduction 21→9) missed
updating. The test
`subsystem_memory::tests::handles_register_initializes_all_21_tf_eviction_counters`
asserts the eviction-counter map has exactly 21 entries, but PR #517
shrank `Tf::ALL` from 21 → 9. Result: `cargo test -p tickvault-app
--lib` fails on `main` with `assertion `left == right` failed:
BUG-L13: every TF must be pre-warmed at boot — left: 9, right: 21`.

Surfaced as a CI failure on PR #518 (plan-doc-only) at job
`Test (app)`.

## Fix

Two-line update plus a defensive cross-check pinned against
`tf_symmetry_guard`:

- Test renamed: `_all_21_tf_eviction_counters` →
  `_all_9_tf_eviction_counters`.
- Assertion now uses `Tf::ALL.len()` so the same test self-corrects
  on any future symmetric resize. A second `assert_eq!(Tf::ALL.len(),
  9, ...)` pins the magic number locally so a future change can't
  silently drift.

## Test plan

- [x] `cargo fmt -p tickvault-app` clean
- [x] `cargo test -p tickvault-app --lib subsystem_memory` — 23/23
      pass (was 22/23 with this test failing)
- [x] `cargo test -p tickvault-app --lib` — 578/578 pass
- [ ] CI green on this PR

## Why this didn't ship in PR #517

PR #517 used the symmetry ratchet `tf_symmetry_guard` to catch the
4 main TF surfaces (config, metrics_catalog, cascade_fanout, VIEW_DEFS),
but `subsystem_memory.rs` consumes `Tf::ALL` indirectly via the
eviction-counter map and was outside the ratchet's scan. This hotfix
hardens the test against that miss without expanding the ratchet
itself (the `Tf::ALL.len()` assertion makes the test self-correcting).

## References

- PR #517 — TF reduction 21→9 (commit `60d3194`)
- Wave-5 §K-L6/L7/L8 — `.claude/plans/active-plan-in-memory-store-aws-instance.md`
- `tf_symmetry_guard` — `crates/common/tests/tf_symmetry_guard.rs`

https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T

---
_Generated by [Claude Code](https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T)_