### PR TITLE
feat(app): outer daily-universe boot orchestrator (fetch→reconcile→audit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,6 +3951,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "signal-hook",
  "tickvault-api",
  "tickvault-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ csv = "1.4.0"
 thiserror = "2.0.18"
 anyhow = "1.0.102"
 bytes = "1.11.1"
+sha2 = "0.10.9"
 
 # ---- Section 12: System & Resilience ----
 core_affinity = "0.8.3"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -45,6 +45,9 @@ chrono-tz = { workspace = true }
 rustls = { workspace = true }
 reqwest = { workspace = true }
 core_affinity = { workspace = true }
+# Only the feature-gated daily-universe boot orchestrator hashes the CSV
+# (source_csv_sha256 provenance); optional so the default build stays lean.
+sha2 = { workspace = true, optional = true }
 
 [features]
 # Sub-PR #10b-ζ-2 of the 2026-05-27 daily-universe expansion: forwards
@@ -53,6 +56,7 @@ core_affinity = { workspace = true }
 # seam compiles against both. Dormant by default per rule §21 — the boot
 # callsite + feature flip land in the final Sub-PR #10 boot orchestrator.
 daily_universe_fetcher = [
+    "dep:sha2",
     "tickvault-core/daily_universe_fetcher",
     "tickvault-storage/daily_universe_fetcher",
 ]

--- a/crates/app/src/daily_universe_boot.rs
+++ b/crates/app/src/daily_universe_boot.rs
@@ -1,0 +1,437 @@
+//! Outer daily-universe BOOT orchestrator — the top-level glue that the
+//! `main.rs` boot path calls (the spawn callsite is the next, final
+//! wiring step). Chains the three layers merged across the
+//! daily-universe sequence into one fail-closed async entry point:
+//!
+//! 1. [`run_daily_universe_fetch_runner`] (core) — drives the §4 infinite
+//!    -retry CSV fetch + `build_universe_from_bytes`, returning a built
+//!    [`DailyUniverse`] once a fetch+build cycle succeeds (boot stays
+//!    BLOCKED until then under `max_attempts = None`).
+//! 2. [`run_lifecycle_reconcile`] (#850) — load yesterday's rows → diff →
+//!    §24 audit-first UPSERT/UPDATE. Fail-closed: a read-back error or a
+//!    partial prior read aborts the whole boot.
+//! 3. [`record_terminal_success`] (#837) — write the terminal
+//!    `instrument_fetch_audit` Success row (counts + provenance).
+//!
+//! ## CSV provenance (SHA-256)
+//!
+//! The audit row + every lifecycle row carry `source_csv_sha256` (§3/§9
+//! tamper-evidence + L3 day-over-day reconcile). The core fetch loop
+//! discards the bytes after building, so this orchestrator WRAPS the
+//! caller's `fetch_fn` to capture the SHA-256 + CSV data-row count of each
+//! fetched body. On success the last capture is the body that built the
+//! universe (fetch→build are sequential per attempt; success returns
+//! immediately). No change to the core runner's contract.
+//!
+//! ## §10 write ordering
+//!
+//! Reconcile (lifecycle UPSERT/UPDATE + lifecycle audit) runs BEFORE the
+//! `instrument_fetch_audit` terminal-success row: a reconcile failure
+//! aborts the boot before we record a "clean fetch" outcome. The next
+//! idempotent boot re-runs.
+//!
+//! Single responsibility: this module does NOT spawn a tokio task, parse
+//! the `--operator-acknowledge-stale-csv` escape valve, or dispatch
+//! Telegram (the runner already emits structured tracing the Loki→Telegram
+//! path consumes). Those remaining bits live in the `main.rs` Step-6c
+//! wiring PR. Generic over `fetch_fn` so tests drive every branch with a
+//! synthetic CSV + no live HTTP / QuestDB.
+//!
+//! **Feature-gated** under `daily_universe_fetcher` per rule §21 —
+//! dormant in the default build.
+
+#![cfg(feature = "daily_universe_fetcher")]
+
+use core::future::Future;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use tickvault_common::config::QuestDbConfig;
+use tickvault_core::instrument::csv_downloader::CsvDownloadError;
+use tickvault_core::instrument::daily_universe::InstrumentRole;
+use tickvault_core::instrument::instr_fetch_loop::LoopOutcome;
+use tickvault_core::instrument::instr_fetch_runner::run_daily_universe_fetch_runner;
+use tracing::info;
+
+use crate::instr_fetch_audit_writer::record_terminal_success;
+use crate::lifecycle_reconcile_orchestrator::{ReconcileRunOutcome, run_lifecycle_reconcile};
+
+/// Outcome of a full daily-universe boot — surfaced to the boot caller for
+/// the Telegram summary + any post-boot assertions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DailyUniverseBootOutcome {
+    /// 1-based fetch attempts that ran before the build succeeded.
+    pub attempts_used: u32,
+    /// Instruments in the built universe.
+    pub universe_size: i64,
+    /// CSV data rows (excludes the header) of the body that built.
+    pub total_rows: i64,
+    /// Lowercase-hex SHA-256 of the CSV body that built the universe.
+    pub source_csv_sha256: String,
+    /// The reconcile tally (the caller MUST inspect `reconcile.apply.errors`).
+    pub reconcile: ReconcileRunOutcome,
+}
+
+/// Lowercase-hex SHA-256 of the CSV bytes — the `source_csv_sha256`
+/// provenance + the §9 L2/L3 tamper-evidence digest. PURE.
+#[must_use]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    // Build the 64-char hex into one pre-sized String (no per-byte
+    // `format!` allocation — keeps the hot-path scanner happy even though
+    // this is a cold path).
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(64);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Count CSV DATA rows (excluding the header line). PURE. A trailing line
+/// without a newline still counts; an empty body is 0; a header-only body
+/// is 0.
+///
+/// The production fetch path body-caps the CSV at 50 MB (§18), so the
+/// newline count is far below `i64::MAX`; the saturating conversion below
+/// is purely defensive against a pathological input and can never trip in
+/// a body-capped boot.
+#[must_use]
+pub fn count_csv_data_rows(bytes: &[u8]) -> i64 {
+    if bytes.is_empty() {
+        return 0;
+    }
+    let newlines = bytes.iter().filter(|&&b| b == b'\n').count();
+    // Physical lines = newline count + 1 unless the body ends in newline.
+    let trailing = i64::from(bytes[bytes.len() - 1] != b'\n');
+    let physical_lines = i64::try_from(newlines)
+        .unwrap_or(i64::MAX)
+        .saturating_add(trailing);
+    // Subtract the header line.
+    physical_lines.saturating_sub(1).max(0)
+}
+
+/// Fail-closed guard before recording a clean fetch-audit Success. PURE.
+/// `run_lifecycle_reconcile` returns `Ok` even when individual lifecycle
+/// UPSERT/UPDATE actions failed (counted, not raised) — so a naive boot
+/// would write `FetchOutcome::Success` while lifecycle rows are partially
+/// unwritten (a false-OK, charter Rule 11). If any apply error OR a
+/// missing-detail skip occurred, the boot is NOT clean: refuse to record
+/// Success so the idempotent next boot re-runs the failed applies and only
+/// then stamps a truthful Success row.
+///
+/// # Errors
+///
+/// Returns `Err` when `apply.errors > 0` or `apply.skipped_missing_detail > 0`.
+pub fn ensure_reconcile_fully_applied(reconcile: &ReconcileRunOutcome) -> Result<()> {
+    let errors = reconcile.apply.errors;
+    let skipped = reconcile.apply.skipped_missing_detail;
+    if errors > 0 || skipped > 0 {
+        anyhow::bail!(
+            "reconcile did not fully apply ({errors} write error(s), {skipped} \
+             skipped-missing-detail) — refusing to record a clean fetch-audit Success; \
+             the idempotent next boot re-runs the failed applies"
+        );
+    }
+    Ok(())
+}
+
+/// Run the full daily-universe boot. Cold path — called once at startup.
+/// See module docs for the 3-layer chain + fail-closed semantics.
+///
+/// `fetch_fn` is the §4 retry loop's per-attempt fetcher (production: a
+/// closure over `CsvDownloader::fetch_csv`). `max_attempts = None` is the
+/// production infinite-retry path; tests pass `Some(n)`.
+///
+/// # Errors
+///
+/// Returns `Err` when (a) the runner yields no universe (the test-only
+/// `Exhausted` path), (b) provenance capture is missing after a successful
+/// fetch (internal invariant), (c) the lifecycle reconcile fails
+/// (read-back unavailable / partial — fail-closed), (d) the reconcile did
+/// not fully apply (`apply.errors > 0` or a missing-detail skip — see
+/// [`ensure_reconcile_fully_applied`]; refuses to record a false-OK
+/// Success), or (e) the terminal-success audit write fails.
+pub async fn run_daily_universe_boot<Fetch, FetchFut>(
+    questdb_config: &QuestDbConfig,
+    fetch_fn: Fetch,
+    now_ist_nanos: i64,
+    today_ist_nanos: i64,
+    dry_run: bool,
+    max_attempts: Option<u32>,
+) -> Result<DailyUniverseBootOutcome>
+where
+    Fetch: FnMut(u32) -> FetchFut,
+    FetchFut: Future<Output = Result<Vec<u8>, CsvDownloadError>>,
+{
+    // Capture provenance (sha + data-row count) of each fetched body. On
+    // success the last capture is the body that built the universe.
+    let captured: Arc<Mutex<Option<(String, i64)>>> = Arc::new(Mutex::new(None));
+    let mut inner = fetch_fn;
+    let cap_for_closure = Arc::clone(&captured);
+    let wrapped = move |attempt: u32| {
+        let fut = inner(attempt);
+        let cap = Arc::clone(&cap_for_closure);
+        async move {
+            let result = fut.await;
+            if let Ok(bytes) = &result {
+                let provenance = (sha256_hex(bytes), count_csv_data_rows(bytes));
+                if let Ok(mut guard) = cap.lock() {
+                    *guard = Some(provenance);
+                }
+            }
+            result
+        }
+    };
+
+    let (outcome, universe) = run_daily_universe_fetch_runner(wrapped, max_attempts).await;
+
+    let Some(universe) = universe else {
+        anyhow::bail!(
+            "daily-universe fetch produced no universe (outcome: {outcome:?}) — boot blocked"
+        );
+    };
+    let LoopOutcome::Success { attempts_used } = outcome else {
+        anyhow::bail!("daily-universe runner returned a universe with a non-Success outcome");
+    };
+
+    // Recover the captured value even from a poisoned mutex (the data is
+    // valid; poison only signals a prior panic) so a poison can't be
+    // misattributed as "provenance missing".
+    let captured_provenance = match captured.lock() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    };
+    let (source_csv_sha256, total_rows) = captured_provenance
+        .context("CSV provenance missing after a successful fetch (internal invariant)")?;
+
+    let universe_size = i64::try_from(universe.total_count()).unwrap_or(i64::MAX);
+    let index_count =
+        i64::try_from(universe.count_by_role(InstrumentRole::Index)).unwrap_or(i64::MAX);
+    let underlying_count =
+        i64::try_from(universe.count_by_role(InstrumentRole::FnoUnderlying)).unwrap_or(i64::MAX);
+
+    // §10 ordering: reconcile FIRST (lifecycle UPSERT/UPDATE + lifecycle
+    // audit), then the instrument_fetch_audit terminal-success row. A
+    // fail-closed reconcile error aborts before recording a clean outcome.
+    let reconcile = run_lifecycle_reconcile(
+        questdb_config,
+        &universe,
+        now_ist_nanos,
+        today_ist_nanos,
+        &source_csv_sha256,
+        dry_run,
+    )
+    .await
+    .context("daily lifecycle reconcile failed")?;
+
+    // Refuse to stamp a clean Success audit row if the reconcile did not
+    // fully apply (false-OK guard — the next idempotent boot completes it).
+    ensure_reconcile_fully_applied(&reconcile)?;
+
+    record_terminal_success(
+        questdb_config,
+        &outcome,
+        now_ist_nanos,
+        today_ist_nanos,
+        total_rows,
+        universe_size,
+        index_count,
+        underlying_count,
+        &source_csv_sha256,
+        dry_run,
+    )
+    .await
+    .context("instrument_fetch_audit terminal-success write failed")?;
+
+    info!(
+        attempts_used,
+        universe_size,
+        total_rows,
+        upserted = reconcile.apply.upserted,
+        expired = reconcile.apply.expired,
+        errors = reconcile.apply.errors,
+        dry_run,
+        "daily-universe boot complete"
+    );
+    Ok(DailyUniverseBootOutcome {
+        attempts_used,
+        universe_size,
+        total_rows,
+        source_csv_sha256,
+        reconcile,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_unreachable() -> QuestDbConfig {
+        // Closed loopback port → connection-refused on a real host, so the
+        // read-back fails closed without hitting a live QuestDB. (Matches
+        // the unreachable-config convention of the sibling reconcile tests.)
+        QuestDbConfig {
+            host: "127.0.0.1".to_string(),
+            http_port: 1,
+            pg_port: 8812,
+            ilp_port: 9009,
+        }
+    }
+
+    /// A valid Detailed-CSV body that `build_universe_from_bytes` accepts
+    /// (131 instruments: 100 NSE_EQ underlyings + 30 NSE indices + 1 BSE
+    /// SENSEX + 100 FUTSTK derivatives). Mirrors the core orchestrator's
+    /// own end-to-end fixture so the universe clears the [100, 400]
+    /// envelope.
+    fn valid_csv() -> Vec<u8> {
+        let mut s = String::from(
+            "SECURITY_ID,EXCH_ID,SEGMENT,INSTRUMENT,SYMBOL_NAME,UNDERLYING_SECURITY_ID\n",
+        );
+        for i in 0..100 {
+            s.push_str(&format!("28{i:04},NSE,NSE_EQ,EQUITY,STK{i},\n"));
+        }
+        for i in 0..30 {
+            s.push_str(&format!("{},NSE,IDX_I,INDEX,IDX{i},\n", 1000 + i));
+        }
+        s.push_str("51,BSE,IDX_I,INDEX,SENSEX,\n");
+        for i in 0..100 {
+            s.push_str(&format!(
+                "{},NSE,NSE_FNO,FUTSTK,STK{i}FUT,28{i:04}\n",
+                38000 + i
+            ));
+        }
+        s.into_bytes()
+    }
+
+    // ---- sha256_hex ----
+
+    #[test]
+    fn test_sha256_hex_known_vectors() {
+        // Standard NIST/RFC test vectors.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn test_sha256_hex_is_64_hex_chars() {
+        let h = sha256_hex(b"tickvault");
+        assert_eq!(h.len(), 64);
+        assert!(
+            h.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+    }
+
+    // ---- count_csv_data_rows ----
+
+    #[test]
+    fn test_count_csv_data_rows_excludes_header() {
+        assert_eq!(count_csv_data_rows(b"H1,H2\na,b\nc,d\n"), 2);
+    }
+
+    #[test]
+    fn test_count_csv_data_rows_no_trailing_newline() {
+        assert_eq!(count_csv_data_rows(b"H1,H2\na,b\nc,d"), 2);
+    }
+
+    #[test]
+    fn test_count_csv_data_rows_header_only_is_zero() {
+        assert_eq!(count_csv_data_rows(b"H1,H2\n"), 0);
+        assert_eq!(count_csv_data_rows(b"H1,H2"), 0);
+    }
+
+    #[test]
+    fn test_count_csv_data_rows_empty_is_zero() {
+        assert_eq!(count_csv_data_rows(b""), 0);
+    }
+
+    // ---- ensure_reconcile_fully_applied ----
+
+    fn reconcile_with(errors: usize, skipped: usize) -> ReconcileRunOutcome {
+        use crate::apply_reconcile_plan::ApplyOutcome;
+        ReconcileRunOutcome {
+            universe_size: 10,
+            prev_rows_loaded: 10,
+            skipped_unknown_state: 0,
+            skipped_malformed: 0,
+            plan_size: 1,
+            apply: ApplyOutcome {
+                upserted: 1,
+                expired: 0,
+                errors,
+                malformed_expiry: 0,
+                skipped_missing_detail: skipped,
+            },
+        }
+    }
+
+    #[test]
+    fn test_ensure_reconcile_fully_applied_ok_when_clean() {
+        assert!(ensure_reconcile_fully_applied(&reconcile_with(0, 0)).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_reconcile_fully_applied_errors_on_apply_errors() {
+        assert!(
+            ensure_reconcile_fully_applied(&reconcile_with(1, 0)).is_err(),
+            "apply errors must block a clean Success audit row (false-OK guard)"
+        );
+    }
+
+    #[test]
+    fn test_ensure_reconcile_fully_applied_errors_on_missing_detail() {
+        assert!(
+            ensure_reconcile_fully_applied(&reconcile_with(0, 2)).is_err(),
+            "a missing-detail skip means lifecycle rows did not fully land"
+        );
+    }
+
+    // ---- run_daily_universe_boot ----
+
+    #[tokio::test]
+    async fn test_run_daily_universe_boot_no_universe_bails() {
+        // Stub fetch returns a TINY (invalid — below the size envelope)
+        // CSV; with max_attempts=Some(1) the runner exhausts → no universe
+        // → boot bails.
+        let cfg = cfg_unreachable();
+        let fetch = |_attempt: u32| async {
+            Ok::<_, CsvDownloadError>(
+                b"SECURITY_ID,EXCH_ID,SEGMENT,INSTRUMENT,SYMBOL_NAME,UNDERLYING_SECURITY_ID\n51,BSE,IDX_I,INDEX,SENSEX,\n".to_vec(),
+            )
+        };
+        let result = run_daily_universe_boot(&cfg, fetch, 1, 1, false, Some(1)).await;
+        assert!(result.is_err(), "no universe built → boot must bail");
+    }
+
+    #[tokio::test]
+    async fn test_run_daily_universe_boot_valid_csv_reaches_reconcile_then_fails_closed() {
+        // Valid CSV → runner Success → universe built → SHA provenance
+        // captured + counts extracted → reconcile load-prev hits the
+        // unreachable QuestDB → fail-closed Err carrying the reconcile
+        // context. Reaching the `reconcile` context (NOT the no-universe
+        // or `provenance missing` bail) proves the full wiring ran:
+        // wrapper capture → runner Success → universe → counts → reconcile.
+        let cfg = cfg_unreachable();
+        let fetch = |_attempt: u32| async { Ok::<_, CsvDownloadError>(valid_csv()) };
+        let result = run_daily_universe_boot(&cfg, fetch, 1, 1, false, Some(1)).await;
+        let msg = format!("{:#}", result.expect_err("reconcile must fail-closed"));
+        assert!(
+            msg.contains("reconcile"),
+            "should carry reconcile context: {msg}"
+        );
+        assert!(
+            !msg.contains("provenance missing"),
+            "provenance was captured: {msg}"
+        );
+        assert!(!msg.contains("no universe"), "universe was built: {msg}");
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -82,6 +82,11 @@ pub mod apply_reconcile_plan;
 // Feature-gated §21; the HTTP-fetch/retry/main.rs spawn is a follow-up.
 #[cfg(feature = "daily_universe_fetcher")]
 pub mod lifecycle_reconcile_orchestrator;
+// Outer daily-universe boot orchestrator: §4 fetch-runner → reconcile →
+// terminal fetch-audit, capturing CSV SHA-256 provenance. Feature-gated
+// §21; the main.rs Step-6c task spawn is the final wiring PR.
+#[cfg(feature = "daily_universe_fetcher")]
+pub mod daily_universe_boot;
 // 2026-05-25 — Crash-recovery REHYDRATE of the option-chain current-
 // expiry cache from QuestDB's `option_chain_minute_snapshot` table.
 // See `option_chain_cache_loader.rs` module docs for the 3-tier


### PR DESCRIPTION
## Summary

The top-level glue the `main.rs` boot path calls (the task-spawn callsite is the final wiring step). Chains the three layers merged across the daily-universe sequence into one fail-closed async entry point, `run_daily_universe_boot`. Feature-gated under `daily_universe_fetcher` (rule §21) — **dormant in the default build**.

1. `run_daily_universe_fetch_runner` (core) — §4 infinite-retry CSV fetch + `build_universe_from_bytes` → a built `DailyUniverse` (boot BLOCKED until success under `max_attempts=None`).
2. `run_lifecycle_reconcile` (#850) — load prior → diff → §24 audit-first UPSERT/UPDATE. Fail-closed on read-back error / partial read.
3. `record_terminal_success` (#837) — the terminal `instrument_fetch_audit` Success row (counts + provenance).

## CSV provenance (SHA-256) + the new `sha2` dep

The core fetch loop discards the bytes after building, so this orchestrator **wraps** the caller's `fetch_fn` to capture the SHA-256 + CSV data-row count of each fetched body into an `Arc<Mutex>`. The loop is sequential fetch→build per attempt and returns on first success, so the last capture is exactly the body that built the universe (verified against `instr_fetch_loop`). **No change to the core runner contract.**

Operator approved adding the pinned **`sha2` 0.10.9** crate (already in the lockfile via `totp-rs`; `{ workspace = true, optional = true }`, enabled only under the feature so the default build stays lean).

## §10 write ordering

Reconcile FIRST (lifecycle UPSERT/UPDATE + lifecycle audit), THEN the fetch-audit Success row — a fail-closed reconcile error aborts before recording a clean outcome.

## Z+ adversarial review (dependency-checker + hostile + security; 0 CRITICAL / 0 HIGH after fix)

- **dependency-checker: PASS** — `sha2` exact-pinned at workspace, `{ workspace = true }`, single version, no RUSTSEC advisory.
- **hostile: HIGH — FIXED.** `run_lifecycle_reconcile` returns `Ok` even with per-action apply errors; the boot used to stamp `FetchOutcome::Success` regardless (false-OK, charter Rule 11). Added pure `ensure_reconcile_fully_applied`: if `apply.errors > 0` OR `skipped_missing_detail > 0` the boot bails BEFORE the Success row, so the idempotent next boot completes the failed applies and only then stamps a truthful Success. The provenance-capture claim was verified to hold across the fetch-ok/build-fail-then-rebuild path.
- **security: 1 MED + 2 LOW addressed.** `count_csv_data_rows` saturation is unreachable under the §18 50 MB body cap (documented); mutex-poison now recovers via `into_inner()` instead of masquerading as "provenance missing"; `sha256_hex` rewritten allocation-free (no per-byte `format!`) so the hot-path scanner stays clean. No secrets logged; CSV body never logged/retained.

## Z+ 15-row "100% everything" — this PR's specifics

| Demand | Proof |
|---|---|
| Code coverage | 11 unit tests across `sha256_hex`, `count_csv_data_rows`, `ensure_reconcile_fully_applied`, `run_daily_universe_boot` |
| Audit coverage | writes the terminal `instrument_fetch_audit` Success row + delegates lifecycle audit to reconcile |
| Security | `sha256_hex` output is fixed 64-char lowercase hex (no injection); body never logged; `cargo audit` clean |
| Code checks | banned-pattern + pub-fn-test-guard + clippy clean; dep pinned exact |
| Bug fixing | 3-agent review; 1 HIGH false-OK fixed inline + MED/LOW dispositioned |
| Logging | `info!` boot summary (numeric/bool only, no secrets, no body) |
| Scenarios | no-universe bail, valid-CSV→reconcile-fail-closed, partial-apply false-OK guard |
| Extreme check | pub-fn-test ratchet stable; default build proves the feature is dormant (sha2 absent) |

## Z+ 7-row resilience — this PR's specifics

| Demand | This PR |
|---|---|
| Zero ticks lost | N/A — cold boot orchestrator |
| Never slow/locked/hanged | cold path; `Arc<Mutex>` never held across `.await`; allocation-free hex |
| QuestDB never fails | reconcile + audit both `Result`; fail-closed on reconcile error AND on partial apply (no false-OK Success) |
| Uniqueness + dedup | delegates to reconcile's `(security_id, exchange_segment)` keying (I-P1-11) |
| Real-time proof | `DailyUniverseBootOutcome` tally + structured `info!`; per-failure context via `anyhow` |

## Honest 100% claim

100% inside the tested envelope, with ratcheted regression coverage: the three pure helpers are unit-tested (NIST SHA vectors, CSV row-count edges, the false-OK guard truth table); the async chain is verified end-to-end up to the fail-closed reconcile via a synthetic valid CSV + unreachable QuestDB. **Honest caveats:** (1) the full success path (reconcile + audit both landing) needs a live QuestDB — not unit-tested here, but the component writes are storage-crate-tested and the apply loop was verified in #849; (2) `--operator-acknowledge-stale-csv` + the `main.rs` task spawn are the next PR; (3) the production flag flip stays a separate go-live PR.

## Test plan
- [x] `cargo test -p tickvault-app --features daily_universe_fetcher` — 11 new tests green (504 feature / 421 default)
- [x] banned-pattern scanner clean
- [x] pub-fn-test-guard clean (count stable 111)
- [x] clippy clean for the new file
- [x] default build compiles with `sha2` absent (feature off)
- [x] `cargo audit` clean for `sha2 0.10.9`
- [ ] CI all green

Next: the `main.rs` Step-6c task spawn (+ the `--operator-acknowledge-stale-csv` escape valve), still flag-OFF. The production `daily_universe_fetcher` flag flip stays the separate, deliberate final go-live PR.

https://claude.ai/code/session_01PV5xzywyUHszxQ4qpEzij3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRxuAcTcWRQEpDNQQKTarN)_