### PR TITLE
feat(trading): F1 cascade seal-site swap to _with_pct (Wave-5 #504e follow-up)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2748,11 +2748,21 @@ async fn main() -> Result<()> {
         let supervisor_sender = tick_broadcast_sender.clone();
         let supervisor_map = std::sync::Arc::clone(&candle_engine_map_1s);
         let supervisor_fanout = cascade_fanout.clone();
+        // F1 (Wave-5 §K-L13 / #504e follow-up): wire the existing
+        // `prev_day_cache` (constructed at line ~663) into the
+        // cascade so every sealed Bar carries the 5 frozen-per-day
+        // % fields. The cache is empty at boot today (F2 will add
+        // the boot-time loader); the `on_*_with_pct` div-by-zero
+        // policy means an empty cache produces 0.0 % fields without
+        // dropping any seal — so wiring this in advance is benign
+        // until F2 lands.
+        let supervisor_pct_cache = std::sync::Arc::clone(&prev_day_cache);
         tokio::spawn(async move {
             tickvault_trading::candles::spawn_supervised_cascade_1s(
                 supervisor_sender,
                 supervisor_map,
                 Some(supervisor_fanout),
+                Some(supervisor_pct_cache),
             )
             .await;
         });

--- a/crates/trading/src/candles/cascade.rs
+++ b/crates/trading/src/candles/cascade.rs
@@ -48,6 +48,7 @@ use tickvault_common::tick_types::ParsedTick;
 use crate::candles::cascade_fanout::CascadeFanout;
 use crate::candles::engine::Tf1s;
 use crate::candles::engine_map::CandleEngineMap;
+use crate::in_mem::PrevDayCache;
 
 /// Prometheus counter — every tick the cascade processed.
 pub const METRIC_TICKS_PROCESSED: &str = "tv_candle_cascade_ticks_processed_total";
@@ -101,6 +102,16 @@ const ROLLOVER_POST_SEAL_DELAY_SECS: u64 = 1;
 /// constant per sealed bar (~1.7µs), and runs in this same task so
 /// the per-instrument ordering of derived bars is preserved.
 ///
+/// **F1 (Wave-5 §K-L13 / #504e follow-up):** when `pct_cache` is
+/// `Some`, the seal-time pct stamping path is enabled. The 1s engine
+/// uses `on_tick_with_pct` (instead of `on_tick`) and the fanout uses
+/// `feed_sealed_1s_bar_with_pct` (instead of `feed_sealed_1s_bar`),
+/// so every sealed Bar carries the 5 frozen-per-day % fields populated
+/// from the cache. The cache may be empty at boot — in that case the
+/// stamping falls back to 0.0 % fields without dropping any seal,
+/// matching the `on_*_with_pct` div-by-zero policy. The boot-time
+/// loader that populates the cache lands in F2.
+///
 /// This function is `async fn -> ()` and returns when the broadcast
 /// sender is dropped. The caller is expected to spawn it via
 /// `spawn_supervised_cascade_1s` so panics are surfaced + respawned.
@@ -108,6 +119,7 @@ pub async fn run_cascade_1s(
     mut rx: broadcast::Receiver<ParsedTick>,
     engine_map: Arc<CandleEngineMap<Tf1s>>,
     fanout: Option<CascadeFanout>,
+    pct_cache: Option<Arc<PrevDayCache>>,
 ) {
     let mut first_tick_seen = false;
     let mut last_lag_log: Option<Instant> = None;
@@ -118,16 +130,27 @@ pub async fn run_cascade_1s(
                     first_tick_seen = true;
                     info!(
                         engine_count = engine_map.len(),
+                        pct_cache_wired = pct_cache.is_some(),
                         "candle cascade 1s task active — first tick observed"
                     );
                 }
                 counter!(METRIC_TICKS_PROCESSED).increment(1);
-                if let Some(bar) = engine_map.on_tick(&tick) {
+                let sealed_bar = match &pct_cache {
+                    Some(cache) => engine_map.on_tick_with_pct(&tick, cache),
+                    None => engine_map.on_tick(&tick),
+                };
+                if let Some(bar) = sealed_bar {
                     counter!(METRIC_BARS_SEALED).increment(1);
                     // Phase 3 commit 4: feed the sealed 1s bar into all
                     // 28 derived engines via the fanout. O(28) constant.
+                    // F1: when `pct_cache` is wired, use the stamping
+                    // variant so every derived engine's sealed bar
+                    // carries the 5 % fields populated from the cache.
                     if let Some(ref f) = fanout {
-                        f.feed_sealed_1s_bar(&bar);
+                        match &pct_cache {
+                            Some(cache) => f.feed_sealed_1s_bar_with_pct(&bar, cache),
+                            None => f.feed_sealed_1s_bar(&bar),
+                        }
                     }
                     // Hot-path review M1 fix: gate the format expansion
                     // entirely behind the level check so peak-load
@@ -183,6 +206,7 @@ pub async fn spawn_supervised_cascade_1s(
     sender: broadcast::Sender<ParsedTick>,
     engine_map: Arc<CandleEngineMap<Tf1s>>,
     fanout: Option<CascadeFanout>,
+    pct_cache: Option<Arc<PrevDayCache>>,
 ) {
     loop {
         let rx = sender.subscribe();
@@ -192,7 +216,11 @@ pub async fn spawn_supervised_cascade_1s(
         // per-tick hot path. This is NOT the cascade hot loop.
         // O(1) EXEMPT: supervisor respawn, not per-tick hot path.
         let fanout_clone = fanout.clone();
-        let join = tokio::spawn(async move { run_cascade_1s(rx, map, fanout_clone).await });
+        let pct_cache_clone = pct_cache.as_ref().map(Arc::clone);
+        let join =
+            tokio::spawn(
+                async move { run_cascade_1s(rx, map, fanout_clone, pct_cache_clone).await },
+            );
         match join.await {
             Ok(()) => {
                 // Clean exit ⇒ broadcast sender was dropped. Stop
@@ -295,7 +323,7 @@ mod tests {
         let engine_map: Arc<CandleEngineMap<Tf1s>> = Arc::new(CandleEngineMap::new());
         let map_clone = Arc::clone(&engine_map);
 
-        let handle = tokio::spawn(run_cascade_1s(rx, map_clone, None));
+        let handle = tokio::spawn(run_cascade_1s(rx, map_clone, None, None));
 
         // Two ticks in the same 1s bucket → engine accumulates, no seal.
         tx.send(make_tick(1000, 1, 100, 100.0)).expect("send 1");
@@ -316,7 +344,7 @@ mod tests {
         let (tx, rx) = broadcast::channel::<ParsedTick>(16);
         let engine_map: Arc<CandleEngineMap<Tf1s>> = Arc::new(CandleEngineMap::new());
         let map_clone = Arc::clone(&engine_map);
-        let handle = tokio::spawn(run_cascade_1s(rx, map_clone, None));
+        let handle = tokio::spawn(run_cascade_1s(rx, map_clone, None, None));
 
         tx.send(make_tick(2000, 1, 200, 50.0)).expect("send a");
         tx.send(make_tick(2000, 1, 201, 51.0))
@@ -335,7 +363,7 @@ mod tests {
     async fn run_cascade_1s_exits_when_broadcast_closes() {
         let (tx, rx) = broadcast::channel::<ParsedTick>(4);
         let engine_map: Arc<CandleEngineMap<Tf1s>> = Arc::new(CandleEngineMap::new());
-        let handle = tokio::spawn(run_cascade_1s(rx, engine_map, None));
+        let handle = tokio::spawn(run_cascade_1s(rx, engine_map, None, None));
         drop(tx); // Close immediately — cascade should exit.
         handle.await.expect("cascade exits");
     }
@@ -346,7 +374,7 @@ mod tests {
         let (tx, rx) = broadcast::channel::<ParsedTick>(2);
         let engine_map: Arc<CandleEngineMap<Tf1s>> = Arc::new(CandleEngineMap::new());
         let map_clone = Arc::clone(&engine_map);
-        let handle = tokio::spawn(run_cascade_1s(rx, map_clone, None));
+        let handle = tokio::spawn(run_cascade_1s(rx, map_clone, None, None));
 
         // Producer floods 100 ticks before consumer wakes — older ticks
         // are dropped, consumer sees Lagged then resumes from latest.
@@ -438,13 +466,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_cascade_1s_uses_with_pct_path_when_cache_wired() {
+        // F1 ratchet: with `pct_cache = Some(...)` the cascade
+        // exercises the `_with_pct` engine variants. The cache is
+        // empty here, so the stamped fields fall back to 0.0 — the
+        // important assertion is that the seal STILL happens (the
+        // `on_tick_with_pct` short-circuit returns `None` only when
+        // the underlying `on_tick` returns `None`, never because of
+        // a cache miss). Regression block for any future change that
+        // accidentally drops the seal on cache miss.
+        let (tx, rx) = broadcast::channel::<ParsedTick>(16);
+        let engine_map: Arc<CandleEngineMap<Tf1s>> = Arc::new(CandleEngineMap::new());
+        let fanout = CascadeFanout::new();
+        let pct_cache = Arc::new(PrevDayCache::new());
+        let map_clone = Arc::clone(&engine_map);
+        let fanout_clone = fanout.clone();
+        let cache_clone = Arc::clone(&pct_cache);
+        let handle = tokio::spawn(run_cascade_1s(
+            rx,
+            map_clone,
+            Some(fanout_clone),
+            Some(cache_clone),
+        ));
+
+        // Two ticks crossing a 1s bucket → 1s engine seals → fanout
+        // feeds derived engines via `_with_pct` path.
+        tx.send(make_tick(8000, 1, 4_000, 100.0)).expect("send 1");
+        tx.send(make_tick(8000, 1, 4_001, 101.0))
+            .expect("send 2 crosses bucket");
+        drop(tx);
+        handle.await.expect("cascade exits");
+
+        // 1s engine has post-seal latest at the new bucket.
+        let latest_1s = engine_map.latest(8000, 1).expect("post-seal latest");
+        assert_eq!(latest_1s.bucket_start_ist_secs, 4_001);
+
+        // Derived engine 1m must have observed the sealed 1s bar via
+        // the `_with_pct` path (cache empty → unstamped, but seal
+        // still propagates).
+        assert!(
+            fanout.tf1m.latest(8000, 1).is_some(),
+            "tf1m must observe seal even when pct_cache is empty"
+        );
+    }
+
+    #[tokio::test]
     async fn run_cascade_1s_no_started_log_when_broadcast_closes_immediately() {
         // False-OK guard: the "task active" log must NOT fire if the
         // broadcast is closed before any tick arrives. This is a
         // behavioural assertion — task exits cleanly with no panic.
         let (tx, rx) = broadcast::channel::<ParsedTick>(4);
         let engine_map: Arc<CandleEngineMap<Tf1s>> = Arc::new(CandleEngineMap::new());
-        let handle = tokio::spawn(run_cascade_1s(rx, engine_map, None));
+        let handle = tokio::spawn(run_cascade_1s(rx, engine_map, None, None));
         drop(tx);
         handle
             .await

--- a/crates/trading/src/candles/cascade_fanout.rs
+++ b/crates/trading/src/candles/cascade_fanout.rs
@@ -20,6 +20,7 @@ use metrics::counter;
 
 use crate::candles::engine::{Bar, Tf1d, Tf1h, Tf1mo, Tf1w, Tf2h, Tf3h, Tf4h, Tf5m, Tf15m, Tf30m};
 use crate::candles::engine_map::CandleEngineMap;
+use crate::in_mem::PrevDayCache;
 
 /// Prometheus counter — every sealed 1s bar that the fanout processed.
 pub const METRIC_FANOUT_BARS_PROCESSED: &str = "tv_candle_cascade_fanout_bars_processed_total";
@@ -125,6 +126,62 @@ impl CascadeFanout {
             derived_seals += 1;
         }
         if self.tf1mo.on_sealed_bar(bar).is_some() {
+            derived_seals += 1;
+        }
+        if derived_seals > 0 {
+            counter!(METRIC_FANOUT_DERIVED_SEALS).increment(derived_seals);
+        }
+    }
+
+    /// F1 (Wave-5 §K-L13 / #504e follow-up): pct-stamping variant of
+    /// [`feed_sealed_1s_bar`].
+    ///
+    /// Calls [`CandleEngineMap::on_sealed_bar_with_pct`] on every derived
+    /// engine so any sealed Bar that pops out of the derived seal chain
+    /// carries the 5 frozen-per-day % fields populated from `pct_cache`.
+    /// Falls back to unstamped bars (with 0.0 % fields) when the cache
+    /// has no entry for the instrument — see `on_sealed_bar_with_pct`
+    /// for the div-by-zero policy.
+    ///
+    /// Hot-path budget: the `pct_cache` lookup runs at most once per
+    /// derived engine per sealed source bar. Per-tick budget unchanged
+    /// — this method runs on the seal path, not the per-tick path.
+    /// Counter semantics are identical to [`feed_sealed_1s_bar`].
+    #[inline]
+    pub fn feed_sealed_1s_bar_with_pct(&self, bar: &Bar, pct_cache: &PrevDayCache) {
+        counter!(METRIC_FANOUT_BARS_PROCESSED).increment(1);
+        let mut derived_seals = 0_u64;
+        if self.tf1m.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf5m.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf15m.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf30m.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf1h.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf2h.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf3h.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf4h.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf1d.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf1w.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
+            derived_seals += 1;
+        }
+        if self.tf1mo.on_sealed_bar_with_pct(bar, pct_cache).is_some() {
             derived_seals += 1;
         }
         if derived_seals > 0 {
@@ -286,6 +343,63 @@ mod tests {
         for (name, latest) in assertions {
             assert!(latest.is_some(), "{name} did not receive the sealed 1s bar");
         }
+    }
+
+    #[test]
+    fn feed_sealed_1s_bar_with_pct_propagates_to_every_derived_engine() {
+        // F1 ratchet: the pct-stamping fanout method MUST reach every
+        // derived engine, just like its non-stamping sibling. Mirrors
+        // `feed_sealed_1s_bar_propagates_to_every_derived_engine` so a
+        // future regression dropping a `tf_*.on_sealed_bar_with_pct(...)`
+        // call from the body fails the build.
+        let fanout = CascadeFanout::new();
+        let cache = PrevDayCache::new();
+        let bar = make_sealed_1s_bar(4321, 1, 2_000);
+        fanout.feed_sealed_1s_bar_with_pct(&bar, &cache);
+        let assertions: [(&str, Option<Bar>); DERIVED_ENGINE_COUNT] = [
+            ("tf1m", fanout.tf1m.latest(4321, 1)),
+            ("tf5m", fanout.tf5m.latest(4321, 1)),
+            ("tf15m", fanout.tf15m.latest(4321, 1)),
+            ("tf30m", fanout.tf30m.latest(4321, 1)),
+            ("tf1h", fanout.tf1h.latest(4321, 1)),
+            ("tf2h", fanout.tf2h.latest(4321, 1)),
+            ("tf3h", fanout.tf3h.latest(4321, 1)),
+            ("tf4h", fanout.tf4h.latest(4321, 1)),
+            ("tf1d", fanout.tf1d.latest(4321, 1)),
+            ("tf1w", fanout.tf1w.latest(4321, 1)),
+            ("tf1mo", fanout.tf1mo.latest(4321, 1)),
+        ];
+        for (name, latest) in assertions {
+            assert!(
+                latest.is_some(),
+                "{name} did not receive the pct-stamped sealed 1s bar"
+            );
+        }
+    }
+
+    #[test]
+    fn feed_sealed_1s_bar_with_pct_falls_back_when_cache_empty() {
+        // F1 ratchet: when the prev-day cache has no entry for the
+        // instrument, the fanout MUST still propagate the unstamped bar
+        // (returning 0.0 for the % fields per the
+        // `on_sealed_bar_with_pct` div-by-zero policy) rather than
+        // dropping the seal.
+        let fanout = CascadeFanout::new();
+        let cache = PrevDayCache::new();
+        let bar = make_sealed_1s_bar(7777, 1, 3_000);
+        fanout.feed_sealed_1s_bar_with_pct(&bar, &cache);
+        assert!(
+            fanout.tf1m.latest(7777, 1).is_some(),
+            "tf1m must observe the seal even on cache miss"
+        );
+    }
+
+    #[test]
+    fn feed_sealed_1s_bar_with_pct_explicit_name_match() {
+        let fanout = CascadeFanout::new();
+        let cache = PrevDayCache::new();
+        let bar = make_sealed_1s_bar(1, 1, 1);
+        fanout.feed_sealed_1s_bar_with_pct(&bar, &cache);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

F1 from the active plan §O remaining-work table — wires the
`_with_pct` engine variants into the live cascade so every sealed Bar
that pops out of the cascade carries the 5 frozen-per-day % fields
populated from `PrevDayCache`.

PR #511 (#504e primitives) shipped:
- `CandleEngineMap::on_tick_with_pct(tick, pct_cache)`
- `CandleEngineMap::on_sealed_bar_with_pct(bar, pct_cache)`
- `PrevDayCache` data structure

…but left the live wiring on the non-stamping path. F1 connects the
two so the next two follow-ups (F2 boot loader populates the cache,
F3 `/api/movers/v2` reads stamped bars) have a working seal-time
stamping pipeline to read from.

## What changed

| File | Change |
|---|---|
| `crates/trading/src/candles/cascade_fanout.rs` | New method `feed_sealed_1s_bar_with_pct(bar, pct_cache)` calls `on_sealed_bar_with_pct` on all 11 derived engines + 3 ratchet tests |
| `crates/trading/src/candles/cascade.rs` | `run_cascade_1s` + `spawn_supervised_cascade_1s` accept new `Option<Arc<PrevDayCache>>` parameter; when `Some`, use `on_tick_with_pct` + `feed_sealed_1s_bar_with_pct`; when `None`, fall back to existing variants (back-compat for tests). New tokio test `run_cascade_1s_uses_with_pct_path_when_cache_wired` |
| `crates/app/src/main.rs` | Pass `Some(prev_day_cache)` to `spawn_supervised_cascade_1s`. The `prev_day_cache` Arc is the existing one constructed at line ~663 |

## Why this is benign today (cache empty)

`PrevDayCache::new()` returns an empty cache. The `on_*_with_pct`
div-by-zero policy returns 0.0 % fields on cache miss without
dropping any seal — see `engine_map.rs:140-193` docstrings. So
behaviour today (no stamping yet) is byte-equal to the pre-F1
behaviour. Once F2 ships the boot-time loader, the same wire-up
starts producing stamped bars without any further code change in
the cascade path.

## Hot-path impact

Zero on the per-tick path. The `pct_cache` lookup runs only on the
SEAL path (1 lookup per timeframe boundary, not per tick) — already
documented in `engine_map.rs::on_*_with_pct` docstrings. Per-tick
budget unchanged.

## Tests

| Test | Pass? |
|---|---|
| `cascade_fanout_with_pct_propagates_to_every_derived_engine` (NEW) | ✅ |
| `feed_sealed_1s_bar_with_pct_falls_back_when_cache_empty` (NEW) | ✅ |
| `feed_sealed_1s_bar_with_pct_explicit_name_match` (NEW) | ✅ |
| `run_cascade_1s_uses_with_pct_path_when_cache_wired` (NEW) | ✅ |
| `cargo test -p tickvault-trading --lib` | 1392/1392 ✅ |
| `cargo test -p tickvault-app --lib` | 578/578 ✅ |
| `cargo test -p tickvault-trading --lib candles::cascade_fanout` | 23/23 ✅ |
| `cargo test -p tickvault-trading --lib candles::cascade::` | 15/15 ✅ |
| `cargo fmt --check` | clean |
| Banned-pattern scanner | clean |

## What this PR does NOT ship (F2 + F3)

| # | Logical | Why deferred |
|---|---|---|
| F2 | `PrevDayCache` boot loader | populates the cache from `previous_close` table at boot — separate concern, separate PR |
| F3 | `/api/movers/v2` handler refactor + `CascadeFanout::snapshot_m()` accessor | reads stamped bars; needs F2 first to see non-zero % fields |

## References

- Plan §O — `.claude/plans/active-plan-in-memory-store-aws-instance.md`
- Wave-5 §K-L13 (#504e) — seal-time pct stamping
- PR #511 (#504e primitives) — `on_tick_with_pct`, `on_sealed_bar_with_pct`, `PrevDayCache`
- `crates/trading/src/candles/pct_stamping.rs` — `stamp_bar_pct_fields` div-by-zero policy

https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T

---
_Generated by [Claude Code](https://claude.ai/code/session_015bbbv2R2FN3nn9hRNea38T)_