### PR TITLE
ci(safety): bump NIGHTLY_VERSION to 2026-05-19 — close 3 sanitizer build failures

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -35,7 +35,12 @@ env:
   # the 14-day safety window. 2026-04-20 is proven working (weekly safety
   # run on that date surfaced issues #302 + #304 — i.e. the build +
   # sanitizer jobs ran end-to-end).
-  NIGHTLY_VERSION: nightly-2026-04-20
+  # 2026-05-23: bumped from 2026-04-20 → 2026-05-19 to clear the three open
+  # nightly-compatibility build failures #460 (cargo-careful), #461 (ASan),
+  # #462 (TSan). The 2026-04-20 pin sat 33 days stale, outside the 14-day
+  # window; recent workspace dep updates (incl. rustls 0.23 chain) required
+  # a newer nightly to compile the sanitizer builds.
+  NIGHTLY_VERSION: nightly-2026-05-19
 
 jobs:
   # ---- cargo-careful: Extra debug checks ----


### PR DESCRIPTION
## Summary

Bumps the Safety Net workflow's nightly toolchain pin from `nightly-2026-04-20` (33 days stale, outside the 14-day window) to `nightly-2026-05-19` (4 days old at push time). Closes three nightly-compatibility build failure issues that all explicitly call for this exact fix:

- Closes #460 — Safety Net: cargo-careful build failure
- Closes #461 — Safety Net: ASan build failure
- Closes #462 — Safety Net: TSan build failure

## Root cause

`.github/workflows/safety.yml` pinned `NIGHTLY_VERSION: nightly-2026-04-20`. Recent workspace dep updates (incl. the rustls 0.23 chain landed in #755) required a newer nightly to compile under cargo-careful + ASan + TSan. Each issue body recommended:

> To fix: update `NIGHTLY_VERSION` in `.github/workflows/safety.yml`.

## Fix

One-line bump + dated audit comment:

```diff
+  # 2026-05-23: bumped from 2026-04-20 → 2026-05-19 to clear the three open
+  # nightly-compatibility build failures #460 (cargo-careful), #461 (ASan),
+  # #462 (TSan). The 2026-04-20 pin sat 33 days stale, outside the 14-day
+  # window; recent workspace dep updates (incl. rustls 0.23 chain) required
+  # a newer nightly to compile the sanitizer builds.
-  NIGHTLY_VERSION: nightly-2026-04-20
+  NIGHTLY_VERSION: nightly-2026-05-19
```

## Behaviour change

None at runtime. CI-only — the safety job uses a newer nightly. If the new pin still cannot build a sanitizer job, the workflow's auto-file step will re-fire and the issue stays open for root-cause investigation.

## Scope NOT covered

This PR does **not** touch the separate runtime findings in #394 (ASan memory issues) and #395 (TSan data races) — those are real sanitizer reports against actual code paths and require independent investigation. They'll be a separate follow-up after this PR merges.

## Honest envelope

CI-pin-only refresh. Verification is the next scheduled safety run itself; auto-merge gates wait for required jobs (Build & Verify, tests, Secret Scan) on this PR — the weekly safety workflow runs on schedule independently and validates the bump there.

https://claude.ai/code/session_01QyzAwGr2usbuV1m97KAvUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyzAwGr2usbuV1m97KAvUD)_