### PR TITLE
docs(plan,bridge): cancel active-plan.md item 8 — superseded by Rust depth-200

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Wave-1-3 Live Hotfixes (4 bugs caught at 12:49 IST 2026-04-28)
 
-**Status:** PARTIALLY-VERIFIED (items 1-5, 6, 7, 9, 10 shipped; item 8 Docker/Grafana deferred to follow-up commit)
+**Status:** VERIFIED (items 1-7, 9, 10 shipped; item 8 CANCELLED 2026-05-09 — superseded by Rust depth-200 path after Dhan ticket #5610706)
 **Date:** 2026-04-28
 **Approved by:** Parthiban (operator) — verbatim "fix everything"
 **Branch:** `claude/verify-waves-status-HQP6A`
@@ -58,13 +58,19 @@
   - Tests: test_counters_increment_on_frame_parse
   - Tests: test_state_version_gauge_tracks_reloads
 
-- [ ] **8. Docker compose service + Grafana panel + Prometheus alert rule for the bridge**
-  - Files: deploy/docker/docker-compose.yml
-  - Files: deploy/docker/prometheus/alerts.yml
-  - Files: deploy/docker/prometheus/prometheus.yml
-  - Files: deploy/docker/grafana/dashboards/depth-200-bridge.json
-  - Tests: test_alerts_yml_contains_depth_200_bridge_rules
-  - Tests: test_prometheus_yml_scrapes_depth_200_bridge
+- [x] **8. Docker compose service + Grafana panel + Prometheus alert rule for the bridge — CANCELLED 2026-05-09**
+  - Status: SUPERSEDED. Per Dhan ticket #5610706 (2026-05-02) the SELF-only
+    token gate that caused TCP resets on concurrent depth-200 subscribes was
+    removed. The Rust depth-200 client now streams cleanly using the shared
+    TOTP/APP token; boot-time verification via the `DEPTH200-SMOKE-01`
+    ratchet (`crates/app/src/boot_smoke_test.rs`) confirms frame arrival
+    within 60 s and alerts if it ever regresses.
+  - The Python sidecar (`scripts/depth_200_bridge.py`) is retained as a
+    manual-only fallback. Header in `scripts/depth_200_bridge_README.md`
+    flags it as legacy / not-wired. No Docker / Prometheus / Grafana
+    wiring will be added.
+  - Operator approval: 2026-05-09 — "go ahead with our rust approach
+    itself as dhan stated as of now since the jwt will work".
 
 - [x] **9. Disk-full pre-flight check before tick spill writes** (closes single highest-risk hole in zero-loss chain)
   - Files: crates/storage/src/tick_persistence.rs

--- a/scripts/depth_200_bridge_README.md
+++ b/scripts/depth_200_bridge_README.md
@@ -1,4 +1,27 @@
-# Depth-200 Python Sidecar Bridge
+# Depth-200 Python Sidecar Bridge — LEGACY / MANUAL FALLBACK ONLY
+
+> **Status (2026-05-09): SUPERSEDED by the Rust depth-200 client.**
+>
+> Per Dhan ticket #5610706 (resolved 2026-05-02), the SELF-only token
+> gate that previously caused TCP resets when ≥4 ATM contracts
+> subscribed concurrently has been removed server-side. The Rust
+> client (`crates/core/src/websocket/depth_connection.rs`) now reuses
+> the shared TOTP/APP token and streams depth-200 cleanly. Boot-time
+> verification: `DEPTH200-SMOKE-01` ratchet
+> (`crates/app/src/boot_smoke_test.rs`) confirms frame arrival within
+> 60 s; alert fires if it ever regresses.
+>
+> **This Python sidecar is retained as a manual-only fallback** for
+> the case where Dhan re-introduces a server-side regression and the
+> Rust client cannot recover within an operator-acceptable window.
+> It is **not** wired into `docker-compose.yml`, **not** scraped by
+> Prometheus, and **not** monitored by Grafana. Active-plan.md item 8
+> (Docker + Grafana + alert wiring) is therefore CANCELLED.
+>
+> **Do not run this bridge alongside the Rust client during normal
+> operation** — both writers target `deep_market_depth` and although
+> DEDUP keys handle overlap, running two sources doubles ILP load and
+> complicates SEBI audit reconstruction.
 
 Production fallback for 200-level depth streaming when the Rust client
 hits Dhan-side resets (chronic on expiry-day with ≥4 ATM contracts


### PR DESCRIPTION
## Summary

Cancels active-plan.md item 8 (Docker compose service + Grafana panel + Prometheus alert rule for the depth-200 Python sidecar bridge). The Rust depth-200 client is the canonical path going forward.

## Why

Per Dhan ticket #5610706 (resolved 2026-05-02), the SELF-only token gate that previously caused TCP resets on concurrent depth-200 subscribes has been **removed server-side**. The Rust depth-200 client (`crates/core/src/websocket/depth_connection.rs`) now streams cleanly using the shared TOTP/APP token. Boot-time verification via the `DEPTH200-SMOKE-01` ratchet (`crates/app/src/boot_smoke_test.rs`) confirms frame arrival within 60 s and alerts if it ever regresses.

The Python sidecar — built in PR #340 et al. as a fallback for the Dhan-side reset storm — is no longer needed for routine operation.

## Changes

**`.claude/plans/active-plan.md`:**
- Plan-level Status: `PARTIALLY-VERIFIED` → `VERIFIED`
- Item 8 marked `CANCELLED` with rationale + Dhan ticket reference + operator approval

**`scripts/depth_200_bridge_README.md`:**
- Header banner flags the bridge as `LEGACY / MANUAL FALLBACK ONLY`
- Documents do-not-run scenarios (alongside Rust client, double ILP load, SEBI audit complexity)
- Cross-references the Rust client + DEPTH200-SMOKE-01 ratchet

## Retained (NOT deleted)

- `scripts/depth_200_bridge.py` — Python sidecar source
- `scripts/test_depth_200_bridge.py` — 19 unit tests
- `scripts/depth_200_bridge_requirements.txt` — pinned deps

These stay on disk for the manual-fallback case where Dhan re-introduces a server-side regression and the Rust client cannot recover within an operator-acceptable window.

## Operator approval

2026-05-09: "go ahead with our rust approach itself as dhan stated as of now since the jwt will work"

## Test plan

- [ ] CI green (no Rust touched — should be a fast doc-only check)

https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP

---
_Generated by [Claude Code](https://claude.ai/code/session_011mrKPgsgtTuw3JfNyR9PPP)_