### PR TITLE
security(aws-sdk): drop legacy rustls 0.21 chain — close 6 Dependabot alerts

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,16 +12,17 @@
 #   - RUSTSEC-2026-0044 / 0048 → fixed by aws-lc-sys 0.40.0
 #   - RUSTSEC-2026-0049 → fixed by rustls-webpki 0.103.13
 #   - RUSTSEC-2026-0097 → fixed by rand 0.9.4
-# All three remaining entries apply to rustls-webpki 0.101.7, which
-# is pulled in by the deep AWS SDK stack
-# (aws-smithy-http-client 1.1.12 → hyper-rustls 0.24.2 → rustls 0.21.12).
-# Fix = AWS SDK suite bump, deferred to its own PR.
+#
+# 2026-05-23 cleanup: 3 entries removed after the AWS SDK crates were
+# switched off their legacy `rustls` feature (which pulled rustls 0.21
+# via aws-smithy-http-client's `legacy-rustls-ring`) and onto the modern
+# `default-https-client` feature (rustls 0.23 + aws-lc-rs). The vulnerable
+# rustls-webpki 0.101.7 is no longer in the lockfile:
+#   - RUSTSEC-2026-0098 (URI name-constraint) — chain removed
+#   - RUSTSEC-2026-0099 (wildcard name-constraint) — chain removed
+#   - RUSTSEC-2026-0104 (CRL-parse panic) — chain removed
 # =============================================================================
 
 [advisories]
-ignore = [
-    "RUSTSEC-2026-0098", # rustls-webpki 0.101.7 URI name-constraint — AWS SDK transitive only
-    "RUSTSEC-2026-0099", # rustls-webpki 0.101.7 wildcard name-constraint — AWS SDK transitive only
-    "RUSTSEC-2026-0104", # rustls-webpki 0.101.7 CRL-parse panic — AWS SDK transitive only (CRL parsing not on live-feed path which uses rustls 0.23.37 → webpki 0.103.13)
-]
+ignore = []
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,23 +476,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.13",
- "http 0.2.12",
+ "h2",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -643,7 +637,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1357,7 +1351,7 @@ checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
  "cfg-if",
  "libc",
- "socket2 0.6.3",
+ "socket2",
  "windows-sys 0.60.2",
 ]
 
