### PR TITLE
feat: subscribe IDX_I indices in Quote mode for exchange day OHLC

### DIFF
--- a/.claude/plans/active-plan-table-cleanup.md
+++ b/.claude/plans/active-plan-table-cleanup.md
@@ -1,0 +1,69 @@
+# Implementation Plan: QuestDB Table Cleanup — drop to 13 tables
+
+**Status:** APPROVED
+**Date:** 2026-05-20
+**Approved by:** Parthiban (operator) — verbatim: "remove the entire fucking
+tables except ticks + all candle timeframe tables + one option chain table",
+keep/drop list approved 2026-05-20 with `historical_candles` retained.
+
+## Goal
+
+Cut the QuestDB schema from ~37 tables to **13**. The operator finds the
+table sprawl unmanageable; only the live data plane is wanted.
+
+## KEEP (13)
+
+| Table | Role |
+|---|---|
+| `ticks` | live LTP + greeks (iv/delta/gamma/theta/vega) + day OHLC columns |
+| `candles_1s` | base candle table |
+| `candles_1m` `candles_5m` `candles_15m` `candles_30m` `candles_1h` `candles_2h` `candles_3h` `candles_4h` `candles_1d` | 9 live candle timeframes |
+| `option_chain_minute_snapshot` | the one option-chain table |
+| `historical_candles` | REST historical — cross-verify ground truth |
+
+## DROP (~31) — and rip out the writer code, not just the SQL
+
+| Group | Tables |
+|---|---|
+| Audit (~20) | aggregator_seal_audit, auth_renewal_audit, bar_correction_audit, boot_audit, decision_audit, gap_fill_audit, last_tick_audit, open_price_audit, order_audit, order_update_ws_audit, orphan_position_audit, pnl_audit, self_trade_audit, selftest_audit, signal_audit, sl_replacement_audit, static_ip_audit, volume_nse_audit, ws_reconnect_audit, subscription_audit_log |
+| Instrument (5) | fno_underlyings, derivative_contracts, subscribed_indices, instrument_build_metadata, index_constituents |
+| Candle shadow (9) | candles_1m_shadow … candles_1d_shadow (Wave-6 internal scaffolding) |
+| Misc (6) | market_depth, previous_close, indicator_snapshots, obi_snapshots, nse_holidays, live_instance_lock |
+
+Each dropped table also means deleting its `*_persistence.rs` module, its
+boot-time DDL `tokio::join!` entry in `main.rs`, its notification-event
+variant(s), its `ErrorCode` AUDIT-NN variant(s), and its ratchet tests.
+
+## Consequences (operator-acknowledged)
+
+1. **PR #9 cross-verify** redesigned: keeps `historical_candles` as the
+   compare source, but the result is **Telegram-alert-only — no
+   `cross_verify_audit` table**.
+2. **`order_audit`** (SEBI 5-year order trail) is dropped now (empty —
+   sandbox/dry-run). HARD GATE: it MUST be re-added before `dry_run=false`
+   / live trading. Tracked here so go-live cannot forget it.
+
+## Sequencing (serial PRs, §H — one at a time)
+
+This is too large for one PR. Execute as sequenced sub-PRs:
+
+- [ ] **#T1** — drop the 9 `candles_*_shadow` tables + Wave-6 seal writer
+  (`shadow_persistence.rs`, `shadow_candle_writer.rs`, seal_writer_loop,
+  seal_ring, cascade shadow wiring, boot wiring, ratchets).
+- [ ] **#T2** — drop the ~20 audit tables + their `*_audit_persistence.rs`
+  modules + boot DDL + notification/ErrorCode wiring + ratchets.
+- [ ] **#T3** — drop the 5 instrument tables + `instrument_persistence.rs`
+  surface for them + boot DDL.
+- [ ] **#T4** — drop the 6 misc tables (market_depth, previous_close,
+  indicator_snapshots, obi_snapshots, nse_holidays, live_instance_lock)
+  + their persistence modules + boot wiring.
+- [ ] **#T5** — cross-verify (PR #9) lands table-free (Telegram-only)
+  against `historical_candles`.
+
+Net effect: supersedes the original AWS-lifecycle PR #10 QuestDB-cleanup
+scope and folds it in.
+
+## Pre-req
+
+PR #722 (IDX_I Quote mode) must merge to `main` first (§H serial
+completion). Then #T1 starts.

