### PR TITLE
feat(api): expose prev-day + seal-time pct fields on MoversV2Bar (PR 5b1.5)

### DIFF
--- a/crates/api/src/handlers/movers_v2.rs
+++ b/crates/api/src/handlers/movers_v2.rs
@@ -174,6 +174,18 @@ pub struct MoversV2Bar {
     pub oi: i64,
     pub tick_count: u32,
     pub sealed: bool,
+    /// 2026-05-09 PR 5b1.5 — prev-day reference + seal-time pct
+    /// stamping (added in PR #520 F1). Frontend dashboards expect
+    /// `change_pct` as a single derived field; exposing both
+    /// `prev_day_close` and the pre-computed `close_pct_from_prev_day`
+    /// lets clients render the column without a second QuestDB hop
+    /// for `previous_close` rows. Equivalent fields exist on the
+    /// underlying `Bar`; this is pure additive plumbing.
+    pub prev_day_close: f64,
+    pub prev_day_oi: i64,
+    pub close_pct_from_prev_day: f64,
+    pub oi_pct_from_prev_day: f64,
+    pub volume_pct_from_prev_day: f64,
 }
 
 impl From<&tickvault_trading::candles::Bar> for MoversV2Bar {
@@ -191,6 +203,11 @@ impl From<&tickvault_trading::candles::Bar> for MoversV2Bar {
             oi: bar.oi,
             tick_count: bar.tick_count,
             sealed: bar.sealed,
+            prev_day_close: bar.prev_day_close,
+            prev_day_oi: bar.prev_day_oi,
+            close_pct_from_prev_day: bar.close_pct_from_prev_day,
+            oi_pct_from_prev_day: bar.oi_pct_from_prev_day,
+            volume_pct_from_prev_day: bar.volume_pct_from_prev_day,
         }
     }
 }
@@ -478,6 +495,29 @@ mod tests {
         assert_eq!(v2.volume, bar.volume);
         assert_eq!(v2.tick_count, bar.tick_count);
         assert_eq!(v2.sealed, bar.sealed);
+    }
+
+    /// 2026-05-09 PR 5b1.5 ratchet — prev-day reference + seal-time
+    /// pct fields MUST propagate from `Bar` to `MoversV2Bar`. PR 5b2
+    /// (frontend migration) needs `change_pct` to render the
+    /// gainers/losers % column without a second QuestDB hop for
+    /// `previous_close` rows. The pct fields are computed at
+    /// seal-time by `seal_with_pct` (PR #520 F1) so the API response
+    /// can hand them off untouched.
+    #[test]
+    fn movers_v2_bar_propagates_prev_day_and_pct_fields() {
+        let mut bar = make_sealed_1s_bar(13, 0, 1_000);
+        bar.prev_day_close = 95.0;
+        bar.prev_day_oi = 150;
+        bar.close_pct_from_prev_day = 5.79;
+        bar.oi_pct_from_prev_day = 33.33;
+        bar.volume_pct_from_prev_day = 12.5;
+        let v2 = MoversV2Bar::from(&bar);
+        assert!((v2.prev_day_close - 95.0).abs() < f64::EPSILON);
+        assert_eq!(v2.prev_day_oi, 150);
+        assert!((v2.close_pct_from_prev_day - 5.79).abs() < f64::EPSILON);
+        assert!((v2.oi_pct_from_prev_day - 33.33).abs() < f64::EPSILON);
+        assert!((v2.volume_pct_from_prev_day - 12.5).abs() < f64::EPSILON);
     }
 
     /// 2026-05-09 PR 5b1 ratchet — identity fields MUST propagate


### PR DESCRIPTION
## Summary

PR 5b1.5 — continuation of the 5b unblocking sequence (PR #531 added identity fields). This adds the prev-day reference + seal-time pct fields needed by the static dashboards to render the `change_pct` / `oi_change_pct` / `volume_change_pct` columns:

- `prev_day_close: f64`
- `prev_day_oi: i64`
- `close_pct_from_prev_day: f64`
- `oi_pct_from_prev_day: f64`
- `volume_pct_from_prev_day: f64`

All five already exist on `tickvault_trading::candles::Bar` (seal-time stamped by PR #520 F1, Wave-5 §K-L13). This PR is pure additive plumbing through `MoversV2Bar`.

## Why both prev-day reference + pre-computed pct

- Pre-computed pct lets the frontend render the column without re-deriving the calculation (avoids client-side div-by-zero on `prev_day_close == 0`).
- `prev_day_close` + `prev_day_oi` are still useful for per-row tooltips so the operator can sanity-check the calculation.

## Risk

LOW. Pure additive change on a dormant endpoint (`config.api.movers_v2_enabled` defaults to false). No public fields removed or renamed.

## Ratchet

`movers_v2_bar_propagates_prev_day_and_pct_fields` (NEW) — constructs a `Bar` with non-zero pct/prev-day values and asserts they round-trip into `MoversV2Bar`.

## Test plan

- [x] `cargo test -p tickvault-api --lib handlers::movers_v2::` (34/34 ok; was 33)
- [x] `cargo test -p tickvault-api --lib` (346/346 ok)
- [x] `cargo fmt --check`
- [x] `bash .claude/hooks/banned-pattern-scanner.sh`

## Honest 100% claim

100% inside the tested envelope. `MoversV2Bar` now carries every field the legacy `/api/market/stock-movers` response needed (identity + OHLCV + prev-day reference + computed pct). PR 5b2 (frontend migration + `movers_questdb.rs` deletion) is now unblocked for a future operator-present session — no further backend additive work is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP

---
_Generated by [Claude Code](https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP)_