@@ -1707,25 +1701,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1922,30 +1897,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1954,7 +1905,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1969,33 +1920,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -2005,7 +1941,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2024,12 +1960,12 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2464,15 +2400,15 @@ dependencies = [
  "base64",
  "evmap",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "indexmap",
  "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "rustls 0.23.40",
+ "rustls",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3075,13 +3011,13 @@ dependencies = [
  "questdb-confstr",
  "rand 0.9.4",
  "ring",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "ryu",
  "serde",
  "serde_json",
  "slugify",
- "socket2 0.6.3",
+ "socket2",
  "ureq",
  "webpki-roots",
  "winapi",
@@ -3105,8 +3041,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.40",
- "socket2 0.6.3",
+ "rustls",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3126,7 +3062,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3144,7 +3080,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3332,7 +3268,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
@@ -3406,7 +3342,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "js-sys",
  "log",
@@ -3436,12 +3372,12 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -3449,7 +3385,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -3457,7 +3393,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3559,18 +3495,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -3580,7 +3504,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3618,10 +3542,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3633,16 +3557,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -3709,16 +3623,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "secrecy"
@@ -3974,16 +3878,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4168,7 +4062,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest 0.13.3",
- "rustls 0.23.40",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -4200,7 +4094,7 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "rkyv",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "secrecy",
  "serde",
  "serde_json",
@@ -4238,7 +4132,7 @@ dependencies = [
  "reqwest 0.13.3",
  "rkyv",
  "rtrb",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "secrecy",
  "serde",
@@ -4390,7 +4284,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4408,21 +4302,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls",
  "tokio",
 ]
 
@@ -4445,11 +4329,11 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -4558,7 +4442,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -4782,7 +4666,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,9 +137,15 @@ rustls = { version = "0.23.40", default-features = false, features = ["aws_lc_rs
 rustls-native-certs = "0.8.3"
 
 # ---- Section 11: AWS SDK ----
-aws-config = "1.8.16"
-aws-sdk-sns = "1.99.0"
-aws-sdk-ssm = "1.109.0"
+# 2026-05-23: opt out of each crate's legacy `rustls` feature (which pulls
+# vulnerable rustls 0.21 + rustls-webpki 0.101.7 via aws-smithy-http-client's
+# `legacy-rustls-ring`) and opt INTO `default-https-client` instead, which
+# routes through `aws-smithy-http-client/rustls-aws-lc` (rustls 0.23 +
+# aws-lc-rs — already pinned by the workspace at line 136). Closes the 3
+# RUSTSEC advisories on the AWS chain without an upstream SDK release.
+aws-config = { version = "1.8.16", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
+aws-sdk-sns = { version = "1.99.0", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
+aws-sdk-ssm = { version = "1.109.0", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 
 # ---- Section 16: CLI ----
 clap = { version = "4.6.1", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -36,11 +36,12 @@ unmaintained = "workspace"
 # SDK stack (aws-smithy-http-client 1.1.12). Bumping the AWS SDK suite
 # is its own change requiring a separate PR + verification window — see
 # the deferred-work table in PR #323 for context.
-ignore = [
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 (AWS SDK transitive only — not on tickvault's primary TLS path which is now 0.103.13)" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 (AWS SDK transitive only — not on tickvault's primary TLS path which is now 0.103.13)" },
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL-parse panic — AWS SDK transitive only; CRL parsing is not on tickvault's live-feed path (which uses rustls 0.23.37 → webpki 0.103.13, patched). Exploit surface: attacker-controlled CRL from an AWS SDK endpoint — not a realistic attack vector for us. Full fix = AWS SDK suite bump, deferred to its own branch." },
-]
+# 2026-05-23: 3 entries removed after AWS SDK crates were switched off
+# their legacy `rustls` feature onto modern `default-https-client`
+# (rustls 0.23 + aws-lc-rs). Vulnerable rustls-webpki 0.101.7 is no
+# longer in the lockfile — see Cargo.toml Section 11 for the feature
+# selection. Closed advisories: RUSTSEC-2026-0098, 0099, 0104.
+ignore = []
 
 # --- Licenses: Block incompatible licenses ---
 [licenses]


### PR DESCRIPTION
## Summary

Closes all 6 GitHub Dependabot alerts (2 High + 4 Low) on `main` by dropping the AWS SDK's legacy `rustls 0.21` chain entirely from `Cargo.lock` — no upstream SDK release required, no code changes, no behavior change.

## Root cause

`aws-config`, `aws-sdk-ssm`, and `aws-sdk-sns` all default to their `rustls` feature, which routes through `aws-smithy-runtime/tls-rustls` → `aws-smithy-http-client/legacy-rustls-ring`. That pulled `rustls 0.21.12` + `rustls-webpki 0.101.7` + the old `webpki` crate into the lockfile alongside our healthy `rustls 0.23.40` chain.

The 6 Dependabot alerts (3 RUSTSEC × 2 manifests):

| RUSTSEC | Severity | What |
|---|---|---|
| `RUSTSEC-2026-0104` | High × 2 | rustls-webpki 0.101.7 CRL-parse panic |
| `RUSTSEC-2026-0099` | Low × 2 | webpki wildcard name-constraint |
| `RUSTSEC-2026-0098` | Low × 2 | webpki URI name-constraint |

## Fix

`aws-smithy-http-client` exposes a modern `rustls-aws-lc` feature (rustls 0.23 + aws-lc-rs) wired via `aws-smithy-runtime/default-https-client`. Each AWS SDK crate exposes a corresponding `default-https-client` feature. Switching all three workspace deps to `default-features = false` + `default-https-client` (without `rustls`) drops the legacy chain entirely.

## Verification — lockfile after fix

```text
rustls            → only 0.23.40         (was 0.21.12 + 0.23.40)
rustls-webpki     → only 0.103.13        (was 0.101.7 + 0.103.13)
webpki (0.22.x)   → GONE
legacy-rustls     → GONE
legacy-hyper-rustls → GONE
```

| Check | Result |
|---|---|
| `cargo check -p tickvault-app` | Finished, 0 warnings |
| `cargo test -p tickvault-core --lib auth::` | 279 passed |
| `cargo test -p tickvault-app --lib` | 463 passed |
| banned-pattern / pub-fn-test / pub-fn-wiring guards | clean |
| test count | 6774 (stable) |

`.cargo/audit.toml` and `deny.toml` ignore lists are emptied — the chain is no longer present so the ignores were stale.

## Behavior change

None. `aws_config::defaults(...)` continues to work — `SdkConfig` now uses the modern TLS stack internally. AWS API endpoints (SSM/SNS/STS) speak standard TLS; the swap from rustls 0.21 to rustls 0.23 is invisible to them.

## Honest envelope

Per `z-plus-defense-doctrine.md`, this is a dep-tree security fix with zero behavior change — L1 (existing tests) + L5 (the AWS code path is unchanged) suffice. Once merged, GitHub Dependabot's next scan finds no vulnerable versions and the 6 UI alerts auto-close.

https://claude.ai/code/session_01QyzAwGr2usbuV1m97KAvUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyzAwGr2usbuV1m97KAvUD)_