--- a/.claude/plans/active-plan-table-cleanup.md
+++ b/.claude/plans/active-plan-table-cleanup.md
@@ -1,67 +1,79 @@
-# Implementation Plan: QuestDB Table Cleanup — drop to 13 tables
+# Implementation Plan: QuestDB Table Cleanup — drop to 24 tables
 
 **Status:** APPROVED
 **Date:** 2026-05-20
-**Approved by:** Parthiban (operator) — verbatim: "remove the entire fucking
-tables except ticks + all candle timeframe tables + one option chain table",
-keep/drop list approved 2026-05-20 with `historical_candles` retained.
+**Approved by:** Parthiban (operator) — keep list corrected 2026-05-20:
+`ticks` + 21 candle timeframe tables (1m…15m each minute, 30m, 1h, 2h,
+3h, 4h, 1d) + one option-chain table + `historical_candles`. NO
+`candles_1s`. Everything else dropped.
 
 ## Goal
 
-Cut the QuestDB schema from ~37 tables to **13**. The operator finds the
-table sprawl unmanageable; only the live data plane is wanted.
+Cut the QuestDB schema to **24 tables** — only the live data plane the
+operator queries. No second-level base table, no shadow tables, no
+audit/instrument/misc sprawl.
 
-## KEEP (13)
+## KEEP (24)
 
-| Table | Role |
+| Table(s) | Role |
 |---|---|
 | `ticks` | live LTP + greeks (iv/delta/gamma/theta/vega) + day OHLC columns |
-| `candles_1s` | base candle table |
-| `candles_1m` `candles_5m` `candles_15m` `candles_30m` `candles_1h` `candles_2h` `candles_3h` `candles_4h` `candles_1d` | 9 live candle timeframes |
+| `candles_1m` `candles_2m` `candles_3m` `candles_4m` `candles_5m` `candles_6m` `candles_7m` `candles_8m` `candles_9m` `candles_10m` `candles_11m` `candles_12m` `candles_13m` `candles_14m` `candles_15m` | 15 minute timeframes (1→15) |
+| `candles_30m` `candles_1h` `candles_2h` `candles_3h` `candles_4h` `candles_1d` | 6 higher timeframes |
 | `option_chain_minute_snapshot` | the one option-chain table |
 | `historical_candles` | REST historical — cross-verify ground truth |
 
-## DROP (~31) — and rip out the writer code, not just the SQL
+= 1 + 21 + 1 + 1 = **24**.
+
+## Candle architecture change — NO `candles_1s` base
+
+Today the 9 candle matviews sample from a `candles_1s` base table (a
+2-tier cascade). The operator does not want `candles_1s`. Therefore:
+
+- Each of the 21 candle timeframe tables becomes a QuestDB
+  **materialized view that samples `ticks` directly**
+  (`SAMPLE BY <tf>` with `first/max/min/last` OHLC + `sum` volume).
+- `candles_1s` is **dropped**.
+- The in-memory 29-TF cascade (`tickvault_trading::candles`), the
+  `candles_1s` writer, and the 9 `candles_*_shadow` tables are all
+  **removed** — superseded by direct `ticks`→matview aggregation.
+- 12 sub-15m timeframes (`candles_2m,3m,4m,6m,7m,8m,9m,10m,11m,12m,13m,14m`)
+  were retired in PR #517 — they are **re-created** as matviews here.
+
+## DROP — and rip out the writer code, not just the SQL
 
 | Group | Tables |
 |---|---|
+| `candles_1s` base | candles_1s |
+| Candle shadow (9) | candles_1m_shadow … candles_1d_shadow |
 | Audit (~20) | aggregator_seal_audit, auth_renewal_audit, bar_correction_audit, boot_audit, decision_audit, gap_fill_audit, last_tick_audit, open_price_audit, order_audit, order_update_ws_audit, orphan_position_audit, pnl_audit, self_trade_audit, selftest_audit, signal_audit, sl_replacement_audit, static_ip_audit, volume_nse_audit, ws_reconnect_audit, subscription_audit_log |
 | Instrument (5) | fno_underlyings, derivative_contracts, subscribed_indices, instrument_build_metadata, index_constituents |
