### PR TITLE
docs(plan): table-cleanup column audit + RAM-first candle architecture

### DIFF
--- a/.claude/plans/active-plan-table-cleanup.md
+++ b/.claude/plans/active-plan-table-cleanup.md
@@ -25,20 +25,43 @@ audit/instrument/misc sprawl.
 
 = 1 + 21 + 1 + 1 = **24**.
 
-## Candle architecture change — NO `candles_1s` base
+## Candle architecture — RAM-FIRST (operator-locked 2026-05-20)
 
-Today the 9 candle matviews sample from a `candles_1s` base table (a
-2-tier cascade). The operator does not want `candles_1s`. Therefore:
+> **Operator lock 2026-05-20 (verbatim):** "keep everything in RAM
+> memory and periodically flush to db ... for trading decision nowhere
+> we can tolerate ... we cannot touch db and db is only for replay and
+> historical purpose."
+>
+> This supersedes the earlier (WRONG) matview proposal. QuestDB
+> materialized views push the candle aggregation **into the database**
+> — that is a DB-on-hot-path violation of `aws-budget.md` rule 12
+> (RAM-first) and operator-charter §C. **NO materialized views. EVER.**
 
-- Each of the 21 candle timeframe tables becomes a QuestDB
-  **materialized view that samples `ticks` directly**
-  (`SAMPLE BY <tf>` with `first/max/min/last` OHLC + `sum` volume).
-- `candles_1s` is **dropped**.
-- The in-memory 29-TF cascade (`tickvault_trading::candles`), the
-  `candles_1s` writer, and the 9 `candles_*_shadow` tables are all
-  **removed** — superseded by direct `ticks`→matview aggregation.
+The candle architecture is RAM-first:
+
+| Stage | Where | Detail |
+|---|---|---|
+| Tick → live bar update | **RAM** | the Rust in-memory multi-timeframe aggregator updates the open bar for all 21 timeframes per tick — O(1), zero-alloc |
+| Bar seal at TF boundary | **RAM** | sealed bar stays in the RAM bar cache (today + yesterday) AND is queued for async flush |
+| Periodic flush | **async cold path** | a background task ILP-writes sealed bars to the 21 plain QuestDB candle tables |
+| Trading decision / indicator read | **RAM ONLY** | reads the RAM bar cache — **never** `SELECT` from QuestDB |
+| Replay / cross-verify / dashboards | QuestDB (cold) | the only consumers of the QuestDB candle tables |
+
+Therefore:
+
+- The 21 QuestDB candle tables are **plain `CREATE TABLE` tables** —
+  the flush sink. **NOT** materialized views.
+- The **in-memory multi-timeframe aggregator is KEPT** as the RAM
+  source of truth — trimmed/extended to exactly the 21 TFs. (Earlier
+  draft said "remove the in-memory cascade" — that was wrong; it is
+  the heart of the RAM-first design and stays.)
+- `candles_1s` is **dropped** — no QuestDB base table, no QuestDB-side
+  aggregation, no cascade-over-QuestDB.
+- The 9 `candles_*_shadow` tables are **dropped** — the 21 plain
+  candle tables ARE the flush targets now, no separate shadow layer.
 - 12 sub-15m timeframes (`candles_2m,3m,4m,6m,7m,8m,9m,10m,11m,12m,13m,14m`)
-  were retired in PR #517 — they are **re-created** as matviews here.
+  retired in PR #517 — re-created here as RAM aggregator timeframes +
+  plain flush tables.
 
 ## DROP — and rip out the writer code, not just the SQL
 
@@ -63,9 +86,11 @@ its `ErrorCode` variant(s), and its ratchet tests.
 
 ## Sequencing (serial PRs, §H — one at a time)
 
-- [ ] **#T1** — candle re-architecture: 21 matviews sampling `ticks`
-  directly (incl. re-creating the 12 sub-15m TFs); drop `candles_1s`,
-  the 9 shadow tables, the in-memory 29-TF cascade + seal writer.
+- [ ] **#T1** — candle re-architecture (RAM-first): 21 **plain**
+  QuestDB candle tables fed by the in-memory aggregator's periodic
+  async flush; KEEP + extend the RAM aggregator to the 21 TFs (incl.
+  re-adding the 12 sub-15m TFs); drop `candles_1s` + the 9 shadow
+  tables + any QuestDB matview chain. NO materialized views.
 - [ ] **#T2** — drop ~20 audit tables + `*_audit_persistence.rs` modules
   + boot DDL + notification/ErrorCode wiring + ratchets.
 - [ ] **#T3** — drop 5 instrument tables + their persistence surface.
@@ -78,4 +103,66 @@ Supersedes the original AWS-lifecycle PR #10 QuestDB-cleanup scope.
 ## Pre-req
 
 PR #722 (IDX_I Quote mode) must merge to `main` first (§H serial
