### PR TITLE
chore(cross-verify): scope `Datelike` import to tests only (PR #788 follow-up)

### DIFF
--- a/crates/core/src/historical/cross_verify_scheduler.rs
+++ b/crates/core/src/historical/cross_verify_scheduler.rs
@@ -28,7 +28,7 @@
 //! this window. 09:00:30 sits 30s into the window; 15:31:00 sits 29
 //! minutes before shutdown — both safe.
 
-use chrono::{Datelike, Duration, NaiveDate};
+use chrono::{Duration, NaiveDate};
 
 use tickvault_common::constants::{IST_UTC_OFFSET_SECONDS_I64, SECONDS_PER_DAY};
 
@@ -121,6 +121,7 @@ pub fn ist_date_now(now_utc_secs: i64) -> NaiveDate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Datelike;
 
     #[test]
     fn test_secs_until_next_daily_1d_fire_alias_for_guard() {


### PR DESCRIPTION
## Summary

PR #788 follow-up cleanup. The `Datelike` import landed at module top-level but is only used inside the `#[cfg(test)] mod tests` block. Move it inside the tests module so the release build no longer emits:

```
warning: unused import: `Datelike`
  --> crates/core/src/historical/cross_verify_scheduler.rs:31:14
```

## Diff

| File | Change |
|---|---|
| `crates/core/src/historical/cross_verify_scheduler.rs` | 2 ins / 1 del (3 lines) |

## Test plan

- [x] `cargo check -p tickvault-core` — clean (no warning)
- [x] `cargo test -p tickvault-core --lib cross_verify_scheduler` — 15/15 passing (incl. `test_ist_date_now_alias_for_guard` which uses `Datelike::year()`)

## Honest envelope

100% inside the tested envelope: the import is now scoped exactly where it's used (the tests module). Pre-existing warnings on other crates are unchanged.

## Why narrow

Per operator-charter §H (one PR at a time, focused) and `audit-findings-2026-04-17.md` Rule 14 (no skeleton PRs). The architectural decision for the recurring 09:00:30 IST + 15:31:00 IST cross-verify spawn site (formerly intended for this PR) was promoted to a focused follow-up PR #790 — it involves resolving a conflict with the 2026-04-22 directive about pre-market historical fetching, and needs its own dedicated review.

https://claude.ai/code/session_01Lsg1EatU7QYnpajhPgtKAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lsg1EatU7QYnpajhPgtKAE)_