-| Candle shadow (9) | candles_1m_shadow … candles_1d_shadow (Wave-6 internal scaffolding) |
 | Misc (6) | market_depth, previous_close, indicator_snapshots, obi_snapshots, nse_holidays, live_instance_lock |
 
-Each dropped table also means deleting its `*_persistence.rs` module, its
-boot-time DDL `tokio::join!` entry in `main.rs`, its notification-event
-variant(s), its `ErrorCode` AUDIT-NN variant(s), and its ratchet tests.
+Each dropped table also means deleting its `*_persistence.rs` module,
+its boot-time DDL entry in `main.rs`, its notification-event variant(s),
+its `ErrorCode` variant(s), and its ratchet tests.
 
 ## Consequences (operator-acknowledged)
 
 1. **PR #9 cross-verify** redesigned: keeps `historical_candles` as the
-   compare source, but the result is **Telegram-alert-only — no
-   `cross_verify_audit` table**.
-2. **`order_audit`** (SEBI 5-year order trail) is dropped now (empty —
-   sandbox/dry-run). HARD GATE: it MUST be re-added before `dry_run=false`
-   / live trading. Tracked here so go-live cannot forget it.
+   compare source, result is **Telegram-alert-only — no audit table**.
+2. **`order_audit`** (SEBI 5-year order trail) dropped now (empty —
+   sandbox/dry-run). HARD GATE: MUST be re-added before `dry_run=false`.
 
 ## Sequencing (serial PRs, §H — one at a time)
 
-This is too large for one PR. Execute as sequenced sub-PRs:
-
-- [ ] **#T1** — drop the 9 `candles_*_shadow` tables + Wave-6 seal writer
-  (`shadow_persistence.rs`, `shadow_candle_writer.rs`, seal_writer_loop,
-  seal_ring, cascade shadow wiring, boot wiring, ratchets).
-- [ ] **#T2** — drop the ~20 audit tables + their `*_audit_persistence.rs`
-  modules + boot DDL + notification/ErrorCode wiring + ratchets.
-- [ ] **#T3** — drop the 5 instrument tables + `instrument_persistence.rs`
-  surface for them + boot DDL.
-- [ ] **#T4** — drop the 6 misc tables (market_depth, previous_close,
-  indicator_snapshots, obi_snapshots, nse_holidays, live_instance_lock)
-  + their persistence modules + boot wiring.
+- [ ] **#T1** — candle re-architecture: 21 matviews sampling `ticks`
+  directly (incl. re-creating the 12 sub-15m TFs); drop `candles_1s`,
+  the 9 shadow tables, the in-memory 29-TF cascade + seal writer.
+- [ ] **#T2** — drop ~20 audit tables + `*_audit_persistence.rs` modules
+  + boot DDL + notification/ErrorCode wiring + ratchets.
+- [ ] **#T3** — drop 5 instrument tables + their persistence surface.
+- [ ] **#T4** — drop 6 misc tables + their persistence modules.
 - [ ] **#T5** — cross-verify (PR #9) lands table-free (Telegram-only)
   against `historical_candles`.
 
-Net effect: supersedes the original AWS-lifecycle PR #10 QuestDB-cleanup
-scope and folds it in.
+Supersedes the original AWS-lifecycle PR #10 QuestDB-cleanup scope.
 
 ## Pre-req
 

--- a/.claude/rules/project/live-market-feed-subscription.md
+++ b/.claude/rules/project/live-market-feed-subscription.md
@@ -204,11 +204,28 @@ spam from the watchdog disconnect/reconnect cycle that occurs when Dhan sends no
 data after market close. During market hours, infinite retries are maintained
 (Dhan pings every 10s, so consecutive failures = real problem worth retrying).
 
-### IDX_I Special Case
+### IDX_I Special Case — Quote mode (operator directive 2026-05-20)
 
