### PR TITLE
perf(memory): rightsize tick rescue ring 5M → 100K (frees ~980 MB)

### DIFF
--- a/.claude/rules/project/aws-budget.md
+++ b/.claude/rules/project/aws-budget.md
@@ -66,7 +66,7 @@ S3 archival exports detached partitions before removal (Plan Item 7, needs aws-s
      - Valkey: 512MB
      - Prometheus: 384MB (7d retention)
      - Alertmanager: 256MB (KEPT — independent process for app-crash alerts)
-   - **Host process — Tickvault app: 2.0 GB** (Wave 7-A4 BUMP: today's + yesterday's sealed bars in RAM + indicator state + 5M tick rescue ring; RAM-only hot path for trading decisions)
+   - **Host process — Tickvault app: 2.0 GB cap** (today's + yesterday's sealed bars in RAM + indicator state + 100K tick rescue ring; RAM-only hot path for trading decisions — actual use ~700 MB after the 2026-05-20 ring trim)
    - **OS + filesystem cache: 600 MB** (tracing log writes, audit flush bursts, kernel TCP buffers)
    - **Total used: ~6.0 GB**
    - **Headroom (HARD FLOOR): 2.0 GB** — Linux kswapd needs ≥1 GB free; 2 GB prevents OOM under bursts
@@ -120,7 +120,7 @@ S3 archival exports detached partitions before removal (Plan Item 7, needs aws-s
 
 | Component | RAM | Type | Notes |
 |---|---|---|---|
-| **Tickvault app** | **2.0 GB** | **Host process** | **Today + Yesterday sealed bars in RAM + indicator state + 5M rescue ring + RAM-only hot path** |
+| **Tickvault app** | **2.0 GB cap** | **Host process** | **Today + Yesterday sealed bars in RAM + indicator state + 100K rescue ring + RAM-only hot path (actual ~700 MB)** |
 | QuestDB | 1.5 GB | Docker | Time-series DB (cold-path persistence + cross-verify) |
 | Grafana | 768 MB | Docker | Dashboards |
 | **OS + FS cache** | **600 MB** | **Host kernel** | **tracing log writes + audit bursts** |
@@ -146,10 +146,16 @@ S3 archival exports detached partitions before removal (Plan Item 7, needs aws-s
 | Tracing + log writer queues | bounded | 5 MB |
 | Tokio runtime + 4 thread stacks | 4 × 2 MB + internal | 20 MB |
 | **WORKING SET SUBTOTAL** | | **~540 MB** |
-| **Rescue ring buffer (5M ticks × 200 bytes)** | 5M × 200 | **1.0 GB** |
-| Heap fragmentation (~25% w/ jemalloc tuning) | | 200 MB |
-| **APP TOTAL** | | **~1.74 GB** |
-| **App safety margin inside 2 GB cap** | | **~260 MB** ✅ |
+| **Rescue ring buffer (100K ticks × 200 bytes)** | 100K × 200 | **20 MB** |
+| Heap fragmentation (~25% w/ jemalloc tuning) | | 140 MB |
+| **APP TOTAL** | | **~700 MB** |
+| **App safety margin inside 2 GB cap** | | **~1.35 GB** ✅ |
+
+> **2026-05-20 — rescue ring rightsized 5M → 100K.** The universe
+> narrowed to 4 IDX_I SIDs (~15-20 tps); a 5M ring (1.0 GB) buffered
+> ~130 hours for a feed that needs minutes. Trimmed to 100K (~20 MB),
+> freeing ~980 MB. The 2.0 GB app cap is now generously loose — a full
+> re-budget is a separate follow-up.
 
 ### Why 2 GB Host Headroom Is Non-Negotiable
 
@@ -240,7 +246,7 @@ S3 archival exports detached partitions before removal (Plan Item 7, needs aws-s
 | Dashboards | Grafana operator-health single page | ✅ KEEP |
 | HTTP gateway | AWS ALB (free tier) | ✅ replaces Traefik |
 | Distributed tracing | CloudWatch X-Ray (optional, free tier 100K traces/mo) | ⚠️ optional |
-| Zero tick loss envelope | Rescue ring 5M ticks (Wave 7-A4) | ✅ 30 sec absorbed |
+| Zero tick loss envelope | Rescue ring 100K ticks (4-SID rightsized) | ✅ 60 sec+ absorbed at 4-SID rates |
 | **RAM-first hot path** | **today + yesterday sealed bars in RAM** | ✅ Wave 7-A4 locks |
 
 ## Common Runtime / Dynamic / Scalable / Automated Charter (mandatory)
@@ -267,11 +273,11 @@ notified on Telegram, no manual inputs."
 
 | Change | File | Status |
 |---|---|---|
-| `TICK_BUFFER_CAPACITY: 2_000_000` → `5_000_000` | `crates/common/src/constants.rs` | ⏳ pending Mac commit (sandbox cargo broken) |
+| `TICK_BUFFER_CAPACITY` rightsized 5M → 100K (4-SID universe) | `crates/common/src/constants.rs` | ✅ done 2026-05-20 |
 | Today + yesterday sealed bar cache implementation | `crates/trading/src/indicator/bar_cache.rs` (new) | ⏳ pending Wave 6 sub-PR #1 |
 | Boot-time rehydration of today's bars | `crates/core/src/boot/historical_loader.rs` (new) | ⏳ pending Wave 6 sub-PR #2 |
 | Banned-pattern: SELECT from hot path | `.claude/hooks/banned-pattern-scanner.sh` | ⏳ pending Mac commit |
-| DHAT zero-alloc verify with 5M ring + bar cache | `crates/core/tests/dhat_*.rs` | ⏳ pending |
+| DHAT zero-alloc verify with 100K ring + bar cache | `crates/core/tests/dhat_*.rs` | ⏳ pending |
 | Adversarial 3-agent review | hot-path + security + bug-hunt | ⏳ pending Wave 6 sub-PR rollout |
 
 ## Trigger

--- a/.claude/rules/project/operator-charter-forever.md
+++ b/.claude/rules/project/operator-charter-forever.md
@@ -89,7 +89,7 @@ The `.mcp.json` `tickvault-logs` entry is loaded automatically — same MCP tool
 
 | Demand | Honest envelope (the truth) | Per-item proof |
 |---|---|---|
-| Zero ticks lost | Bounded zero loss inside chaos envelope: 5M-tick rescue ring → NDJSON spill → DLQ NDJSON catches every payload | item must not introduce new tick-drop path |
+| Zero ticks lost | Bounded zero loss inside chaos envelope: 100K-tick rescue ring → NDJSON spill → DLQ NDJSON catches every payload | item must not introduce new tick-drop path |
 | WS never disconnects | SEBI 24h JWT forces ≥1 reconnect/day BY LAW. DETECT ≤5s, reconnect with `SubscribeRxGuard`, sleep-until-open post-close. | item must not break `SubscribeRxGuard` or pool watchdog |
 | Never slow/locked/hanged | DHAT ≤4 alloc blocks/8KB across 10K calls; Criterion p99 ≤100ns enqueue; tick-gap >30s coalesced Telegram; core_affinity Core 0 | item must not add hot-path allocation |
 | QuestDB never fails | ABSORB via 3-tier rescue→spill→DLQ + schema self-heal via `ALTER ADD COLUMN IF NOT EXISTS` | item must not break self-heal |
@@ -140,7 +140,7 @@ When ANY PR body / commit message / Telegram message / docs writes "100% guarant
 
 > "100% inside the tested envelope, with ratcheted regression coverage:
 > ≤60s QuestDB outage absorbed by rescue→spill→DLQ;
-> ≤5,000,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`, ratcheted by `zero_tick_loss_alert_guard.rs`);
+> ≤100,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`, ratcheted by `zero_tick_loss_alert_guard.rs`);
 > bench-gated O(1) hot path;
 > composite-key uniqueness;
 > chaos-tested 65h Fri 16:00 IST → Mon 09:00 IST weekend sleep/wake.

--- a/.claude/rules/project/per-wave-guarantee-matrix.md
+++ b/.claude/rules/project/per-wave-guarantee-matrix.md
@@ -61,7 +61,7 @@ qualified exactly:
 
 > "100% inside the tested envelope, with ratcheted regression coverage:
 > ≤60s QuestDB outage absorbed by rescue→spill→DLQ;
-> ≤5,000,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`,
+> ≤100,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`,
 > `crates/common/src/constants.rs`, ratcheted by
 > `crates/storage/tests/zero_tick_loss_alert_guard.rs`); bench-gated
 > O(1) hot path; composite-key uniqueness;

--- a/.claude/rules/project/wave-4-shared-preamble.md
+++ b/.claude/rules/project/wave-4-shared-preamble.md
@@ -233,7 +233,7 @@ When the PR description quotes "100% guarantee", it MUST be phrased exactly:
 
 > "100% inside the tested envelope, with ratcheted regression coverage:
 > <= 60s QuestDB outage absorbed by rescue->spill->DLQ;
-> <= 5,000,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`,
+> <= 100,000-tick ring buffer capacity (constant `TICK_BUFFER_CAPACITY`,
 > `crates/common/src/constants.rs`, ratcheted by
 > `crates/storage/tests/zero_tick_loss_alert_guard.rs`); bench-gated
 > O(1) hot path; composite-key uniqueness;

--- a/.claude/rules/project/z-plus-defense-doctrine.md
+++ b/.claude/rules/project/z-plus-defense-doctrine.md
@@ -182,7 +182,7 @@ When any PR / Telegram / commit body says "100% guarantee", it MUST be qualified
 > "100% inside the tested envelope, with ratcheted regression coverage: <list specific envelope bounds with constants + ratchet test files>. Beyond the envelope, <fallback mechanism> catches every payload as recoverable text."
 
 **Examples (good):**
-- "100% inside the tested envelope: ≤80s soft-restart absorbed by 5M-tick rescue ring (constant `TICK_BUFFER_CAPACITY`, ratcheted by `zero_tick_loss_alert_guard.rs`)"
+- "100% inside the tested envelope: ≤80s soft-restart absorbed by 100K-tick rescue ring (constant `TICK_BUFFER_CAPACITY`, ratcheted by `zero_tick_loss_alert_guard.rs`)"
 - "100% inside the tested envelope: 60s QuestDB outage absorbed by 3-tier rescue→spill→DLQ"
 
 **Examples (rejected):**

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -1532,46 +1532,37 @@ pub const TICK_FLUSH_INTERVAL_MS: u64 = 1000;
 /// Tick ring buffer capacity for QuestDB outage resilience.
 /// Holds ticks in memory when QuestDB is down, drains on recovery.
 ///
-/// Sized for 25K instruments (5 WS connections × 5,000 each):
-/// - 2,000,000 ticks × ~112 bytes = ~224 MB RAM (pre-allocated at boot
-///   via `VecDeque::with_capacity` in `tick_persistence.rs`)
-/// - At 10K ticks/sec (realistic peak) = 200 seconds (3m20s) before disk spill
-/// - At 25K ticks/sec (extreme peak) = 80 seconds before disk spill
-/// - Full-day QuestDB outage: disk spill handles overflow (~23 GB for 10K/sec)
+/// **Rightsized 2026-05-20 for the 4-SID indices-only universe.**
+/// The live universe is 4 IDX_I SIDs (NIFTY, BANKNIFTY, SENSEX,
+/// INDIA VIX) in Quote mode — a tick rate of ~10-20/sec, not the
+/// ~5,000/sec of the old 25K-instrument universe the 5M ring was
+/// sized for.
 ///
-/// **Memory budget audit (2026-05-03 PR #452):** AWS c7i.xlarge has
-/// 8 GB total. Per `aws-budget.md` the Docker containers consume
-/// 7.4 GB (QuestDB 4G + Valkey 1G + Prometheus 512M + Grafana 1G +
-/// Alertmanager 256M + Traefik 512M + Valkey-exporter 128M),
-/// leaving ~600 MB for OS + tickvault binary. The 224 MB ring fits
-/// comfortably with ~376 MB margin for the rest of the binary + OS.
+/// - 100,000 ticks × ~200 bytes = ~20 MB RAM (pre-allocated at boot
+///   via `VecDeque::with_capacity` in `tick_persistence.rs`).
+/// - At a sustained ~20 ticks/sec = ~83 minutes before disk spill.
+/// - At an extreme ~400 ticks/sec burst = ~4 minutes before spill.
+/// - Both far exceed the ≤60-second QuestDB-outage SLA; the disk
+///   spill + DLQ still backstop any overflow beyond that.
 ///
-/// **Why 2M (not 4.5M)**: operator-confirmed cap on c7i.xlarge —
-/// 4.5M / 504 MB ring would leave only ~96 MB for OS + rest of
-/// binary, too tight. Operator chose Option B (2M / 224 MB) over
-/// Option A (1M / 112 MB) for higher outage-survival headroom while
-/// staying within the c7i.xlarge envelope. Bumping to c7i.2xlarge
-/// (16 GB) would cost an extra ₹2,478/mo per `aws-budget.md` and
-/// is explicitly out of scope per "NEVER provision a larger
-/// instance than c7i.xlarge without Parthiban's approval".
-///
-/// **Bump history:**
-/// - 600K → 2M (PR #452, 2026-05-03): operator-spec'd extreme
-///   memory pressure handling. 233% capacity increase. ~3.3× outage
-///   survival window before disk spill kicks in.
-/// - 2M → 5M (Wave 7-A4, 2026-05-11): RAM-first hot-path hardening
-///   per `.claude/rules/project/aws-budget.md` § "Host Memory Budget
-///   — Wave 7-A4 Locked". 5M × ~200B = ~1.0 GB pre-allocated VecDeque,
-///   absorbed inside the app's 2 GB allocation. Absorbs ≤30 sec
-///   QuestDB outage at peak burst (~99K seals/min minute boundary
-///   spike), or ~3 hours at sustained ~470 ticks/sec.
-pub const TICK_BUFFER_CAPACITY: usize = 5_000_000;
+/// **Trim history:**
+/// - 600K → 2M (PR #452, 2026-05-03): extreme-memory-pressure spec
+///   for the old large universe.
+/// - 2M → 5M (Wave 7-A4, 2026-05-11): RAM-first hardening, ~1.0 GB
+///   pre-allocated, sized for the old ~5,000-tick/sec workload.
+/// - 5M → 100K (2026-05-20): the universe narrowed to 4 IDX_I SIDs;
+///   a 5M ring (~1 GB) buffered ~130 hours for a feed that needs
+///   minutes. Trimmed to 100K — frees ~980 MB RAM on the 8 GB host.
+///   Conservative resize: spill + DLQ retained. The deeper
+///   simplification (10K + drop spill/DLQ) is tracked in
+///   `docs/architecture/resilience-simplification-4-sids.md`.
+pub const TICK_BUFFER_CAPACITY: usize = 100_000;
 
 /// High watermark threshold for tick ring buffer (80% of capacity).
 /// When buffer occupancy exceeds this, a WARN-level alert fires once
 /// to signal imminent disk spill. Triggers Telegram via Loki ERROR rule.
-/// 80% of 5,000,000 = 4,000,000 ticks.
-pub const TICK_BUFFER_HIGH_WATERMARK: usize = TICK_BUFFER_CAPACITY * 4 / 5; // 4,000,000
+/// 80% of 100,000 = 80,000 ticks.
+pub const TICK_BUFFER_HIGH_WATERMARK: usize = TICK_BUFFER_CAPACITY * 4 / 5; // 80,000
 
 /// Minimum free disk space (bytes) to log a warning before spill write.
 /// 100 MB — below this, a WARN fires on each spill open to alert operator

--- a/crates/common/tests/wave4_section8_wording_guard.rs
+++ b/crates/common/tests/wave4_section8_wording_guard.rs
@@ -12,14 +12,16 @@
 //! handling. Wording in `wave-4-shared-preamble.md` + `per-wave-guarantee-matrix.md`
 //! updated to "2,000,000-tick" in tandem.
 //!
-//! 2026-05-11 (Wave 7-A4): rescue ring capacity bumped 2M → 5M (~1.0 GB
-//! pre-allocated VecDeque) per RAM-first hot-path hardening spec in
-//! `.claude/rules/project/aws-budget.md` § "Host Memory Budget — Wave
-//! 7-A4 Locked". Wording in both rule files updated to "5,000,000-tick"
-//! in tandem.
+//! 2026-05-11 (Wave 7-A4): rescue ring capacity bumped 2M → 5M for the
+//! old large universe.
+//!
+//! 2026-05-20: rescue ring rightsized 5M → 100K (~20 MB pre-allocated
+//! VecDeque) — the universe narrowed to 4 IDX_I SIDs (~15-20 tps), so
+//! a 5M ring buffered ~130 hours for a feed that needs minutes.
+//! Wording in both rule files updated to "100,000-tick" in tandem.
 //!
 //! After investigation:
-//! - `TICK_BUFFER_CAPACITY = 5_000_000` exists in
+//! - `TICK_BUFFER_CAPACITY = 100_000` exists in
 //!   `crates/common/src/constants.rs` and is ratcheted by
 //!   `crates/storage/tests/zero_tick_loss_alert_guard.rs`.
 //! - The 65h Fri 16:00 → Mon 09:00 IST weekend sleep/wake test
@@ -61,17 +63,17 @@ fn section8_does_not_claim_unproven_70h_chaos() {
 }
 
 #[test]
-fn section8_keeps_2m_rescue_ring_claim_with_evidence_pointer() {
+fn section8_keeps_rescue_ring_claim_with_evidence_pointer() {
     for (label, path) in [("preamble", PREAMBLE_PATH), ("matrix", MATRIX_PATH)] {
         let text = read(path);
-        // PR #452 (2026-05-03): rescue ring bumped 600K → 2M. The
-        // claim must cite the constant + ratchet test so future
-        // readers can verify the proof in one grep.
+        // 2026-05-20: rescue ring rightsized 5M → 100K for the 4-SID
+        // indices-only universe. The claim must cite the constant +
+        // ratchet test so future readers can verify the proof.
         assert!(
-            text.contains("5,000,000-tick ring buffer capacity"),
-            "{label} ({path}) must keep the proven 5,000,000-tick ring \
-             buffer capacity claim (Wave 7-A4 bumped 2M → 5M for \
-             RAM-first hot-path hardening per aws-budget.md)."
+            text.contains("100,000-tick ring buffer capacity"),
+            "{label} ({path}) must keep the proven 100,000-tick ring \
+             buffer capacity claim (rightsized 5M → 100K 2026-05-20 for \
+             the 4-SID indices-only universe per aws-budget.md)."
         );
         assert!(
             text.contains("`TICK_BUFFER_CAPACITY`"),
@@ -81,7 +83,7 @@ fn section8_keeps_2m_rescue_ring_claim_with_evidence_pointer() {
         assert!(
             text.contains("zero_tick_loss_alert_guard.rs"),
             "{label} ({path}) must cite the ratchet test that pins the \
-             2,000,000 value."
+             100,000 value."
         );
     }
 }

--- a/crates/storage/tests/chaos_burst_indices_only.rs
+++ b/crates/storage/tests/chaos_burst_indices_only.rs
@@ -1,34 +1,29 @@
-//! Wave 5 Item 11 — burst-defence chaos test.
+//! Burst-defence chaos test — 4-SID indices-only scope.
 //!
-//! Pins the envelope claim from `active-plan-wave-5-indices-only.md`:
+//! Pins the rescue-ring envelope for the LOCKED 4-IDX_I universe
+//! (NIFTY=13, BANKNIFTY=25, SENSEX=51, INDIA VIX=21).
 //!
-//! > "We CAN promise: under the verified 11,018-instrument indices-only
-//! > scope at observed peak rates (≤110K tps theoretical, typically ~30K
-//! > tps), the chain absorbs without drop. Item 11 chaos test pins this
-//! > envelope."
+//! **Rewritten 2026-05-20** when `TICK_BUFFER_CAPACITY` was rightsized
+//! 5M → 100K. The old assertions were pinned to the retired Wave-5
+//! 11,018-instrument universe (~110K tps) and no longer reflected the
+//! live scope — a 4-SID feed runs at ~15-20 tps, not 110,000.
 //!
 //! What this test exercises:
-//! - `TICK_BUFFER_CAPACITY` (rescue ring) is at least 600K rows — enough
-//!   to absorb a 5-second 110K-tps burst without overflow even if the
-//!   QuestDB writer is fully blocked.
-//! - `TICK_BUFFER_HIGH_WATERMARK` is at 80% of capacity — alert fires
-//!   BEFORE catastrophic fill.
-//! - `MAX_TOTAL_SUBSCRIPTIONS` (25K) and `MAX_TOTAL_SUBSCRIPTIONS_TARGET`
-//!   (24.5K) bracket the indices-only universe (~11K) with comfortable
-//!   headroom — capacity-overflow path never fires.
-//! - A synthetic 200K-row VecDeque (the rescue ring's underlying type)
-//!   absorbs without panic — bounded memory, FIFO eviction.
-//! - The Wave 5 envelope numbers (11,018 instruments × ~10 pkts/sec ≈
-//!   ~110K tps) fit comfortably under the 2M ring capacity (PR #452
-//!   bumped from 600K, 2026-05-03) at >18s QuestDB outage tolerance.
+//! - `TICK_BUFFER_CAPACITY` (rescue ring) absorbs a full 60-second
+//!   QuestDB outage at the 4-SID extreme-peak tick rate without ring
+//!   overflow, with ≥2× headroom.
+//! - `TICK_BUFFER_HIGH_WATERMARK` sits at 80% of capacity — the WARN
+//!   fires well before catastrophic fill.
+//! - `MAX_TOTAL_SUBSCRIPTIONS` (25K) / `MAX_TOTAL_SUBSCRIPTIONS_TARGET`
+//!   (24.5K) bracket the 4-SID universe with vast headroom.
+//! - A synthetic VecDeque (the rescue ring's underlying type) absorbs
+//!   a full-ring burst without panic — bounded memory, FIFO eviction.
 //!
 //! What this test does NOT do:
-//! - Spin up a real QuestDB / parser / WS pipeline. The full burst test
-//!   requires Docker QuestDB + replay harness — see
-//!   `chaos_questdb_full_session.rs` for the integration path.
-//! - Promise "no drops ever". The honest envelope acknowledges that
-//!   beyond ~2M queued rows + spill capacity + DLQ, OS resources can
-//!   exhaust. PROC-01 + RESOURCE-01..03 cover those.
+//! - Spin up a real QuestDB / parser / WS pipeline (see
+//!   `chaos_questdb_full_session.rs` for the integration path).
+//! - Promise "no drops ever". Beyond the ring + spill + DLQ, OS
+//!   resources can exhaust — PROC-01 + RESOURCE-01..03 cover those.
 //!
 //! Run cost: ~10 ms. No Docker, no network, no root.
 
@@ -41,75 +36,68 @@ use tickvault_common::constants::{
     TICK_BUFFER_HIGH_WATERMARK,
 };
 
-/// Wave 5 universe size confirmed live 2026-04-25 against the planner
-/// output: 3 IDX_I + 26 display + 216 NSE_EQ + 2,037 index F&O +
-/// 22,042 stock F&O = 24,324 (pre-Item-2). Indices-only drops the stock
-/// F&O block, leaving 11,018 instruments. The envelope claim assumes
-/// peak inflow at the IDX_I + index F&O + NSE_EQ universe.
-const WAVE_5_INDICES_ONLY_INSTRUMENT_COUNT: usize = 11_018;
+/// The LOCKED live universe: 4 IDX_I SIDs per
+/// `crates/common/src/locked_universe.rs`.
+const INDICES_ONLY_INSTRUMENT_COUNT: usize = 4;
 
-/// Conservative peak inflow assumption per `active-plan-wave-5-indices-only.md`:
-/// 11,018 instruments × 10 packets/sec/instrument = ~110,180 tps.
-const WAVE_5_PEAK_TPS: usize = 110_180;
+/// Conservative extreme-peak inflow for the 4 IDX_I SIDs in Quote
+/// mode: 4 indices × ~100 packets/sec/index = ~400 tps. The realistic
+/// average is ~15-20 tps; 400 is a deliberate over-estimate so the
+/// envelope claim holds under volatility bursts.
+const INDICES_ONLY_PEAK_TPS: usize = 400;
 
-/// Worst-case QuestDB outage the rescue ring should absorb without
-/// dropping a single row, per the plan's "≤60s outage absorbed" SLA.
-/// Result: 110,180 × 5 = 550,900 ticks queued at 5-second outage; the
-/// 2M ring (PR #452, was 600K) covers it with ~1.4M headroom.
-const WAVE_5_QUESTDB_OUTAGE_TOLERANCE_SECS: usize = 5;
+/// The QuestDB-outage SLA the rescue ring must absorb without dropping
+/// a single row: 60 seconds. 400 tps × 60s = 24,000 ticks queued — the
+/// 100K ring covers it with ~76K headroom.
+const QUESTDB_OUTAGE_SLA_SECS: usize = 60;
 
 #[test]
 #[allow(
     clippy::assertions_on_constants,
     reason = "compile-time constant ratchet — assertion IS the test"
 )]
-fn test_chaos_burst_envelope_constants_match_wave_5_plan() {
-    // The plan's hard cap.
+fn test_chaos_burst_envelope_constants_match_indices_only_scope() {
     assert_eq!(
         MAX_TOTAL_SUBSCRIPTIONS, 25_000,
-        "Wave 5 plan capacity hard cap pinned at 25,000 — change requires \
-         updating plan + scenarios table"
+        "capacity hard cap pinned at 25,000 — change requires updating \
+         the plan + scenarios table"
     );
     assert!(
         MAX_TOTAL_SUBSCRIPTIONS_TARGET < MAX_TOTAL_SUBSCRIPTIONS,
-        "target must stay below hard cap so the warn-threshold gauge fires \
-         BEFORE Dhan-side rejection"
+        "target must stay below hard cap so the warn-threshold gauge \
+         fires BEFORE Dhan-side rejection"
     );
-    // The Wave-5 universe must fit comfortably under the warn target.
     assert!(
-        WAVE_5_INDICES_ONLY_INSTRUMENT_COUNT < MAX_TOTAL_SUBSCRIPTIONS_TARGET,
-        "indices-only universe ({}) must fit under target ({})",
-        WAVE_5_INDICES_ONLY_INSTRUMENT_COUNT,
+        INDICES_ONLY_INSTRUMENT_COUNT < MAX_TOTAL_SUBSCRIPTIONS_TARGET,
+        "4-SID universe ({}) must fit under target ({})",
+        INDICES_ONLY_INSTRUMENT_COUNT,
         MAX_TOTAL_SUBSCRIPTIONS_TARGET
     );
 }
 
 #[test]
-fn test_chaos_burst_rescue_ring_absorbs_5s_questdb_outage_at_peak_tps() {
-    let queued_at_5s = WAVE_5_PEAK_TPS
-        .checked_mul(WAVE_5_QUESTDB_OUTAGE_TOLERANCE_SECS)
+fn test_chaos_burst_rescue_ring_absorbs_60s_questdb_outage_at_peak_tps() {
+    let queued_at_sla = INDICES_ONLY_PEAK_TPS
+        .checked_mul(QUESTDB_OUTAGE_SLA_SECS)
         .expect("constants overflow");
     assert!(
-        queued_at_5s <= TICK_BUFFER_CAPACITY,
-        "Wave 5 envelope claim: ≤{}s QuestDB outage at peak {} tps must \
+        queued_at_sla <= TICK_BUFFER_CAPACITY,
+        "envelope claim: a {}s QuestDB outage at extreme peak {} tps must \
          absorb without ring overflow. queued={}, ring={}",
-        WAVE_5_QUESTDB_OUTAGE_TOLERANCE_SECS,
-        WAVE_5_PEAK_TPS,
-        queued_at_5s,
+        QUESTDB_OUTAGE_SLA_SECS,
+        INDICES_ONLY_PEAK_TPS,
+        queued_at_sla,
         TICK_BUFFER_CAPACITY
     );
-
-    // Headroom should be at least 1 second of inflow — ensures we don't
-    // fill the ring exactly at the SLA boundary. (~50K headroom for the
-    // current parameters.)
-    let headroom = TICK_BUFFER_CAPACITY - queued_at_5s;
+    // Headroom past the SLA boundary: the ring must keep at least one
+    // more full SLA-window burst in reserve beyond the 60s SLA.
+    let headroom = TICK_BUFFER_CAPACITY - queued_at_sla;
     assert!(
-        headroom >= WAVE_5_PEAK_TPS / 4,
-        "ring must have ≥1s of headroom past the {}s SLA boundary — \
-         current headroom {} ticks vs needed {} ticks",
-        WAVE_5_QUESTDB_OUTAGE_TOLERANCE_SECS,
+        headroom >= queued_at_sla,
+        "ring must hold ≥2× the {}s-SLA burst — headroom {} vs burst {}",
+        QUESTDB_OUTAGE_SLA_SECS,
         headroom,
-        WAVE_5_PEAK_TPS / 4
+        queued_at_sla
     );
 }
 
@@ -129,35 +117,35 @@ fn test_chaos_burst_high_watermark_alert_fires_before_overflow() {
         "high watermark must sit in the 75%..85% band — current {pct}%"
     );
 
-    // At peak tps, the operator gets ~ (HW / peak_tps) seconds of warning
-    // before overflow. Wave 5 envelope demands at least 4 seconds.
-    let warn_seconds = TICK_BUFFER_HIGH_WATERMARK / WAVE_5_PEAK_TPS;
+    // Lead time at extreme peak: (HW / peak_tps) seconds of warning
+    // before overflow. Must give the operator at least the full SLA.
+    let warn_seconds = TICK_BUFFER_HIGH_WATERMARK / INDICES_ONLY_PEAK_TPS;
     assert!(
-        warn_seconds >= 4,
-        "high-watermark gives only {warn_seconds}s lead time at {WAVE_5_PEAK_TPS} tps — \
-         operator may not react in time"
+        warn_seconds >= QUESTDB_OUTAGE_SLA_SECS,
+        "high-watermark gives only {warn_seconds}s lead time at \
+         {INDICES_ONLY_PEAK_TPS} tps — operator may not react in time"
     );
 }
 
 #[test]
-fn test_chaos_burst_synthetic_200k_row_vecdeque_bounded_no_panic() {
-    // Synthetic check: a VecDeque with a 200K capacity (proxy for a
-    // 5-second burst at sub-peak rates) absorbs without panic and
-    // never re-allocates beyond its preallocated cap.
-    let mut ring: VecDeque<u64> = VecDeque::with_capacity(200_000);
+fn test_chaos_burst_synthetic_vecdeque_bounded_no_panic() {
+    // Synthetic check: a VecDeque sized at the rescue-ring capacity
+    // (proxy for the real ring's underlying type) absorbs a full-ring
+    // burst without panic and never re-allocates beyond its prealloc.
+    let mut ring: VecDeque<u64> = VecDeque::with_capacity(TICK_BUFFER_CAPACITY);
     let preallocated_capacity = ring.capacity();
-    for i in 0u64..200_000 {
+    for i in 0u64..(TICK_BUFFER_CAPACITY as u64) {
         ring.push_back(i);
     }
-    assert_eq!(ring.len(), 200_000);
-    // Capacity should not have grown — VecDeque's `with_capacity`
-    // contract is "at least N", and we wrote exactly N.
+    assert_eq!(ring.len(), TICK_BUFFER_CAPACITY);
+    // Capacity should not have grown — `with_capacity` contract is
+    // "at least N", and we wrote exactly N.
     assert!(ring.capacity() >= preallocated_capacity);
-    // Drain and verify FIFO order (drain semantics).
+    // Drain and verify FIFO order.
     let first = ring.pop_front();
     let last = ring.pop_back();
     assert_eq!(first, Some(0));
-    assert_eq!(last, Some(199_999));
+    assert_eq!(last, Some(TICK_BUFFER_CAPACITY as u64 - 1));
 }
 
 #[test]
@@ -166,14 +154,13 @@ fn test_chaos_burst_synthetic_200k_row_vecdeque_bounded_no_panic() {
     reason = "compile-time constant ratchet — assertion IS the test"
 )]
 fn test_chaos_burst_invariant_documentation_complete() {
-    // Documentation ratchet: ensure the named constants the plan cites
-    // are reachable + non-zero. Trivial today but pins regression where
-    // someone removes a constant assuming it's unused.
+    // Documentation ratchet: ensure the named constants the envelope
+    // cites are reachable + non-zero.
     assert!(TICK_BUFFER_CAPACITY > 0);
     assert!(TICK_BUFFER_HIGH_WATERMARK > 0);
     assert!(MAX_TOTAL_SUBSCRIPTIONS > 0);
     assert!(MAX_TOTAL_SUBSCRIPTIONS_TARGET > 0);
-    assert!(WAVE_5_INDICES_ONLY_INSTRUMENT_COUNT > 0);
-    assert!(WAVE_5_PEAK_TPS > 0);
-    assert!(WAVE_5_QUESTDB_OUTAGE_TOLERANCE_SECS > 0);
+    assert!(INDICES_ONLY_INSTRUMENT_COUNT > 0);
+    assert!(INDICES_ONLY_PEAK_TPS > 0);
+    assert!(QUESTDB_OUTAGE_SLA_SECS > 0);
 }


### PR DESCRIPTION
## Summary

Rightsizes the tick rescue ring for the live 4-SID universe. Operator-
approved this session ("conservative: 5M → 100K only").

`TICK_BUFFER_CAPACITY` was **5,000,000** ticks (~1 GB pre-allocated
`VecDeque`), sized for the retired 25K-instrument universe at ~5,000
ticks/sec. The live universe is **4 IDX_I SIDs** (NIFTY, BANKNIFTY,
SENSEX, INDIA VIX) in Quote mode at ~15-20 ticks/sec — a 5M ring
buffered **~130 hours** for a feed that needs minutes.

Trimmed to **100,000** ticks (~20 MB) — **frees ~980 MB RAM** on the
8 GB host. 100K absorbs a full **60-second** QuestDB-outage SLA at a
400 ticks/sec extreme-peak rate with ~76K headroom.

**Conservative scope** (per the decision): spill + DLQ retained as the
overflow backstop. The deeper simplification (10K + delete spill/DLQ,
~4,800 LoC) stays tracked in
`docs/architecture/resilience-simplification-4-sids.md` as a separate
future PR.

## Changes

| File | Change |
|---|---|
| `constants.rs` | `TICK_BUFFER_CAPACITY` 5,000,000 → 100,000; `TICK_BUFFER_HIGH_WATERMARK` auto-derives to 80,000. Doc comment rewritten. |
| `chaos_burst_indices_only.rs` | Rewritten — old assertions were pinned to the retired Wave-5 11,018-instrument universe (110K tps) and would fail at a 100K ring. Now asserts the 4-SID envelope: 100K ring absorbs a 60s outage at 400 tps with 2× headroom. |
| `wave4_section8_wording_guard.rs` | Honest-claim ratchet now pins the `100,000-tick` wording. |
| `operator-charter-forever.md` · `per-wave-guarantee-matrix.md` · `wave-4-shared-preamble.md` · `z-plus-defense-doctrine.md` | Honest-envelope wording 5M → 100K. |
| `aws-budget.md` | Memory tables: ring 1 GB → 20 MB; app actual ~700 MB under the 2 GB cap. |

`zero_tick_loss_alert_guard.rs` floors the ring at `>= 100_000` — 100K
is exactly that floor, so the ratchet passes untouched.

## Honest envelope

100K ring absorbs ≥60s QuestDB outage at the 4-SID peak; spill + DLQ
backstop anything beyond. The deeper spill/DLQ removal is deferred.

## Test plan

- [x] `cargo check -p tickvault-common -p tickvault-storage --tests` clean
- [x] chaos test arithmetic verified (24K queued ≤ 100K ring; 80K HW = 200s lead time)
- [x] pre-commit gate green
- [ ] CI green

https://claude.ai/code/session_012emMMx3SnMUHdURNmx8cQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012emMMx3SnMUHdURNmx8cQZ)_