### PR TITLE
refactor: #T5 — lock cross-verify table-free (Telegram-only)

### DIFF
--- a/.claude/plans/archive/2026-05-20-questdb-table-cleanup.md
+++ b/.claude/plans/archive/2026-05-20-questdb-table-cleanup.md
@@ -1,6 +1,7 @@
 # Implementation Plan: QuestDB Table Cleanup — drop to 24 tables
 
-**Status:** APPROVED
+**Status:** VERIFIED — all items #T1–#T5 merged (PRs #731/#733/#734,
+#737/#738, #739, #740, #741). Archived 2026-05-20.
 **Date:** 2026-05-20
 **Approved by:** Parthiban (operator) — keep list corrected 2026-05-20:
 `ticks` + 21 candle timeframe tables (1m…15m each minute, 30m, 1h, 2h,
@@ -129,8 +130,12 @@ its `ErrorCode` variant(s), and its ratchet tests.
   (market_depth, previous_close, indicator_snapshots, obi_snapshots,
   nse_holidays, live_instance_lock — modules deleted, callers rewired,
   boot DDL trimmed.)
-- [ ] **#T5** — cross-verify (PR #9) lands table-free (Telegram-only)
-  against `historical_candles`.
+- [x] **#T5** — cross-verify (PR #9) lands table-free (Telegram-only)
+  against `historical_candles`. (PR #741 — design lock: the cross-verify
+  subsystem writes NO QuestDB table; `cross_verify/mod.rs` doc +
+  `option-chain-cross-verify-error-codes.md` §2/§3 + `error-rules.yaml`
+  updated; `cross_verify_audit`/`cross_verify_mismatches` table refs
+  removed — Telegram + `errors.jsonl` are the only sinks.)
 
 Supersedes the original AWS-lifecycle PR #10 QuestDB-cleanup scope.
 

--- a/.claude/rules/project/option-chain-cross-verify-error-codes.md
+++ b/.claude/rules/project/option-chain-cross-verify-error-codes.md
@@ -80,13 +80,25 @@ Per `option-chain-z-plus-heart-piece.md` §8. The option_chain REST fetcher runs
 
 Per `aws-indices-only-locked-architecture.md` §14. Two daily gates: 15:31 IST same-day intraday verify + 08:05 IST morning 1d check.
 
+> **#T5 table-cleanup lock (2026-05-20):** cross-verify is **table-free**.
+> It compares our derived `candles_<tf>` against Dhan REST and against
+> `historical_candles`, and reports outcomes **via Telegram only** —
+> there is NO `cross_verify_audit` / `cross_verify_mismatches` QuestDB
+> table. The earlier design (`aws-indices-only-locked-architecture.md`
+> §14.4-14.5, `precision-realism-and-table-redesign.md` tables 11-12)
+> proposed audit tables; the QuestDB table-cleanup plan
+> (`.claude/plans/archive/`, item #T5) supersedes that — the result is
+> a Telegram alert + the structured `error!` log in
+> `data/logs/errors.jsonl.*`, nothing more. Future #9b+ schedulers
+> MUST NOT add an audit-table writer.
+
 ### CROSS-VERIFY-01 — 15:31 IST same-day mismatch
 
 **Severity:** Critical.
 **Auto-triage:** No (operator review).
-**Behavior:** alert + audit row only — does **NOT** block trading the next day (operator-locked 2026-05-18).
+**Behavior:** Telegram alert only — does **NOT** block trading the next day (operator-locked 2026-05-18) and writes **no audit table** (#T5).
 **Trigger:** at 15:31 IST after market close, the cross-verify scheduler runs 12 pairs (4 SIDs × 3 TFs: 1m, 5m, 15m). For each pair, our derived `candles_<tf>` is compared against Dhan REST `/v2/charts/intraday` for the same trading-date timestamps. Zero-tolerance OHLCV match required. Any mismatch fires this code.
-**Triage:** inspect `cross_verify_mismatches` table for the affected candle timestamps. Verify whether our aggregator missed ticks during a known disconnect window (check `ws_reconnect_audit`).
+**Triage:** the Telegram alert names every mismatched `(timeframe, candle timestamp, field)`; the same detail is in the structured `error!` log (`data/logs/errors.jsonl.*`). Verify whether our aggregator missed ticks during a known disconnect window (cross-check the WebSocket reconnect log lines).
 
 ### CROSS-VERIFY-02 — 15:31 IST historical REST unreachable
 
@@ -99,9 +111,9 @@ Per `aws-indices-only-locked-architecture.md` §14. Two daily gates: 15:31 IST s
 
 **Severity:** Critical.
 **Auto-triage:** No (operator review).
-**Behavior:** alert + audit row only — does **NOT** block trading the day (operator-locked 2026-05-18).
+**Behavior:** Telegram alert only — does **NOT** block trading the day (operator-locked 2026-05-18) and writes **no audit table** (#T5).
 **Trigger:** at 08:05 IST every trading day, fetch yesterday's 1d candle via `/v2/charts/historical` and compare against our derived `candles_1d` row. Zero-tolerance OHLCV match. Mismatch fires this code.
-**Triage:** inspect `cross_verify_audit` table. If our 1d derivation used incorrect day-boundary alignment, fix the boundary logic and re-derive. Yesterday's close becomes part of strategy decisions — operator must decide whether to trade today based on suspect data.
+**Triage:** the Telegram alert + the `error!` log (`data/logs/errors.jsonl.*`) carry the mismatched fields. If our 1d derivation used incorrect day-boundary alignment, fix the boundary logic and re-derive. Yesterday's close becomes part of strategy decisions — operator must decide whether to trade today based on suspect data.
 
 ### CROSS-VERIFY-04 — 08:05 IST historical REST unreachable
 
@@ -116,7 +128,7 @@ Per `aws-indices-only-locked-architecture.md` §14. Two daily gates: 15:31 IST s
 
 | Charter demand | How these stubs satisfy |
 |---|---|
-| 100% audit coverage | Every code maps to a future `option_chain_request_audit` or `cross_verify_audit` row when consumers land |
+| 100% audit coverage | Each code's full forensic detail is the Telegram alert + the structured `error!` line in `data/logs/errors.jsonl.*` (hourly-rotated, 48h retained). Cross-verify is table-free per #T5 — no QuestDB audit table |
 | 100% logging | Each code carries a `Severity` so tracing macros route correctly to CloudWatch |
 | 100% alerting | Critical-severity codes auto-route to SNS 4-leg fan-out (SMS + TG + Email + Connect call) |
 | 100% extreme check | `error_code_tag_guard.rs` enforces `code = ErrorCode::X.code_str()` field on every emit; `error_code_rule_file_crossref.rs` enforces this file's existence + cross-references |

--- a/.claude/triage/error-rules.yaml
+++ b/.claude/triage/error-rules.yaml
@@ -1180,11 +1180,12 @@ rules:
     justification: >-
       CROSS-VERIFY-01 = 15:31 IST same-day OHLCV mismatch vs Dhan REST
       /v2/charts/intraday. Severity::Critical. Operator-locked
-      2026-05-18 — does NOT block trading (alert+audit only).
-      Operator inspects cross_verify_mismatches table; verifies
-      whether aggregator missed ticks during known disconnect
-      (ws_reconnect_audit). Auto-backfill via REST is the recovery
-      mechanism for the candles_<tf> tables.
+      2026-05-18 — does NOT block trading (Telegram alert only;
+      cross-verify is table-free per #T5). Operator reads the
+      mismatched fields from the Telegram alert + errors.jsonl;
+      verifies whether the aggregator missed ticks during a known
+      disconnect. Auto-backfill via REST is the recovery mechanism
+      for the candles_<tf> tables.
 
   - name: cross-verify-02-1531-hist-unreachable-escalate
     match:
@@ -1209,8 +1210,9 @@ rules:
     justification: >-
       CROSS-VERIFY-03 = 08:05 IST morning 1d mismatch vs Dhan REST
       /v2/charts/historical. Severity::Critical. Operator-locked
-      2026-05-18 — does NOT block trading (alert+audit only).
-      Operator inspects cross_verify_audit for yesterday's derivation;
+      2026-05-18 — does NOT block trading (Telegram alert only;
+      cross-verify is table-free per #T5). Operator reads yesterday's
+      mismatched derivation from the Telegram alert + errors.jsonl;
       if our day-boundary alignment is wrong, fix the boundary logic
       and re-derive. Operator decides whether to trade today on
       suspect data.

--- a/crates/core/src/cross_verify/mod.rs
+++ b/crates/core/src/cross_verify/mod.rs
@@ -16,12 +16,22 @@
 //! Without this layer, missed ticks are invisible: a single dropped
 //! WebSocket packet silently corrupts the OHLCV the strategy trades on.
 //!
-//! # PR #9a scope
+//! # Scope
 //!
-//! This sub-PR ships ONLY the pure-logic [`comparator`] — the
-//! zero-tolerance OHLCV comparison engine and its verdict types. The
-//! schedulers, the Dhan REST integration, the QuestDB audit writer and
-//! the boot wiring land in subsequent sub-PRs (#9b onward). The
-//! comparator is fully unit-tested in isolation here.
+//! This module ships the pure-logic [`comparator`] — the zero-tolerance
+//! OHLCV comparison engine and its verdict types. The schedulers, the
+//! Dhan REST integration and the boot wiring land in subsequent
+//! sub-PRs (#9b onward). The comparator is fully unit-tested in
+//! isolation here.
+//!
+//! # Table-free (QuestDB table-cleanup #T5, 2026-05-20)
+//!
+//! Cross-verify is **table-free**. The comparison sources are Dhan
+//! REST and the `historical_candles` table (read-only); the verdict is
+//! reported **via Telegram only** plus the structured `error!` log
+//! (`data/logs/errors.jsonl.*`). There is NO `cross_verify_audit` /
+//! `cross_verify_mismatches` QuestDB table — the #9b+ schedulers MUST
+//! NOT add an audit-table writer. See
+//! `.claude/rules/project/option-chain-cross-verify-error-codes.md` §2.
 
 pub mod comparator;


### PR DESCRIPTION
## Summary

Item **#T5** — the final item of the QuestDB table-cleanup plan
(now archived to `.claude/plans/archive/2026-05-20-questdb-table-cleanup.md`).

The cross-verify subsystem **already writes no QuestDB table**: it
reads `historical_candles` + the `candles_<tf>` tables, compares
zero-tolerance OHLCV, and reports outcomes via Telegram + the
structured `error!` log (`data/logs/errors.jsonl.*`). The
`cross_verify_audit` / `cross_verify_mismatches` tables existed only
in design docs — never in code. This PR **locks that design** so the
future #9b+ cross-verify schedulers cannot reintroduce an audit table.

## Changes (docs / design-lock only — no code logic, no schema)

- **`cross_verify/mod.rs`** — module doc gains an explicit
  "Table-free" section; dropped the stale "QuestDB audit writer lands
  in #9b" line.
- **`option-chain-cross-verify-error-codes.md`** — §2 gains a #T5
  table-free lock note; CROSS-VERIFY-01/03 "behavior" + "triage"
  rewritten from "audit row" / "inspect `cross_verify_*` table" to
  Telegram + `errors.jsonl`; §3 audit-coverage row updated.
- **`error-rules.yaml`** — CROSS-VERIFY-01/03 triage text
  de-references the dropped tables.
- **Plan archived** — `active-plan-table-cleanup.md` →
  `.claude/plans/archive/`; all #T1–#T5 merged.

## Table-cleanup plan — complete

| PR | Item |
|---|---|
| #731/#733/#734 | #T1 — candle re-architecture (RAM-first) |
| #737/#738 | #T2 — ~20 audit tables |
| #739 | #T3 — 5 instrument tables |
| #740 | #T4 — 6 misc tables |
| **this PR** | **#T5 — cross-verify table-free** |

QuestDB is now the **24-table KEEP set**: `ticks` + 21 `candles_<tf>`
+ `option_chain_minute_snapshot` + `historical_candles`.

## Test plan

- [x] `cargo check -p tickvault-core` green
- [x] `cargo test -p tickvault-core --lib cross_verify` — 213 green
- [x] `error_code_rule_file_crossref` — 3 green (CROSS-VERIFY-01..04 still resolve)
- [x] `triage_rules_guard` + `triage_rules_full_coverage_guard` — 13 green
- [x] `error-rules.yaml` valid YAML
- [x] banned-pattern scanner clean
- [ ] CI

## Honest 100% claim

100% inside the tested envelope: doc/design-lock change only, no code
logic or schema touched; the error-code cross-ref and triage-rule
ratchets confirm the CROSS-VERIFY-01..04 contract is intact.

https://claude.ai/code/session_01BMBXx9cAVoUHVupAMJ2yUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMBXx9cAVoUHVupAMJ2yUz)_