### PR TITLE
feat(app): cohort-source counter for RAM vs SQL telemetry (PR 5c.2.5)

### DIFF
--- a/crates/app/src/depth_dynamic_pipeline_v2.rs
+++ b/crates/app/src/depth_dynamic_pipeline_v2.rs
@@ -331,8 +331,27 @@ pub fn spawn_depth_dynamic_pool(
                             );
                             cohort_failing = false;
                         }
+                        // 2026-05-09 PR 5c.2.5 — observability: emit a
+                        // counter labelled by source so the operator
+                        // can verify in Grafana that RAM is producing
+                        // healthy cohorts (vs falling through to SQL).
+                        // Once `ram_total >> sql_total` over a soak
+                        // window, PR 5c.3 can safely delete the SQL
+                        // fallback + writer infrastructure.
+                        metrics::counter!(
+                            "tv_depth_dynamic_cohort_source_total",
+                            "label" => cfg.label,
+                            "source" => "ram",
+                        )
+                        .increment(1);
                         rows
                     } else {
+                    metrics::counter!(
+                        "tv_depth_dynamic_cohort_source_total",
+                        "label" => cfg.label,
+                        "source" => "sql",
+                    )
+                    .increment(1);
                     match fetch_cohort_from_questdb(&cfg).await {
                         Ok(c) => {
                             if cohort_failing {


### PR DESCRIPTION
## Summary

Adds the observability metric required to safely retire the SQL fallback in PR 5c.3:

```
tv_depth_dynamic_cohort_source_total{label, source}
```

- `label` — `"depth-20-dynamic"` or `"depth-200-dynamic"`
- `source` — `"ram"` (RAM cohort fetcher returned non-empty) or `"sql"` (RAM was None/empty; legacy SQL path ran)

## Why this slice ships before PR 5c.3

PR 5c.2 wired `fetch_cohort_from_ram` ahead of the SQL fallback, but there's no quantitative way to confirm the RAM path actually serves production traffic vs silently falling through to SQL on every cycle. Without a counter, "RAM works in market hours" was aspirational. With this counter, the operator can:

1. Boot the app on a market-hours session.
2. Watch the ratio in Grafana / `mcp__tickvault-logs__prometheus_query`.
3. After ~30 min of in-market traffic, confirm `ram_total / (ram_total + sql_total) ≥ 0.95` for both labels.
4. Only then green-light PR 5c.3 (SQL fallback removal + `movers_writer` deletion).

If the ratio is < 0.95, the operator KNOWS RAM has a gap (cascade not primed in time, instrument-type filter mismatch, registry race) and PR 5c.3 is paused for diagnosis.

## Risk

LOW. Two `metrics::counter!` increments on a 60s cold path — zero impact on hot path or correctness.

## Operator manual

`mcp__tickvault-logs__prometheus_query "tv_depth_dynamic_cohort_source_total"` → confirm `source="ram"` grows, `source="sql"` flat.

## Test plan

- [x] `cargo check -p tickvault-app` clean
- [x] `cargo test -p tickvault-app --lib depth_dynamic_pipeline_v2::` (36/36 ok)
- [x] `cargo fmt --check`
- [x] `bash .claude/hooks/banned-pattern-scanner.sh`

## Honest 100% claim

100% inside the tested envelope. Counter is purely additive; existing wire-up unchanged. Once the operator captures one market-hours soak's ratio, PR 5c.3 has a clear go/no-go signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP

---
_Generated by [Claude Code](https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP)_