### PR TITLE
feat(notification): instant dispatch for per-WS connect milestones

### DIFF
--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -2700,10 +2700,23 @@ impl NotificationEvent {
     /// the full rationale (operator complaint 2026-05-09).
     pub fn dispatch_policy(&self) -> DispatchPolicy {
         match self {
+            // Boot-success milestones — operator's at-a-glance "is the
+            // boot OK?" Telegram pings. PR #526 added the first 4
+            // (Auth/Instruments/PoolOnline/Phase2Complete). PR #6
+            // (2026-05-09 operator request) added the 3 per-WS connect
+            // events so depth-20 / depth-200 / order-update successful
+            // handshakes ship as instant green ✅ pings instead of
+            // coalescing for 60s. Rationale: the Saturday mock-session
+            // boot showed `WebSocketConnected x5` arriving 60s after
+            // `TickVault is live` — operator needs each WS surface to
+            // confirm in real time, not as a delayed batch.
             Self::AuthenticationSuccess
             | Self::InstrumentBuildSuccess { .. }
             | Self::WebSocketPoolOnline { .. }
-            | Self::Phase2Complete { .. } => DispatchPolicy::Immediate,
+            | Self::Phase2Complete { .. }
+            | Self::DepthTwentyConnected { .. }
+            | Self::DepthTwoHundredConnected { .. }
+            | Self::OrderUpdateConnected => DispatchPolicy::Immediate,
             _ => DispatchPolicy::Default,
         }
     }
@@ -4168,6 +4181,46 @@ mod tests {
             assert!(
                 event.severity().tag().contains("[LOW]"),
                 "tag drift detected"
+            );
+        }
+    }
+
+    /// 2026-05-09 PR 6 ratchet (operator request): every per-WS connect
+    /// event MUST render green ✅ [LOW] AND ship immediately. Pre-this-PR
+    /// these events used `DispatchPolicy::Default` → 60s coalesce, so the
+    /// operator's Saturday boot showed `WebSocketConnected x5` arriving
+    /// 60s after `TickVault is live`. Each WS surface now confirms in
+    /// real time. Blocks regression to the coalesced-by-default pattern.
+    #[test]
+    fn test_per_ws_connect_events_are_immediate_low() {
+        let events = [
+            NotificationEvent::DepthTwentyConnected {
+                underlying: "NIFTY".to_string(),
+            },
+            NotificationEvent::DepthTwoHundredConnected {
+                contract: "NIFTY-Jun2026-25000-CE".to_string(),
+                security_id: 12345,
+            },
+            NotificationEvent::OrderUpdateConnected,
+        ];
+        for event in events {
+            assert_eq!(
+                event.dispatch_policy(),
+                DispatchPolicy::Immediate,
+                "{} must request immediate dispatch (operator request 2026-05-09 — \
+                 per-WS connect should not coalesce 60s alongside the boot summary)",
+                event.topic()
+            );
+            assert_eq!(
+                event.severity(),
+                Severity::Low,
+                "{} must render green ✅ [LOW] (success ping)",
+                event.topic()
+            );
+            assert!(
+                event.severity().tag().contains("[LOW]"),
+                "tag drift detected for {}",
+                event.topic()
             );
         }
     }


### PR DESCRIPTION
## Summary

Operator request 2026-05-09 (post PR #526):

> "see clearly when entire instruments fetched within a millisecond or microsecond the telegram notification should come meanwhile same for jwt and even for websocket all connections of live feed depth 20 and depth 200 and live order update okay? only when it is successful it should be triggered instantly"

PR #526 introduced `DispatchPolicy::Immediate` for 4 boot-success events (Auth/Instruments/PoolOnline/Phase2Complete). Per-WS connect events still used the default policy → 60s coalesce delay. This PR closes the gap.

## Changes

| Event | Pre-PR | Post-PR |
|---|---|---|
| `DepthTwentyConnected` | Low + Default → coalesced 60s | Low + **Immediate** ✅ |
| `DepthTwoHundredConnected` | Low + Default → coalesced 60s | Low + **Immediate** ✅ |
| `OrderUpdateConnected` | Low + Default → coalesced 60s | Low + **Immediate** ✅ |

Severity stays `Low` so messages render `✅ [LOW]` (green) — color remains decoupled from routing per the PR #526 charter.

## Ratchet

`test_per_ws_connect_events_are_immediate_low` (NEW) — pins all 3 per-WS connect events to `Severity::Low + DispatchPolicy::Immediate`. Blocks regression to coalesced-by-default.

## Test plan

- [x] `cargo test -p tickvault-core --lib notification::` (281/281 ok including new ratchet)
- [x] `cargo fmt --check`
- [x] `bash .claude/hooks/banned-pattern-scanner.sh`
- [ ] **Operator manual** on next boot: confirm each WS surface fires its own green ✅ [LOW] Telegram immediately on handshake, no 60s coalesce delay.

## Follow-up (queued)

Add aggregate `DepthTwentyPoolOnline` / `DepthTwoHundredPoolOnline` / `OrderUpdatePoolOnline` events so the operator gets a single consolidated "all 4 WS surfaces online" Telegram (today only main feed has the `WebSocketPoolOnline` aggregate). Larger scope — separate PR.

## Honest 100% claim

100% inside the tested envelope, with ratcheted regression coverage. The 7 boot-milestone events (4 from PR #526 + 3 from this PR) all render green ✅ AND ship immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP

---
_Generated by [Claude Code](https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP)_