-completion). Then #T1 starts.
+completion). Then #T1 starts. — **DONE: #722 merged 2026-05-20.**
+
+## Column cleanup — audit result (folds into #T1)
+
+Operator directive 2026-05-20: "check what columns are especially
+needed for ticks / candles / historical / option chain from docs
+design only — drop the rest."
+
+Audited against `docs/dhan-ref/03-live-market-feed-websocket.md`
+(Quote packet bytes 8-49 + OI packet code 5),
+`docs/dhan-ref/05-historical-data.md` (columnar OHLCV) and
+`docs/dhan-ref/06-option-chain.md`.
+
+Buckets: **A = Dhan packet/REST field (KEEP)**, **B = identity /
+timestamp infra (KEEP)**, **C = derived / operational EXTRA (DROP)**.
+
+### `ticks` — 25 cols → keep 16, drop 9
+
+| Bucket | Columns |
+|---|---|
+| A (Dhan Quote/OI packet) | `ltp` `open` `high` `low` `close` `volume` `oi` `avg_price` `last_trade_qty` `total_buy_qty` `total_sell_qty` |
+| B (infra) | `segment` `security_id` `exchange_timestamp` `ts` `received_at` |
+| **C — DROP** | `iv` `delta` `gamma` `theta` `vega` `volume_delta` `prev_day_close` `prev_day_oi` `phase` |
+
+`prev_day_close` is redundant — Quote bytes 38-41 (`close`) already
+IS previous-day close per Ticket #5525125. Greeks: indices-only
+universe never carries options on the main feed → the 5 greek
+columns stay empty; greeks live in `option_chain_minute_snapshot`.
+
+### Candle TF tables (plain tables, flushed from the RAM aggregator) — 10 cols
+
+| Bucket | Columns |
+|---|---|
+| A (OHLCV) | `open`=first `high`=max `low`=min `close`=last `volume`=sum `oi`=last |
+| B (infra) | `segment` `security_id` `ts` |
+| keep (verify) | `tick_count`=count — data-quality / cross-verify |
+| **C — DROP** | `iv` `delta` `gamma` `theta` `vega` `volume_cum_day_at_end` `prev_day_close` `prev_day_oi` `phase` `close_pct_from_prev_day` `oi_pct_from_prev_day` `volume_pct_from_prev_day` |
+
+### `historical_candles` — 11 cols → keep 10, drop 1
+
+| Bucket | Columns |
+|---|---|
+| A (Dhan REST OHLCV) | `open` `high` `low` `close` `volume` `oi` |
+| B (infra) | `segment` `timeframe` `security_id` `ts` |
+| **C — DROP** | `candles_source` |
+
+### `option_chain_minute_snapshot` — 26 cols → keep 24, drop 2
+
+| Bucket | Columns |
+|---|---|
+| A (Dhan option-chain) | `strike` `ce_or_pe` `last_price` `average_price` `oi` `previous_oi` `volume` `previous_volume` `previous_close_price` `top_bid_price` `top_bid_quantity` `top_ask_price` `top_ask_quantity` `implied_volatility` `greek_delta` `greek_theta` `greek_gamma` `greek_vega` |
+| B (infra) | `ts` `trading_date_ist` `underlying_symbol` `underlying_security_id` `exchange_segment` `security_id` |
+| **C — DROP** | `cache_age_used_secs` `fetch_outcome` |
+
+### Open decision (operator must confirm)
+
+The 5 greek columns on `ticks` + candle tables: earlier the operator
+said "track ltp and all greeks". But under the indices-only locked
+universe NO options ride the main feed, so those columns are
+always empty. Greeks of options ARE tracked in
+`option_chain_minute_snapshot`. Recommendation: DROP greeks from
+`ticks` + candles; keep greeks ONLY in the option-chain table.
+Needs explicit operator yes before the column-drop lands in #T1.


### PR DESCRIPTION
## Summary

Documentation-only PR — one clean commit. Extends the
operator-approved QuestDB table-cleanup plan
(`.claude/plans/active-plan-table-cleanup.md`) with two additions.

Replaces #723, which became un-mergeable (`dirty`) — that branch
carried a stale pre-squash copy of the #722 commit. This branch is a
single clean commit on top of `main`; the only changed file is the
plan doc.

## What this adds to the plan

- **Column-cleanup audit** — per-table keep/drop list checked against
  the Dhan reference docs (Quote/OI packet, REST OHLCV, option-chain):
  - `ticks` — keep 16, drop 9 (greeks, `volume_delta`,
    `prev_day_close`, `prev_day_oi`, `phase`)
  - candle TF tables — 10 columns (OHLCV + infra + `tick_count`)
  - `historical_candles` — keep 10, drop `candles_source`
  - `option_chain_minute_snapshot` — keep 24, drop `cache_age_used_secs`
    + `fetch_outcome`
- **RAM-first candle architecture correction (operator-locked
  2026-05-20)** — the 21 candle timeframe tables are **plain QuestDB
  tables** fed by the in-memory aggregator's periodic async flush, NOT
  materialized views. QuestDB materialized views would push candle
  aggregation into the database — a DB-on-hot-path violation of
  `aws-budget.md` rule 12 (RAM-first) and operator-charter §C.
  Trading decisions read candles from RAM only; QuestDB candle tables
  are cold-path (replay / cross-verify / dashboards).

## Open decision (flagged in the plan)

The 5 greek columns on `ticks`/candles are always empty under the
indices-only locked universe (no options on the main feed). Plan
recommends dropping them and keeping greeks only in the option-chain
table — needs explicit operator confirmation before #T1.

## Honest envelope

No production code — documentation only. The 15-row / 7-row guarantee
matrices and adversarial 3-agent review apply to the implementation
sub-PRs #T1–#T5, not to this plan-recording PR.

## Test plan

- [x] No `.rs` files changed — no test impact
- [x] Pre-commit fast gate green
- [ ] CI green

https://claude.ai/code/session_012emMMx3SnMUHdURNmx8cQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012emMMx3SnMUHdURNmx8cQZ)_