### PR TITLE
refactor(core): promote 6 candle_fetcher primitives to pub(crate) (PR-D1)

### DIFF
--- a/.claude/plans/active-plan-item-8-9-gap-fill.md
+++ b/.claude/plans/active-plan-item-8-9-gap-fill.md
@@ -251,7 +251,86 @@ focused session.
 - ✅ Plan-file PR-B abort logged with reference to Rule 14
 - ❌ No production code changes — docs only
 
-## PR-C Status — QUEUED for fresh session
+## PR-C Status (2026-05-17) — MERGED (#671)
+
+PR-C shipped the vertical-slice broadcast plumbing: `DisconnectResolvedEvent`
+type + `WebSocketConnection::with_disconnect_event_sender()` builder + canonical
+post-reconnect send-site + `run_gap_fill_scheduler` task with planner + 3 Prom
+counters + boot wiring in `main.rs`. 3-agent review NO CRITICAL/NO HIGH. 11
+tests pass.
+
+## PR-D1 Status (2026-05-17) — THIS PR (visibility promotion)
+
+Minimal visibility-promotion PR to unblock PR-D2 (the actual REST fetch + UPSERT).
+Promotes 6 private items in `candle_fetcher.rs` to `pub(crate)` so PR-D2's
+per-bar fetch helper can reuse the existing retry/backoff/error-classification
+logic without duplicating it.
+
+Items promoted:
+
+| Item | From | To | Why PR-D2 needs it |
+|---|---|---|---|
+| `ErrorAction` enum | private | `pub(crate)` | Classify Dhan error response for retry decisions |
+| `classify_error()` | private | `pub(crate)` | Run the classification logic |
+| `compute_dh904_backoff_secs()` | private | `pub(crate)` | DH-904 ladder: 10s, 20s, 40s, 80s |
+| `is_dh904_exhausted()` | private | `pub(crate)` | Decide when to give up |
+| `compute_retry_delay_ms()` | private | `pub(crate)` | 5xx linear backoff |
+| `IntradayRequest` struct | private | `pub(crate)` | Construct Dhan REST request body |
+
+Plus: every field of `IntradayRequest` is now `pub` (was implicit `private`)
+so the scheduler module can construct it.
+
+ZERO behavioural change — only visibility keywords. 220 existing
+`candle_fetcher` tests pass without modification. No new pub fns (Rule 14
+compliant). No new call sites needed in this PR — call sites land in PR-D2.
+
+## PR-D2 Status — QUEUED for fresh session
+
+PR-D2 (next session) ships:
+
+1. NEW `pub async fn fetch_intraday_window_for_gap_fill` in `candle_fetcher.rs`
+   that uses the now-pub(crate) primitives. Takes `(http_client, token,
+   client_id, dhan_config, security_id, segment, from_secs, to_secs)`,
+   returns `Result<Vec<HistoricalCandle>, GapFillFetchError>`. NO writer
+   coupling — caller writes.
+2. Update `run_gap_fill_scheduler` signature to accept the deps
+   (`Arc<TokenHandle>`, `SecretString`, `Arc<DhanConfig>`, `Arc<reqwest::Client>`,
+   `Arc<Mutex<CandlePersistenceWriter>>`).
+3. Per-event work in scheduler: receive event → call planner → for each
+   planned bar, fetch via the new pub fn → UPSERT via existing writer →
+   write `gap_fill_audit` row.
+4. Boot wiring in `main.rs` to thread the deps through.
+5. Telegram event emission via `GapFillCompleted`/`Partial`/`Failed`.
+
+PR-D2 will be ~600-1000 LoC across `candle_fetcher.rs`, `gap_fill_scheduler.rs`,
+`main.rs`. Best done in a fresh focused session.
+
+## PR-D3 Status — QUEUED for fresh session
+
+PR-D3 ships the observability layer:
+
+- Grafana panel + alert rule for the 3 Prom counters
+- DH-904 backoff observability counters
+- `tv_gap_fill_rest_latency_ms` histogram (Item 8 of original plan)
+
+## Original plan items mapped to PR series
+
+| Plan Item | PR |
+|---|---|
+| Item 1 (constants) | PR-A (#668) ✅ |
+| Item 2 (ErrorCodes) | PR-A (#668) ✅ |
+| Item 3 (Telegram events) | PR-A (#668) ✅ |
+| Item 4 (target table decision) | PR-B' (#670) ✅ locked |
+| Item 5 (scheduler skeleton + supervisor) | PR-C (#671) ✅ |
+| Item 5b (broadcast wiring) | PR-C (#671) ✅ |
+| Item 6 (pub mod) | PR-C (#671) ✅ |
+| Item 7 (boot wiring) | PR-C (#671) ✅ |
+| Item 8 (Prom counters) | partial PR-C (3 counters); PR-D3 adds histogram |
+| Item 9 (Grafana panel + alert) | PR-D3 |
+| Item 10 (runbook) | PR-A (#668) ✅ |
+| Item 11 (integration tests) | PR-C (#671) ✅ partial; PR-D2 adds REST tests |
+| NEW: visibility promotion | PR-D1 (this PR) |
+| NEW: REST fetch + UPSERT | PR-D2 |
 
 ## Verification before PR (PR-A)
 

--- a/crates/core/src/historical/candle_fetcher.rs
+++ b/crates/core/src/historical/candle_fetcher.rs
@@ -100,8 +100,16 @@ struct DataApiErrorResponse {
 }
 
 /// Classifies a Dhan error response for retry/backoff decisions.
+///
+/// Phase 0 PR-D1 (2026-05-17): visibility promoted to `pub(crate)` so
+/// the gap-fill scheduler (in sibling module `gap_fill_scheduler`) can
+/// reuse the same classification logic for its per-bar REST fetches.
+/// Per `audit-findings-2026-04-17.md` Rule 15 (locked architectural
+/// decisions): gap-fill MUST follow the same DH-904 backoff ladder +
+/// 5xx retry policy as the boot-time historical fetch — pub(crate)
+/// reuse avoids the duplicate-logic anti-pattern.
 #[derive(Debug, PartialEq)]
-enum ErrorAction {
+pub(crate) enum ErrorAction {
     /// Rate limited (DH-904 or HTTP 429) — exponential backoff
     RateLimited,
     /// Too many connections (805) — pause all requests 60s
@@ -115,7 +123,10 @@ enum ErrorAction {
 }
 
 /// Parses error response bytes and classifies the error for retry decisions.
-fn classify_error(status: reqwest::StatusCode, body: &[u8]) -> ErrorAction {
+///
+/// Phase 0 PR-D1 (2026-05-17): visibility promoted to `pub(crate)` —
+/// see [`ErrorAction`] for rationale.
+pub(crate) fn classify_error(status: reqwest::StatusCode, body: &[u8]) -> ErrorAction {
     // HTTP 429 is always rate limiting
     if status.as_u16() == 429 {
         return ErrorAction::RateLimited;
@@ -290,18 +301,27 @@ fn format_intraday_date_range(
 
 /// Computes the DH-904 exponential backoff delay for a given attempt number.
 /// Sequence: 10s, 20s, 40s, 80s (base * 2^attempt).
-fn compute_dh904_backoff_secs(attempt: u32) -> u64 {
+///
+/// Phase 0 PR-D1 (2026-05-17): `pub(crate)` so the gap-fill scheduler
+/// can reuse the same backoff ladder. Per `audit-findings-2026-04-17.md`
+/// Rule 15: gap-fill MUST follow the same DH-904 policy as the
+/// boot-time historical fetch.
+pub(crate) fn compute_dh904_backoff_secs(attempt: u32) -> u64 {
     DH_904_BACKOFF_BASE_SECS.saturating_mul(1_u64.wrapping_shl(attempt))
 }
 
 /// Returns true if the DH-904 attempt count has exceeded the maximum.
-fn is_dh904_exhausted(attempt: u32) -> bool {
+///
+/// Phase 0 PR-D1 (2026-05-17): `pub(crate)` for gap-fill scheduler reuse.
+pub(crate) fn is_dh904_exhausted(attempt: u32) -> bool {
     attempt >= DH_904_MAX_BACKOFF_ATTEMPTS
 }
 
 /// Computes the retry delay in milliseconds for a given attempt number.
 /// Linear backoff: 1000ms * attempt.
-fn compute_retry_delay_ms(attempt: u32) -> u64 {
+///
+/// Phase 0 PR-D1 (2026-05-17): `pub(crate)` for gap-fill scheduler reuse.
+pub(crate) fn compute_retry_delay_ms(attempt: u32) -> u64 {
     1000_u64.saturating_mul(u64::from(attempt))
 }
 
@@ -521,16 +541,21 @@ fn build_failure_reasons(
 // ---------------------------------------------------------------------------
 
 /// Request body for Dhan intraday charts API.
+///
+/// Phase 0 PR-D1 (2026-05-17): visibility promoted to `pub(crate)` so
+/// the gap-fill scheduler can construct intraday-fetch requests for
+/// per-bar gap-fill windows. Field types/serde attrs unchanged — see
+/// `docs/dhan-ref/05-historical-data.md` for the wire contract.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-struct IntradayRequest {
-    security_id: String,
-    exchange_segment: String,
-    instrument: String,
-    interval: String,
-    oi: bool,
-    from_date: String,
-    to_date: String,
+pub(crate) struct IntradayRequest {
+    pub security_id: String,
+    pub exchange_segment: String,
+    pub instrument: String,
+    pub interval: String,
+    pub oi: bool,
+    pub from_date: String,
+    pub to_date: String,
 }
 
 /// Request body for Dhan daily charts API.


### PR DESCRIPTION
## Summary

Minimal visibility-promotion PR. Promotes 6 private primitives in `candle_fetcher.rs` to `pub(crate)` so PR-D2's gap-fill REST fetch helper can reuse them. **ZERO behavioural change.** All 220 existing candle_fetcher tests pass without modification.

**Branch:** `claude/phase-0-pr-d1-rest-fetch-upsert`
**Builds on:** PR-A (#668), PR-A2 (#669), PR-B' (#670), PR-C (#671) — all merged

## What changes

| Item | From | To |
|---|---|---|
| `ErrorAction` enum | private | `pub(crate)` |
| `classify_error()` | private | `pub(crate)` |
| `compute_dh904_backoff_secs()` | private | `pub(crate)` |
| `is_dh904_exhausted()` | private | `pub(crate)` |
| `compute_retry_delay_ms()` | private | `pub(crate)` |
| `IntradayRequest` struct + 7 fields | private | `pub(crate)` struct, `pub` fields |

## Why `pub(crate)` not `pub`

The gap-fill scheduler (sibling module in `crates/core/src/historical/`) needs the same DH-904 backoff ladder + 5xx retry + error classification that `fetch_intraday_with_retry` uses. Per `audit-findings-2026-04-17.md` Rule 15 (locked architectural decisions): gap-fill MUST follow the same policy as boot-time historical fetch. `pub(crate)` reuse avoids the duplicate-logic anti-pattern.

External crates don't need these primitives — `pub(crate)` is the correct scope.

## Why this is NOT the skeleton anti-pattern (Rule 14)

| Anti-pattern signal | This PR |
|---|---|
| `// TODO PR-D` stubs | none |
| New pub fns with no call site | **none — no new pub fns at all** |
| False-OK observability | n/a |
| `enabled=false` config flag | n/a |
| Tests asserting exact-task-count invariants | n/a |

Pure visibility refactor. No new public API surface beyond what PR-D2 will consume.

## Why not the full PR-D in one shot

The full PR-D (REST fetch + UPSERT + scheduler wiring + Telegram + Grafana) needs ~600-1000 LoC threading dependencies (`Arc<TokenHandle>`, `SecretString` client_id, `Arc<DhanConfig>`, `Arc<reqwest::Client>`, `Arc<Mutex<CandlePersistenceWriter>>`) through `main.rs` boot orchestration and the scheduler signature. After PR-A/A2/B'/C this session, a focused PR-D2 in a fresh session is the safer path per Rule 14 (no rushed half-impl). Plan file updated to map the remaining work to PR-D2 + PR-D3.

## Test plan

- [x] `cargo check -p tickvault-core` — clean
- [x] `cargo test -p tickvault-core --lib historical::candle_fetcher` — **220/220 pass**

## Files changed

| File | Change |
|---|---|
| `crates/core/src/historical/candle_fetcher.rs` | 6 keyword changes + doc-comment additions |
| `.claude/plans/active-plan-item-8-9-gap-fill.md` | PR-D1/D2/D3 status + plan-items→PR mapping table |

## Honest 100% claim

> "100% inside the tested envelope: visibility-only refactor, 220 existing tests pass, no behaviour change, no new API surface. Beyond the envelope: PR-D2 (next session) consumes these primitives in the new pub fetch helper + scheduler wiring; PR-D3 adds Grafana panel + alert."

## Session arc — 5 PRs

| PR | Title | Status |
|---|---|---|
| #668 (PR-A) | Phase 0 Items 8+9 foundation | ✅ MERGED |
| #669 (PR-A2) | nse-fact-checker skill + block-bypass hook | ✅ MERGED |
| #670 (PR-B') | Architectural decisions + Rules 14-17 | ✅ MERGED |
| #671 (PR-C) | Broadcast plumbing + scheduler vertical slice | ✅ MERGED |
| **this PR (PR-D1)** | Visibility promotion for PR-D2 reuse | 🟡 PENDING |
| PR-D2 (next session) | REST fetch + UPSERT + scheduler full wiring | queued |
| PR-D3 (next session) | Grafana panel + alert + latency histogram | queued |

https://claude.ai/code/session_01FBbpPVoKC4jjBdR2SARtMm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBbpPVoKC4jjBdR2SARtMm)_