### PR TITLE
security(ci): replace no-op secret-scan job with a real diff scanner

### DIFF
--- a/.claude/hooks/secret-scanner.sh
+++ b/.claude/hooks/secret-scanner.sh
@@ -56,8 +56,12 @@ scan_secret() {
       continue
     fi
 
+    # -E (ERE) is required: several patterns use {N}/{N,} quantifiers which
+    # are literal text under plain grep (BRE) and would never match — e.g.
+    # the AWS Access Key ID pattern AKIA[0-9A-Z]{16}.
     local matches
-    matches=$(grep -n -i "$pattern" "$full_path" 2>/dev/null \
+    matches=$(grep -n -i -E "$pattern" "$full_path" 2>/dev/null \
+      | grep -v 'secret-scan-ignore' \
       | grep -v '// test' \
       | grep -v '/// ' \
       | grep -v '#\[doc' \
@@ -118,7 +122,10 @@ scan_secret 'password.*=.*"[^"]' 'Hardcoded password'
 scan_secret 'passwd.*=.*"[^"]' 'Hardcoded password'
 scan_secret 'private[_-]key.*=.*"' 'Hardcoded private key'
 scan_secret 'BEGIN.*PRIVATE KEY' 'Embedded private key'
-scan_secret 'bearer.*[A-Za-z0-9_-]{20,}' 'Hardcoded bearer token'
+# Require a space or quote after "bearer" so identifiers like
+# `bearer_token_path` do not false-positive — only a real token value
+# (`Bearer eyJ...`, `bearer = "..."`) follows a space/quote.
+scan_secret 'bearer[ "][A-Za-z0-9_/+.=-]{20,}' 'Hardcoded bearer token'
 
 # Telegram bot tokens
 scan_secret 'bot[0-9]{8,}:' 'Hardcoded Telegram bot token'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,6 +10,36 @@ jobs:
   secret-scan:
     name: "Secret Scan"
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 3
     steps:
-      - run: echo "Verified locally — 0 .env files, 0 hardcoded secrets"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history so the push / PR diff range can be computed.
+          fetch-depth: 0
+      - name: Scan changed files for hardcoded secrets
+        # Runs the project's own secret scanner (the same script the local
+        # pre-commit gate uses) over the files changed in this push / PR.
+        # This makes the CI gate identical in scope to the local hook, so a
+        # commit pushed with the local hook bypassed (`--no-verify`) is still
+        # caught server-side. The scanner exits 2 on a hit, which fails the job.
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.base_ref }}"
+            git fetch --quiet origin "$base_ref"
+            changed=$(git diff --name-only --diff-filter=ACMR "origin/${base_ref}...HEAD")
+          else
+            before="${{ github.event.before }}"
+            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              changed=$(git diff --name-only --diff-filter=ACMR HEAD~1 HEAD 2>/dev/null || git ls-files)
+            else
+              changed=$(git diff --name-only --diff-filter=ACMR "$before" HEAD)
+            fi
+          fi
+          if [ -z "$changed" ]; then
+            echo "No changed files to scan."
+            exit 0
+          fi
+          echo "Scanning changed files:"
+          echo "$changed"
+          bash .claude/hooks/secret-scanner.sh "$GITHUB_WORKSPACE" "$changed"

--- a/scripts/docker-down.sh
+++ b/scripts/docker-down.sh
@@ -11,9 +11,9 @@
 set -euo pipefail
 
 export TV_QUESTDB_PG_USER="${TV_QUESTDB_PG_USER:-_teardown}"
-export TV_QUESTDB_PG_PASSWORD="${TV_QUESTDB_PG_PASSWORD:-_teardown}"
+export TV_QUESTDB_PG_PASSWORD="${TV_QUESTDB_PG_PASSWORD:-_teardown}" # secret-scan-ignore: compose-parse placeholder, never a real secret
 export TV_GRAFANA_ADMIN_USER="${TV_GRAFANA_ADMIN_USER:-_teardown}"
-export TV_GRAFANA_ADMIN_PASSWORD="${TV_GRAFANA_ADMIN_PASSWORD:-_teardown}"
+export TV_GRAFANA_ADMIN_PASSWORD="${TV_GRAFANA_ADMIN_PASSWORD:-_teardown}" # secret-scan-ignore: compose-parse placeholder, never a real secret
 
 docker compose -f deploy/docker/docker-compose.yml down --remove-orphans
 echo ""


### PR DESCRIPTION
## Summary

Proof-audit **gap #1**. The CI "Secret Scan" job was a single
`echo "Verified locally"` step — it scanned nothing and was green by
construction (a "cardboard cut-out" gate). This makes it real.

## Changes

| File | Change |
|---|---|
| `.github/workflows/secret-scan.yml` | Job now runs the project's own scanner (`.claude/hooks/secret-scanner.sh`) over the push / PR diff — same scope as the local pre-commit gate, so a commit pushed with the local hook bypassed (`--no-verify`) is caught server-side. Scanner exits 2 on a hit → job fails. |
| `.claude/hooks/secret-scanner.sh` | **Bug fix:** scanner used plain `grep` (BRE), so the `{16}` / `{10,}` / `{20,}` / `{8,}` quantifiers in the AWS-key, Dhan-client-id, bearer-token and Telegram-token patterns were literal text and **never matched**. Switched to `grep -E`. |
| `.claude/hooks/secret-scanner.sh` | Tightened the bearer pattern to require a space/quote after `bearer` so identifiers like `bearer_token_path` no longer false-positive. |
| `.claude/hooks/secret-scanner.sh` | Added a `secret-scan-ignore` inline-comment exclusion — a documented escape hatch for genuine false positives instead of forcing a hook bypass. |
| `scripts/docker-down.sh` | Annotated the two `${VAR:-_teardown}` compose-parse placeholders with `secret-scan-ignore` (the file header already documents these are never real values). |

## Verification

- ✅ Negative test — fixed hook **catches** a fake AWS Access Key ID (`AKIA…`) and a `Bearer eyJ…` token (exit 2). The old BRE hook missed both.
- ✅ False-positive — `bearer_token_path` in `secret_manager.rs` no longer trips.
- ✅ Full-tree scan with the fixed hook — **clean** (the 2 `docker-down.sh` placeholders handled by `secret-scan-ignore`).
- ✅ This PR's own diff scans clean.

## Honest envelope

This is a regex-based scanner — it catches the credential *shapes*
listed in the hook (AWS keys, JWTs, private keys, Telegram tokens, DB
connection strings, hardcoded api-key/secret/password). It is not an
entropy scanner; a novel high-entropy secret in an unrecognised shape
would pass. It is now a **real** gate identical in scope to the local
pre-commit hook — the no-op `echo` is gone.

## Test plan

- [x] Negative + positive scans verified locally
- [x] Pre-commit gate green
- [ ] CI green (this PR's "Secret Scan" job now does real work)

https://claude.ai/code/session_012emMMx3SnMUHdURNmx8cQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012emMMx3SnMUHdURNmx8cQZ)_