-Indices (segment code 0) are forced to Ticker mode regardless of configured feed
-mode. Dhan silently ignores Quote/Full subscriptions for IDX_I. The subscription
-builder pre-sorts IDX_I instruments into separate Ticker-mode batches.
+Indices (segment code 0) are subscribed in **Quote mode** (`FeedRequestCode`
+17). The `WebSocketConnection` constructor pre-sorts IDX_I instruments into a
+separate Quote-mode subscription batch (`connection.rs`, the
+`idx_instruments` partition).
+
+**Why Quote, not Ticker:** the Quote packet (response code 4, 50 bytes)
+carries `day_open` / `day_high` / `day_low` / `day_close` at fixed offsets
+(parsed by `parse_quote_packet`). That is the exchange-computed session OHLC,
+delivered in every packet — so the index 09:15 open and running day high/low
+come straight from Dhan, with no app-side tracking.
+
+**History:** before 2026-05-20 IDX_I was force-subscribed in Ticker mode
+(LTP-only, 16 bytes) on the *assumption* that "Dhan silently ignores
+Quote/Full for index feeds". That assumption was never live-verified — our
+own code never sent a Quote subscription for an index. The operator directed
+switching to Quote mode to obtain day OHLC directly. Worst case, if Dhan does
+ignore Quote for IDX_I, it still streams Ticker-grade packets, so LTP capture
+is unaffected. Verify against the live `ticks` table after a session: if the
+IDX_I `open`/`high`/`low` columns are non-zero, Dhan honors Quote mode for
+indices and `DayOhlcTracker` is redundant.
 
 ## Key Files
 
@@ -224,7 +241,7 @@ builder pre-sorts IDX_I instruments into separate Ticker-mode batches.
 - Subscribing to wrong instruments (ATM filtering ensures relevance)
 - Exceeding Dhan limits (5 connections, 5000/conn, 100/msg enforced)
 - Numeric SecurityId in JSON (must be string: `"1333"` not `1333`)
-- Wrong feed mode for indices (IDX_I forced to Ticker)
+- Wrong feed mode for indices (IDX_I subscribes in Quote mode for day OHLC)
 - Confusion with depth protocol (main feed = 8-byte header, f32 prices)
 
 ## Trigger

