### PR TITLE
chore(deny): skip aws-lc-sys/aws-lc-rs dual-version — unblocks dependabot PRs #685 + #686

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -101,6 +101,20 @@ skip = [
     { crate = "rand_core", reason = "follows rand version split" },
     { crate = "redis", reason = "deadpool-redis may pull different redis version" },
     { crate = "untrusted", reason = "aws-lc-rs 1.16.3 pins untrusted 0.7.x while ring/aws-credential-types use 0.9.x" },
+    # --- aws-lc dual-version while AWS SDK is on rustls 0.23.x + aws-lc-rs 1.16.3 ---
+    # Dependabot bumps `aws-lc-sys 0.40 → 0.41` (PR #686) and
+    # `aws-lc-rs 1.16.3 → 1.17.0` (PR #685) but the AWS SDK suite
+    # (aws-smithy-http-client 1.1.12 → rustls 0.23.40) still pins the
+    # older aws-lc-rs 1.16.3 → aws-lc-sys 0.40.0. Cargo.lock ends up
+    # with TWO versions of each crate, which `multiple-versions = "deny"`
+    # rejects. The dependabot bumps still ship the CVE fixes for new
+    # call sites on our primary TLS path (rustls 0.23.x → webpki 0.103.13);
+    # the AWS SDK transitive copy is on its own quarantined TLS path.
+    # Skip the duplicate-version error here until the AWS SDK suite
+    # bump lands (which will retire the four `RUSTSEC-2026-009*`
+    # ignores above in one sweep — see comments at lines 36-40).
+    { crate = "aws-lc-sys", reason = "dual-version while AWS SDK still pulls aws-lc-rs 1.16.3" },
+    { crate = "aws-lc-rs", reason = "dual-version while AWS SDK pins 1.16.3 transitively" },
     { crate = "serde_spanned", reason = "figment + toml crate version split" },
     { crate = "toml", reason = "figment uses older toml, we pin newer" },
     { crate = "toml_datetime", reason = "follows toml version split" },


### PR DESCRIPTION
## Summary

Unblocks dependabot PRs **#685** (`aws-lc-rs 1.16.3 → 1.17.0`) and **#686** (`aws-lc-sys 0.40 → 0.41`) which currently fail CI's `Security & Audit` job.

## Root cause (verified locally with `cargo deny check bans`)

```
error[duplicate]: found 2 duplicate entries for crate 'aws-lc-sys'
   ┌─ Cargo.lock:23
23 │ aws-lc-sys 0.40.0  (transitive via AWS SDK → rustls 0.23.40 → aws-lc-rs 1.16.3)
24 │ aws-lc-sys 0.41.0  (direct, from dependabot bump)
```

The AWS SDK suite (`aws-smithy-http-client 1.1.12` → `rustls 0.23.40` → `aws-lc-rs 1.16.3`) still transitively pins `aws-lc-sys 0.40.0`. Dependabot's bump adds `0.41.0` as a second version. `multiple-versions = "deny"` rejects the lockfile.

## Fix

Add `aws-lc-sys` + `aws-lc-rs` to `deny.toml`'s existing `skip` list — same pattern already in place for `rustls`, `hyper-rustls`, `untrusted`, `cpufeatures`, `digest`, `sha2`, etc. (all dual-versioned while we wait for AWS SDK to consolidate).

The 4 `RUSTSEC-2026-009*` ignores at the top of `deny.toml` are blocked on the same AWS SDK suite bump (see comments at lines 36-40); all 6 retirees land in one sweep when `aws-smithy-http-client 1.2+` ships.

## After this merges

1. Dependabot will auto-rebase #685 + #686 on next cycle (within ~1h) OR
2. I'll close + reopen them to trigger fresh CI immediately after this lands.

Either way, their CI will then pass (the only failing check was `Security & Audit / bans`) and auto-merge will fire.

## Test plan

- [x] `cargo deny check bans` → `bans ok` after fix
- [x] `cargo deny check advisories` → `advisories ok` (unchanged)
- [x] Pre-existing `unnecessary-skip` warnings on `redis`/`tokio-tungstenite`/etc. are unaffected (only warn, don't fail).

## Diff scope

1 file, 14 lines added to `deny.toml` skip list with full reasoning comment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CEzV4yUQTLa7Wy8JqD81NC)_