--- a/crates/core/src/websocket/connection.rs
+++ b/crates/core/src/websocket/connection.rs
@@ -383,8 +383,19 @@ impl WebSocketConnection {
     ) -> Self {
         let websocket_base_url = dhan_config.websocket_url.clone(); // O(1) EXEMPT: constructor — once
 
-        // Pre-build subscription messages once. IDX_I instruments only support Ticker mode —
-        // Dhan silently drops Full/Quote subscriptions for index value feeds.
+        // Pre-build subscription messages once.
+        //
+        // IDX_I (index value) instruments are subscribed in QUOTE mode
+        // (operator directive 2026-05-20). The Quote packet (response
+        // code 4, 50 bytes) carries `day_open` / `day_high` / `day_low`
+        // / `day_close` at fixed offsets — see `parse_quote_packet`.
+        // That is the exchange-computed session OHLC, delivered directly
+        // in every packet, so we do NOT have to derive the index open
+        // ourselves. The prior code force-subscribed IDX_I in Ticker
+        // mode (LTP-only, 16 bytes) on the ASSUMPTION that Dhan ignores
+        // Quote/Full for index feeds — that assumption was never
+        // live-verified. Worst case, if Dhan does ignore it, it still
+        // streams Ticker-grade packets and we lose nothing vs before.
         // O(1) EXEMPT: constructor — runs once at startup, not per tick.
         let (idx_instruments, non_idx_instruments): (Vec<_>, Vec<_>) = instruments
             .iter()
@@ -399,7 +410,7 @@ impl WebSocketConnection {
         if !idx_instruments.is_empty() {
             cached_subscription_messages.extend(build_subscription_messages(
                 &idx_instruments,
-                FeedMode::Ticker,
+                FeedMode::Quote,
                 ws_config.subscription_batch_size,
             ));
         }
@@ -2371,7 +2382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cached_messages_idx_i_uses_ticker() {
+    fn test_cached_messages_idx_i_uses_quote() {
         let (tx, _rx) = mpsc::channel(100);
         let instruments = vec![
             InstrumentSubscription::new(ExchangeSegment::IdxI, 13),
@@ -2384,13 +2395,14 @@ mod tests {
             make_test_dhan_config(),
             make_test_ws_config(),
             instruments,
-            FeedMode::Full, // Configured as Full, but IDX_I should use Ticker
+            FeedMode::Full, // Configured as Full, but IDX_I uses Quote
             tx,
             None,
         );
-        // All IDX_I → only Ticker messages (request_code 15), NOT Full (21)
+        // All IDX_I → only Quote messages (request_code 17), NOT Full (21).
+        // Operator directive 2026-05-20 — Quote packet carries day OHLC.
         assert_eq!(conn.cached_subscription_messages.len(), 1);
-        assert!(conn.cached_subscription_messages[0].contains("\"RequestCode\":15"));
+        assert!(conn.cached_subscription_messages[0].contains("\"RequestCode\":17"));
         assert!(!conn.cached_subscription_messages[0].contains("\"RequestCode\":21"));
     }
 
@@ -2450,22 +2462,25 @@ mod tests {
             make_test_dhan_config(),
             make_test_ws_config(),
             instruments,
-            FeedMode::Full, // Non-IDX gets Full (21), IDX_I gets Ticker (15)
+            FeedMode::Full, // Non-IDX gets Full (21), IDX_I gets Quote (17)
             tx,
             None,
         );
-        // 2 non-IDX → 1 Full message, 2 IDX_I → 1 Ticker message = 2 total
+        // 2 non-IDX → 1 Full message, 2 IDX_I → 1 Quote message = 2 total
         assert_eq!(conn.cached_subscription_messages.len(), 2);
         let has_full = conn
             .cached_subscription_messages
             .iter()
             .any(|m| m.contains("\"RequestCode\":21"));
-        let has_ticker = conn
+        // IDX_I subscribes in Quote mode (RequestCode 17) per the
+        // 2026-05-20 operator directive — the Quote packet carries
+        // day open/high/low directly.
+        let has_quote = conn
             .cached_subscription_messages
             .iter()
-            .any(|m| m.contains("\"RequestCode\":15"));
+            .any(|m| m.contains("\"RequestCode\":17"));
         assert!(has_full, "Should have Full mode message for NseFno");
-        assert!(has_ticker, "Should have Ticker mode message for IdxI");
+        assert!(has_quote, "Should have Quote mode message for IdxI");
     }
 
     // --- Edge Case: Empty client_id ---
@@ -2792,7 +2807,7 @@ mod tests {
     // --- Only IDX_I instruments with Ticker mode (should still use Ticker) ---
 
     #[test]
-    fn test_connection_only_idx_i_in_ticker_mode() {
+    fn test_connection_only_idx_i_in_quote_mode() {
         let (tx, _rx) = mpsc::channel(100);
         let instruments = vec![InstrumentSubscription::new(ExchangeSegment::IdxI, 13)];
         let conn = WebSocketConnection::new(
@@ -2802,12 +2817,12 @@ mod tests {
             make_test_dhan_config(),
             make_test_ws_config(),
             instruments,
-            FeedMode::Ticker, // Same as forced mode for IDX_I
+            FeedMode::Ticker, // Passed mode applies to non-IDX only; IDX_I uses Quote
             tx,
             None,
         );
         assert_eq!(conn.cached_subscription_messages.len(), 1);
-        assert!(conn.cached_subscription_messages[0].contains("\"RequestCode\":15"));
+        assert!(conn.cached_subscription_messages[0].contains("\"RequestCode\":17"));
     }
 
     // --- Batch size of 1 with multiple instruments ---
@@ -4181,7 +4196,7 @@ mod tests {
     }
 
     #[test]
-    fn test_connection_idx_instruments_use_ticker_mode() {
+    fn test_connection_idx_instruments_use_quote_mode() {
         let (tx, _rx) = mpsc::channel(100);
         let instruments = vec![InstrumentSubscription::new(ExchangeSegment::IdxI, 13)];
         let conn = WebSocketConnection::new(
@@ -4191,16 +4206,16 @@ mod tests {
             make_test_dhan_config(),
             make_test_ws_config(),
             instruments,
-            FeedMode::Full, // Full mode specified but IDX_I should use Ticker
+            FeedMode::Full, // Full mode specified but IDX_I uses Quote
             tx,
             None,
         );
         assert!(!conn.cached_subscription_messages.is_empty());
-        // The subscription message should contain RequestCode 15 (SubscribeTicker)
+        // The subscription message should contain RequestCode 17 (SubscribeQuote).
         let msg = &conn.cached_subscription_messages[0];
         assert!(
-            msg.contains("15"),
-            "IDX_I should subscribe with Ticker mode (code 15): {}",
+            msg.contains("\"RequestCode\":17"),
+            "IDX_I should subscribe with Quote mode (code 17): {}",
             msg
         );
     }
@@ -4366,9 +4381,9 @@ mod tests {
             tx,
             None,
         );
-        // All instruments are IDX, so all use Ticker (code 15), no Full messages
+        // All instruments are IDX, so all use Quote (code 17), no Full messages
         assert_eq!(conn.cached_subscription_messages.len(), 1);
-        assert!(conn.cached_subscription_messages[0].contains("\"RequestCode\":15"));
+        assert!(conn.cached_subscription_messages[0].contains("\"RequestCode\":17"));
         assert!(!conn.cached_subscription_messages[0].contains("\"RequestCode\":21"));
     }
 


### PR DESCRIPTION
## Summary

The 4 locked IDX_I index SIDs (NIFTY/BANKNIFTY/SENSEX/INDIA VIX) were force-subscribed in **Ticker** mode (LTP-only, 16-byte packet) on the **assumption** that Dhan silently ignores Quote/Full subscriptions for index feeds. That assumption was **never live-verified** — our code never once sent a Quote subscription for an index.

This switches the IDX_I subscription batch from `FeedMode::Ticker` → `FeedMode::Quote`.

## Why it matters

The **Quote packet** (response code 4, 50 bytes) carries `day_open` / `day_high` / `day_low` / `day_close` at fixed offsets — already parsed by `parse_quote_packet` into `ParsedTick`, already persisted to the `ticks` table's `open/high/low` columns. If Dhan honors Quote mode for IDX_I, the **exchange-computed session OHLC — including the 09:15 open — arrives directly in every packet**. No `DayOhlcTracker`, no pre-open-buffer backtrack, no candle-seed hack.

| | Before (Ticker) | After (Quote) |
|---|---|---|
| Packet | 16-byte, LTP only | 50-byte, LTP + day OHLC |
| Index 09:15 open | derived app-side (DayOhlcTracker) | straight from Dhan |
| day high/low | tracked app-side | straight from Dhan |

## Risk: low

If Dhan *does* ignore Quote for IDX_I, it still streams Ticker-grade packets — LTP capture is unaffected vs before. **Verifiable**: after a live session, check the `ticks` table — non-zero IDX_I `open/high/low` ⇒ Dhan honors Quote mode for indices and `DayOhlcTracker` becomes redundant (removable in a follow-up).

## Changes

- `connection.rs`: IDX_I partition subscribes via `FeedMode::Quote` (RequestCode 17) not `FeedMode::Ticker` (15). One production line + rewritten rationale comment. Reused on every reconnect via the existing cached-subscription path.
- 4 connection tests updated to assert RequestCode 17 (`*_uses_ticker` → `*_uses_quote`). **154/154 connection tests green.**
- `live-market-feed-subscription.md` "IDX_I Special Case" rewritten — documents Quote mode + the honest history of the untested assumption.

The 2-WS scope lock and the 4-SID `LOCKED_UNIVERSE` are untouched — only the feed mode of the existing IDX_I batch changes. No new connections, no new instruments.

## Test plan

- [x] `cargo test -p tickvault-core --lib websocket::connection` — 154/154 green
- [x] `cargo fmt --check` clean
- [x] banned-pattern + pub-fn-test-guard + test-count gates green
- [ ] **Operator verification**: after next session, `SELECT open,high,low FROM ticks WHERE security_id=13 ORDER BY ts DESC LIMIT 1` — non-zero ⇒ Quote mode honored

---
_Generated by [Claude Code](https://claude.ai/code/session_012emMMx3SnMUHdURNmx8cQZ)_