### PR TITLE
feat(app): wire daily-universe fetch into boot Step-6c (fail-closed §4) — GO-LIVE PR-1

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,118 +1,49 @@
-# Implementation Plan: PR #772 — auto-trigger deploy-aws on push to main
+# Implementation Plan: Daily-Universe GO-LIVE (250-SID DailyUniverse, prod + local)
 
 **Status:** VERIFIED
-**Date:** 2026-05-24
-**Approved by:** Parthiban (5-PR roadmap confirmed via AskUserQuestion 2026-05-24)
-**Branch:** `claude/confident-brahmagupta-aqN8R`
-**Position in roadmap:** PR #772 of 5 (after #770 + #771 merged)
+**Date:** 2026-05-28
+**Approved by:** Parthiban — "entire 250 SIDs + new scope as production AND local, everywhere"; boot behavior = "Block until CSV (§4 lock)" (AskUserQuestion 2026-05-28)
+**Branch (PR-1):** `claude/daily-universe-boot-wiring`
 
-## Honest re-scope (from original "blue/green ~200ms downtime")
+## End state
 
-Original plan promised blue/green with ~200ms downtime. After investigation:
+The ~250-SID `DailyUniverse` scope is ON in **production AND local** — the
+WebSocket actually streams the ~250 SIDs, and every boot downloads the Dhan
+Detailed CSV, builds the universe, and reconciles the
+instrument_lifecycle / *_audit / instrument_fetch_audit tables. **Fail-closed
+per §4:** prod+local boot BLOCKS (infinite retry, escalating Telegram) until a
+fresh validated CSV is in hand — never trades on stale/partial data.
 
-| Was promised | Reality |
-|---|---|
-| Blue/green ~200ms downtime | Single-instance ~3-5s downtime today (systemctl restart). True 0ms requires socket activation in Rust app code OR dual-instance ₹2,044/mo (out of charter budget). |
-| Downtime kills ticks | Existing `guard_market_hours` step blocks deploys 09:15-15:30 IST → **zero ticks lost during trading** by construction. |
-| `git push` deploys | Today `deploy-aws.yml` triggers ONLY on tag `v*.*.*` or manual workflow_dispatch — operator must manually click "Run workflow" |
+## Serial PR sequence (one at a time to merge, per pr-completion-protocol)
 
-**Reframed #772 scope (tight + honest):** add the missing `push: branches: [main]` trigger to `deploy-aws.yml` so any merge to main with Rust changes auto-deploys outside market hours. Apply the same preflight gate as #771 so the workflow skips cleanly when AWS bootstrap secrets are absent.
+| PR | Scope | Prod effect on merge |
+|---|---|---|
+| **PR-1 (this)** | Boot Step-6c wiring, fail-closed §4, feature-gated | none yet (flag still default-OFF) |
+| **PR-2** | Scope-aware subscription planner consumes DailyUniverse → 250-SID WS plan; thread universe from Step-6c; update scope-lock guard tests | none yet |
+| **PR-3** | Flip prod `default = ["daily_universe_fetcher"]` + `config/base.toml [subscription] scope = "daily_universe"` | **GO-LIVE — 250 SIDs everywhere** |
 
-True 0ms downtime via socket activation = **deferred to #772b** as a follow-up if operator wants it.
+## PR-1 Plan Items
 
-## Plan Items
+- [x] Add feature-gated, fail-closed Step 6c block to the boot sequence
+  - Files: crates/app/src/main.rs
+  - Tokens: ensure_instrument_lifecycle_table, ensure_instrument_lifecycle_audit_table,
+    ensure_instrument_fetch_audit_table, CsvDownloader, run_daily_universe_boot
+  - Behaviour: ensure 3 tables → Arc<CsvDownloader> fetch_fn → run_daily_universe_boot
+    (dry_run=false, max_attempts=None infinite §4) → `?`-bail on Err (fail-closed) → log outcome.
+  - IST nanos per the lifecycle persistence convention (IST wall-clock nanos).
 
-- [x] **Item 1 — Add push-to-main trigger to deploy-aws.yml**
-  - Files: `.github/workflows/deploy-aws.yml`
-  - Behavior: on push to `main` with paths matching `crates/**` OR `Cargo.toml` OR `Cargo.lock` OR `deploy/systemd/**` → workflow auto-fires
-  - Existing tag trigger preserved, existing workflow_dispatch preserved
-  - Validation: push of unrelated change (e.g. docs only) does NOT trigger; push of Rust change DOES trigger
-  - Tests: r11_deploy_aws_has_push_to_main_trigger_with_rust_paths
+- [x] Wiring ratchet test (source-scan, matches the `*_is_wired` guard pattern)
+  - Files: crates/app/tests/daily_universe_boot_wiring_guard.rs
+  - Tests: test_daily_universe_boot_is_wired_into_main,
+    test_step_6c_ensures_three_lifecycle_tables,
+    test_step_6c_is_feature_gated_and_fail_closed
 
-- [x] **Item 2 — Add preflight job to deploy-aws.yml (mirror #771 pattern)**
-  - Files: `.github/workflows/deploy-aws.yml`
-  - Behavior: new `preflight` job runs first; checks if `AWS_ROLE_ARN` OR `AWS_ACCESS_KEY_ID` secret is set. If neither, prints friendly notice + downstream jobs skip. If yes, downstream proceeds.
-  - Why: same chicken-and-egg as #771 — without bootstrap, every contributor PR would fail the deploy check
-  - Validation: workflow runs end-to-end without secrets → preflight = success, build/guard/deploy = skipped
-  - Tests: r12_deploy_aws_has_preflight_gate
+## Scenarios (PR-1)
 
-- [x] **Item 3 — Extend github_workflow_guard.rs ratchet to cover deploy-aws.yml**
-  - Files: `crates/common/tests/github_workflow_guard.rs`
-  - Behavior: add 2 new tests covering deploy-aws.yml — auto-trigger present, preflight gate present
-  - Validation: `cargo test -p tickvault-common --test github_workflow_guard` — all 13 pass
-  - Tests: r11_deploy_aws_has_push_to_main_trigger_with_rust_paths, r12_deploy_aws_has_preflight_gate
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | `cargo run` (feature OFF — current default) | identical to today — 4-IDX_I LOCKED_UNIVERSE, no sha2, no Step 6c |
+| 2 | `cargo run --features daily_universe_fetcher`, Dhan CSV reachable | CSV downloaded, ~250-SID universe built, 3 tables created + populated, INFO summary |
+| 3 | feature ON, Dhan CSV unreachable | infinite retry, escalating Telegram (4/11/21); boot BLOCKS (§4) — never proceeds |
+| 4 | feature ON, QuestDB unreachable mid-reconcile | run_daily_universe_boot returns Err → boot HALTS (fail-closed) |
 
-- [x] **Item 4 — Update deploy-aws.yml header comment to reflect new triggers**
-  - Files: `.github/workflows/deploy-aws.yml`
-  - Behavior: update the docstring at the top of the file to mention auto-trigger on `push to main with Rust paths`
-  - Validation: header comment lists all 3 triggers (push, tag, dispatch)
-  - Tests: r13_deploy_aws_header_documents_push_trigger
-
-## Scenarios covered
-
-| # | Scenario | Expected behavior |
-|---|----------|-------------------|
-| 1 | Operator pushes Rust change to main outside market hours | deploy-aws.yml auto-fires → build → guard (off-hours) → deploy → Telegram |
-| 2 | Operator pushes Rust change to main during market hours (10:00 IST) | deploy-aws.yml auto-fires → build → guard BLOCKS → workflow fails with clear message; no deploy |
-| 3 | Operator pushes docs-only change | deploy-aws.yml does NOT trigger (path filter excludes docs) |
-| 4 | Operator pushes Rust change BEFORE bootstrap | preflight detects no secrets → prints notice → downstream jobs skip cleanly; PR check stays green |
-| 5 | Tag `v1.2.3` pushed | Existing tag trigger fires (unchanged behavior) |
-| 6 | Operator clicks workflow_dispatch with confirm_market_hours=yes during market hours | Existing override path still works (unchanged) |
-
-## Per-item Z+ Defense Matrix
-
-| Layer | Item 1 (trigger) | Item 2 (preflight) | Item 3 (ratchet) | Item 4 (docs) |
-|---|---|---|---|---|
-| L1 DETECT | workflow log on push | preflight log | cargo test | grep header |
-| L2 VERIFY | path filter matches | secret presence check | source-scan asserts | source-scan asserts |
-| L3 RECONCILE | per-push | per-run | per-PR | per-PR |
-| L4 PREVENT | path filter limits scope | gate downstream jobs | banned regression | docs sync |
-| L5 AUDIT | GH Actions log | CloudTrail | ratchet test | git history |
-| L6 RECOVER | manual workflow_dispatch | provide secrets later | revert PR | revert PR |
-| L7 COOLDOWN | concurrency.group | n/a | n/a | n/a |
-
-## Z+ 15-row "100% Everything" Matrix
-
-| Demand | Mechanical proof for THIS PR |
-|---|---|
-| Code coverage | github_workflow_guard.rs extended to 13 tests |
-| Audit coverage | GH Actions log preserves every deploy invocation |
-| Testing coverage | Rust ratchet test + YAML lint + manual scenario walk |
-| Code checks | Pre-commit gate (fmt, secret-scan, conv-commit, S6 invariants) |
-| Code performance | N/A — workflow YAML, not hot path |
-| Monitoring | GH Actions + SNS notify (already wired) |
-| Logging | GH Actions stdout, preserves workflow run history |
-| Alerting | SNS publish to tv-prod-alerts on success/failure (already wired) |
-| Security | OIDC preferred via existing AWS_ROLE_ARN; no new secrets introduced |
-| Security hardening | Path filter limits trigger scope (no accidental deploy on doc changes) |
-| Bug fixing | Closes the missing-auto-trigger gap — operator no longer types "Run workflow" |
-| Scenarios covering | 6 scenarios above |
-| Functionalities covering | Every main-merge with Rust changes auto-deploys outside market hours |
-| Code review | Self-review per plan + Z+ matrix |
-| Extreme check | github_workflow_guard.rs ratchets the new contract |
-
-## Z+ 7-row "Resilience" Matrix
-
-| Demand | Honest envelope |
-|---|---|
-| Zero ticks lost | Market-hours guard (existing) prevents deploy during 09:15-15:30 IST → zero ticks lost in trading window |
-| WS never disconnects | Off-hours deploy = WS already in sleep-until-open dormant state per Wave-2-A — no live disconnects |
-| Never slow/locked/hanged | Workflow 30 min timeout; existing rollback path on failed smoke test |
-| QuestDB never fails | N/A — workflow only deploys the Rust binary |
-| O(1) latency | N/A — provisioning is one-shot |
-| Uniqueness + dedup | `concurrency.group: deploy-aws-prod` prevents simultaneous deploys (already wired) |
-| Real-time proof | Workflow logs visible in GH Actions UI; SNS Telegram message confirms deploy outcomes |
-
-## Honest 100% claim (envelope-qualified per operator-charter-forever.md §F)
-
-> 100% inside the tested envelope: after this PR merges + the one-time AWS bootstrap (from #771's BOOTSTRAP-ONE-TIME.md), every push to main that touches `crates/**`, `Cargo.toml`, `Cargo.lock`, or `deploy/systemd/**` automatically triggers binary build + market-hours guard + SSM deploy + 60s post-deploy monitor + Telegram notification. Market-hours guard blocks the deploy during 09:15-15:30 IST Mon-Fri unless workflow_dispatch with `confirm_market_hours=yes`. Effective tick loss during deploys: **zero** (market-hours guard + off-hours dormant WS pattern). Deploy downtime when it does happen (off-hours): ~3-5s during `systemctl restart`. True 0ms downtime requires socket activation in the Rust app (deferred to #772b follow-up) OR dual-instance (₹+1,022/mo, breaches charter budget).
-
-## Post-merge effective behavior
-
-| Trigger | What happens |
-|---|---|
-| Operator merges Rust change to main, 10pm IST | Auto-deploy fires within ~5 min → live binary updated → Telegram message arrives |
-| Operator merges Rust change to main, 11am IST | Auto-deploy fires → guard blocks (market hours) → workflow fails → Telegram alert → operator sees they tried to deploy in market hours |
-| Operator merges docs change to main | No deploy trigger; only CI runs |
-| Operator merges Terraform change to main | terraform-apply.yml fires (from #771); deploy-aws.yml does NOT fire |
-| Operator tags v1.2.3 | Existing tag trigger fires (unchanged) |

--- a/.claude/plans/archive/2026-05-24-pr772-deploy-aws-push-trigger.md
+++ b/.claude/plans/archive/2026-05-24-pr772-deploy-aws-push-trigger.md
@@ -1,0 +1,118 @@
+# Implementation Plan: PR #772 — auto-trigger deploy-aws on push to main
+
+**Status:** VERIFIED
+**Date:** 2026-05-24
+**Approved by:** Parthiban (5-PR roadmap confirmed via AskUserQuestion 2026-05-24)
+**Branch:** `claude/confident-brahmagupta-aqN8R`
+**Position in roadmap:** PR #772 of 5 (after #770 + #771 merged)
+
+## Honest re-scope (from original "blue/green ~200ms downtime")
+
+Original plan promised blue/green with ~200ms downtime. After investigation:
+
+| Was promised | Reality |
+|---|---|
+| Blue/green ~200ms downtime | Single-instance ~3-5s downtime today (systemctl restart). True 0ms requires socket activation in Rust app code OR dual-instance ₹2,044/mo (out of charter budget). |
+| Downtime kills ticks | Existing `guard_market_hours` step blocks deploys 09:15-15:30 IST → **zero ticks lost during trading** by construction. |
+| `git push` deploys | Today `deploy-aws.yml` triggers ONLY on tag `v*.*.*` or manual workflow_dispatch — operator must manually click "Run workflow" |
+
+**Reframed #772 scope (tight + honest):** add the missing `push: branches: [main]` trigger to `deploy-aws.yml` so any merge to main with Rust changes auto-deploys outside market hours. Apply the same preflight gate as #771 so the workflow skips cleanly when AWS bootstrap secrets are absent.
+
+True 0ms downtime via socket activation = **deferred to #772b** as a follow-up if operator wants it.
+
+## Plan Items
+
+- [x] **Item 1 — Add push-to-main trigger to deploy-aws.yml**
+  - Files: `.github/workflows/deploy-aws.yml`
+  - Behavior: on push to `main` with paths matching `crates/**` OR `Cargo.toml` OR `Cargo.lock` OR `deploy/systemd/**` → workflow auto-fires
+  - Existing tag trigger preserved, existing workflow_dispatch preserved
+  - Validation: push of unrelated change (e.g. docs only) does NOT trigger; push of Rust change DOES trigger
+  - Tests: r11_deploy_aws_has_push_to_main_trigger_with_rust_paths
+
+- [x] **Item 2 — Add preflight job to deploy-aws.yml (mirror #771 pattern)**
+  - Files: `.github/workflows/deploy-aws.yml`
+  - Behavior: new `preflight` job runs first; checks if `AWS_ROLE_ARN` OR `AWS_ACCESS_KEY_ID` secret is set. If neither, prints friendly notice + downstream jobs skip. If yes, downstream proceeds.
+  - Why: same chicken-and-egg as #771 — without bootstrap, every contributor PR would fail the deploy check
+  - Validation: workflow runs end-to-end without secrets → preflight = success, build/guard/deploy = skipped
+  - Tests: r12_deploy_aws_has_preflight_gate
+
+- [x] **Item 3 — Extend github_workflow_guard.rs ratchet to cover deploy-aws.yml**
+  - Files: `crates/common/tests/github_workflow_guard.rs`
+  - Behavior: add 2 new tests covering deploy-aws.yml — auto-trigger present, preflight gate present
+  - Validation: `cargo test -p tickvault-common --test github_workflow_guard` — all 13 pass
+  - Tests: r11_deploy_aws_has_push_to_main_trigger_with_rust_paths, r12_deploy_aws_has_preflight_gate
+
+- [x] **Item 4 — Update deploy-aws.yml header comment to reflect new triggers**
+  - Files: `.github/workflows/deploy-aws.yml`
+  - Behavior: update the docstring at the top of the file to mention auto-trigger on `push to main with Rust paths`
+  - Validation: header comment lists all 3 triggers (push, tag, dispatch)
+  - Tests: r13_deploy_aws_header_documents_push_trigger
+
+## Scenarios covered
+
+| # | Scenario | Expected behavior |
+|---|----------|-------------------|
+| 1 | Operator pushes Rust change to main outside market hours | deploy-aws.yml auto-fires → build → guard (off-hours) → deploy → Telegram |
+| 2 | Operator pushes Rust change to main during market hours (10:00 IST) | deploy-aws.yml auto-fires → build → guard BLOCKS → workflow fails with clear message; no deploy |
+| 3 | Operator pushes docs-only change | deploy-aws.yml does NOT trigger (path filter excludes docs) |
+| 4 | Operator pushes Rust change BEFORE bootstrap | preflight detects no secrets → prints notice → downstream jobs skip cleanly; PR check stays green |
+| 5 | Tag `v1.2.3` pushed | Existing tag trigger fires (unchanged behavior) |
+| 6 | Operator clicks workflow_dispatch with confirm_market_hours=yes during market hours | Existing override path still works (unchanged) |
+
+## Per-item Z+ Defense Matrix
+
+| Layer | Item 1 (trigger) | Item 2 (preflight) | Item 3 (ratchet) | Item 4 (docs) |
+|---|---|---|---|---|
+| L1 DETECT | workflow log on push | preflight log | cargo test | grep header |
+| L2 VERIFY | path filter matches | secret presence check | source-scan asserts | source-scan asserts |
+| L3 RECONCILE | per-push | per-run | per-PR | per-PR |
+| L4 PREVENT | path filter limits scope | gate downstream jobs | banned regression | docs sync |
+| L5 AUDIT | GH Actions log | CloudTrail | ratchet test | git history |
+| L6 RECOVER | manual workflow_dispatch | provide secrets later | revert PR | revert PR |
+| L7 COOLDOWN | concurrency.group | n/a | n/a | n/a |
+
+## Z+ 15-row "100% Everything" Matrix
+
+| Demand | Mechanical proof for THIS PR |
+|---|---|
+| Code coverage | github_workflow_guard.rs extended to 13 tests |
+| Audit coverage | GH Actions log preserves every deploy invocation |
+| Testing coverage | Rust ratchet test + YAML lint + manual scenario walk |
+| Code checks | Pre-commit gate (fmt, secret-scan, conv-commit, S6 invariants) |
+| Code performance | N/A — workflow YAML, not hot path |
+| Monitoring | GH Actions + SNS notify (already wired) |
+| Logging | GH Actions stdout, preserves workflow run history |
+| Alerting | SNS publish to tv-prod-alerts on success/failure (already wired) |
+| Security | OIDC preferred via existing AWS_ROLE_ARN; no new secrets introduced |
+| Security hardening | Path filter limits trigger scope (no accidental deploy on doc changes) |
+| Bug fixing | Closes the missing-auto-trigger gap — operator no longer types "Run workflow" |
+| Scenarios covering | 6 scenarios above |
+| Functionalities covering | Every main-merge with Rust changes auto-deploys outside market hours |
+| Code review | Self-review per plan + Z+ matrix |
+| Extreme check | github_workflow_guard.rs ratchets the new contract |
+
+## Z+ 7-row "Resilience" Matrix
+
+| Demand | Honest envelope |
+|---|---|
+| Zero ticks lost | Market-hours guard (existing) prevents deploy during 09:15-15:30 IST → zero ticks lost in trading window |
+| WS never disconnects | Off-hours deploy = WS already in sleep-until-open dormant state per Wave-2-A — no live disconnects |
+| Never slow/locked/hanged | Workflow 30 min timeout; existing rollback path on failed smoke test |
+| QuestDB never fails | N/A — workflow only deploys the Rust binary |
+| O(1) latency | N/A — provisioning is one-shot |
+| Uniqueness + dedup | `concurrency.group: deploy-aws-prod` prevents simultaneous deploys (already wired) |
+| Real-time proof | Workflow logs visible in GH Actions UI; SNS Telegram message confirms deploy outcomes |
+
+## Honest 100% claim (envelope-qualified per operator-charter-forever.md §F)
+
+> 100% inside the tested envelope: after this PR merges + the one-time AWS bootstrap (from #771's BOOTSTRAP-ONE-TIME.md), every push to main that touches `crates/**`, `Cargo.toml`, `Cargo.lock`, or `deploy/systemd/**` automatically triggers binary build + market-hours guard + SSM deploy + 60s post-deploy monitor + Telegram notification. Market-hours guard blocks the deploy during 09:15-15:30 IST Mon-Fri unless workflow_dispatch with `confirm_market_hours=yes`. Effective tick loss during deploys: **zero** (market-hours guard + off-hours dormant WS pattern). Deploy downtime when it does happen (off-hours): ~3-5s during `systemctl restart`. True 0ms downtime requires socket activation in the Rust app (deferred to #772b follow-up) OR dual-instance (₹+1,022/mo, breaches charter budget).
+
+## Post-merge effective behavior
+
+| Trigger | What happens |
+|---|---|
+| Operator merges Rust change to main, 10pm IST | Auto-deploy fires within ~5 min → live binary updated → Telegram message arrives |
+| Operator merges Rust change to main, 11am IST | Auto-deploy fires → guard blocks (market hours) → workflow fails → Telegram alert → operator sees they tried to deploy in market hours |
+| Operator merges docs change to main | No deploy trigger; only CI runs |
+| Operator merges Terraform change to main | terraform-apply.yml fires (from #771); deploy-aws.yml does NOT fire |
+| Operator tags v1.2.3 | Existing tag trigger fires (unchanged) |

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2174,6 +2174,87 @@ async fn main() -> Result<()> {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Step 6c (go-live PR-1 of the daily-universe sequence) — daily-universe
+    // instrument fetch. Feature-gated by `daily_universe_fetcher`
+    // (`daily-universe-scope-expansion-2026-05-27.md` §21); the prod default
+    // flip is the final PR of this sequence. When compiled in, download the
+    // Dhan Detailed CSV, build the ~250-SID universe, and reconcile it into the
+    // instrument_lifecycle / instrument_lifecycle_audit / instrument_fetch_audit
+    // tables.
+    //
+    // FAIL-CLOSED per operator §4 lock: infinite retry (max_attempts = None)
+    // with escalating Telegram at attempts 4/11/21; boot BLOCKS until a fresh,
+    // validated CSV is in hand. A reconcile/audit error (QuestDB) HALTS boot
+    // rather than proceeding on unknown state. QuestDB readiness is confirmed
+    // above. The scope-aware WS subscription that actually streams the ~250
+    // SIDs lands in the next PR (the planner does not consume DailyUniverse
+    // yet), and the prod default flip is the PR after that.
+    // -----------------------------------------------------------------------
+    #[cfg(feature = "daily_universe_fetcher")]
+    {
+        use anyhow::Context;
+        use std::sync::Arc;
+        use tickvault_common::constants::IST_UTC_OFFSET_SECONDS;
+        use tickvault_core::instrument::csv_downloader::CsvDownloader;
+        use tickvault_storage::instrument_fetch_audit_persistence::ensure_instrument_fetch_audit_table;
+        use tickvault_storage::instrument_lifecycle_persistence::{
+            ensure_instrument_lifecycle_audit_table, ensure_instrument_lifecycle_table,
+        };
+
+        info!(
+            "Step 6c: daily-universe instrument fetch (feature daily_universe_fetcher ON, fail-closed §4)"
+        );
+
+        // Idempotent CREATE TABLE IF NOT EXISTS for the 3 lifecycle/audit
+        // tables — run_daily_universe_boot's downstream writers assume these
+        // exist (they do not self-ensure).
+        ensure_instrument_lifecycle_table(&config.questdb).await;
+        ensure_instrument_lifecycle_audit_table(&config.questdb).await;
+        ensure_instrument_fetch_audit_table(&config.questdb).await;
+
+        // IST wall-clock nanoseconds (host-clock based) per the
+        // instrument_lifecycle_persistence convention. Derived from a single
+        // `now_utc` so `now` and `today-midnight` are consistent.
+        let now_utc = chrono::Utc::now();
+        let offset_nanos = i64::from(IST_UTC_OFFSET_SECONDS) * 1_000_000_000;
+        let now_ist_nanos = now_utc.timestamp_nanos_opt().unwrap_or(0) + offset_nanos;
+        let now_ist = now_utc + chrono::TimeDelta::seconds(i64::from(IST_UTC_OFFSET_SECONDS));
+        let today_ist_nanos = now_ist
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .and_then(|midnight| midnight.and_utc().timestamp_nanos_opt())
+            .unwrap_or(now_ist_nanos);
+
+        let downloader =
+            Arc::new(CsvDownloader::new().context("Step 6c: CsvDownloader init failed")?);
+        let fetch_fn = move |_attempt: u32| {
+            let downloader = Arc::clone(&downloader);
+            async move { downloader.fetch_csv().await }
+        };
+        // §4: infinite retry (None) — boot blocks until a fresh CSV is in hand.
+        // dry_run = false: write real lifecycle/audit rows.
+        let outcome = tickvault_app::daily_universe_boot::run_daily_universe_boot(
+            &config.questdb,
+            fetch_fn,
+            now_ist_nanos,
+            today_ist_nanos,
+            false,
+            None,
+        )
+        .await
+        .context("Step 6c: daily-universe boot failed (fail-closed §4) — halting")?;
+
+        info!(
+            universe_size = outcome.universe_size,
+            total_rows = outcome.total_rows,
+            attempts_used = outcome.attempts_used,
+            upserted = outcome.reconcile.apply.upserted,
+            expired = outcome.reconcile.apply.expired,
+            "Step 6c: daily universe built + lifecycle reconciled"
+        );
+    }
+
     // Candle-engine re-architecture #T1b — drop the legacy candle objects
     // (Engine A `candles_1s` base table + Engine C's 9 `candles_<tf>`
     // materialized views + the retired Wave-6 `candles_<tf>_shadow`

--- a/crates/app/tests/daily_universe_boot_wiring_guard.rs
+++ b/crates/app/tests/daily_universe_boot_wiring_guard.rs
@@ -1,0 +1,59 @@
+//! Source-scan ratchet (Z+ L5 AUDIT / L4 PREVENT) pinning that the
+//! daily-universe boot orchestrator is wired into `main.rs` Step-6c,
+//! fail-closed, and feature-gated. Mirrors the codebase's `*_is_wired`
+//! guard pattern (e.g. `secret_manager.rs::test_orphan_position_watchdog_is_wired_into_main`).
+//!
+//! These tests read the `main.rs` SOURCE text, so they run on the default
+//! build (feature OFF) — the ratchet is always active in CI, independent
+//! of the `daily_universe_fetcher` feature.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn main_rs_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn test_daily_universe_boot_is_wired_into_main() {
+    let src = main_rs_source();
+    assert!(
+        src.contains("run_daily_universe_boot("),
+        "Step-6c must call run_daily_universe_boot — the daily-universe fetch \
+         is otherwise dead code (pub-fn-wiring + go-live regression)."
+    );
+}
+
+#[test]
+fn test_step_6c_ensures_three_lifecycle_tables() {
+    let src = main_rs_source();
+    for ensure_fn in [
+        "ensure_instrument_lifecycle_table",
+        "ensure_instrument_lifecycle_audit_table",
+        "ensure_instrument_fetch_audit_table",
+    ] {
+        assert!(
+            src.contains(ensure_fn),
+            "Step-6c must call {ensure_fn} before run_daily_universe_boot — the \
+             downstream writers assume the table exists."
+        );
+    }
+}
+
+#[test]
+fn test_step_6c_is_feature_gated_and_fail_closed() {
+    let src = main_rs_source();
+    assert!(
+        src.contains("#[cfg(feature = \"daily_universe_fetcher\")]"),
+        "Step-6c must stay feature-gated (default-OFF until the go-live flip)."
+    );
+    // Fail-closed §4: the orchestrator result is `?`-propagated with a
+    // halting context (NOT swallowed / fail-open). Pinning the halt context
+    // string keeps a future edit from silently downgrading to fail-open.
+    assert!(
+        src.contains("daily-universe boot failed (fail-closed") && src.contains("halting"),
+        "Step-6c must be fail-closed per §4 — propagate the orchestrator Err \
+         with a halting context, never log-and-continue."
+    );
+}


### PR DESCRIPTION
## Summary

**GO-LIVE PR-1 of 3** for the 250-SID `DailyUniverse` scope (production + local, fail-closed per operator §4 lock). Wires the merged `run_daily_universe_boot` orchestrator into the `main.rs` boot sequence as a **feature-gated Step-6c**, right after the QuestDB-ready + clock-skew probes.

When `daily_universe_fetcher` is compiled in, boot: (1) ensures the 3 lifecycle/audit tables; (2) downloads the Dhan Detailed CSV via `Arc<CsvDownloader>`; (3) builds the ~250-SID universe + reconciles `instrument_lifecycle` / `instrument_lifecycle_audit` / `instrument_fetch_audit`.

**Fail-closed (§4, confirmed 2026-05-28 "Block until CSV"):** `max_attempts = None` (infinite retry, escalating Telegram 4/11/21); the orchestrator `Err` is `?`-propagated with a halting context — boot **BLOCKS** until a fresh validated CSV is in hand, and HALTS on a QuestDB reconcile failure rather than proceeding on unknown state.

**Default build (feature OFF = current prod default) is byte-for-byte unaffected** — the cfg block compiles out. Prod behavior changes only at PR-3 (the flag flip).

## Serial sequence (prod effect only at PR-3)

| PR | Scope | Prod effect on merge |
|---|---|---|
| **PR-1 (this)** | Boot Step-6c wiring, fail-closed §4, feature-gated | none (flag still default-OFF) |
| PR-2 | Scope-aware planner → WS actually subscribes the ~250 SIDs | none |
| PR-3 | Flip prod `default` flag + `scope = "daily_universe"` | **GO-LIVE — 250 SIDs everywhere** |

## Honest boundary (NOT in PR-1)

The WebSocket subscription still uses the 4-IDX_I `LOCKED_UNIVERSE` — the planner does not consume `DailyUniverse` yet (PR-2). 250 SIDs are **computed + persisted + audited** here, **not yet streamed**.

## Z+ 7-row resilience matrix (this PR's specifics)

| Demand | This PR (honest envelope) |
|---|---|
| Zero ticks lost | N/A — cold boot step; runs before the WS pool spawns, touches no tick path |
| WS never disconnects | N/A — no WS change; subscription untouched (still 4-IDX_I) |
| Never slow/locked/hanged | Cold path; `Arc<CsvDownloader>` fetch is bounded by `CSV_CONNECT_TIMEOUT_SECS` + per-attempt timeout; no `.await` under any std lock; the §4 infinite retry is intentional blocking, not a hang |
| QuestDB never fails | Step-6c runs only after `wait_for_questdb_ready`; reconcile/audit are fail-closed — a QuestDB error HALTS boot (no false-OK) |
| O(1) latency | N/A — one-shot boot fetch, not hot path |
| Uniqueness + dedup | Delegates to reconcile's `(security_id, exchange_segment)` keying (I-P1-11) + the lifecycle DEDUP UPSERT keys |
| Real-time proof | INFO summary (universe_size, total_rows, attempts_used, upserted, expired); fail path = `error!` + halt context; full audit chain in the 3 tables |

## Z+ 15-row "100% everything" matrix (this PR's specifics)

| Demand | Mechanical proof |
|---|---|
| Code coverage | orchestrator's 11 unit tests (#851) + 3 new wiring-ratchet tests |
| Audit coverage | Step-6c populates `instrument_fetch_audit` + `instrument_lifecycle_audit` (SEBI chain) |
| Testing coverage | source-scan ratchet runs on the default build (feature-independent) |
| Code checks | banned-pattern + plan-verify + pub-fn-test clean; clippy clean (feature) |
| Code performance | cold path — no DHAT/bench needed; no hot-path allocation introduced |
| Monitoring | INFO boot summary + `error!` halt with `code = INSTR-FETCH-01` |
| Logging | tracing only; halt carries the typed code field |
| Alerting | §4 escalating Telegram (4/11/21) inside the orchestrator's retry runner |
| Security | no secrets logged; CSV body never logged; downloader hardened (#18 redirect/size/content-type) |
| Bug fixing | builds both ways; fail-closed verified by ratchet |
| Scenarios | 4 scenarios in the plan (feature OFF / CSV reachable / CSV down / QuestDB down) |
| Functionalities | `run_daily_universe_boot` now has a real call site (pub-fn-wiring) |
| Code review | self + the merged #851 3-agent review on the orchestrator it calls |
| Extreme check | wiring ratchet fails the build on silent downgrade to fail-open or removal |

## Honest 100% claim

100% inside the tested envelope, with ratcheted regression coverage: boot is fail-closed and **blocks until a fresh CSV is in hand** (§4), pinned by `daily_universe_boot_wiring_guard.rs`; the orchestrator's sha/row-count/reconcile-gate are unit-tested (#851); default build is byte-for-byte unchanged (feature OFF). **NOT claimed in PR-1:** 250 SIDs streaming (PR-2) or prod-default-ON (PR-3).

## Test plan
- [x] default build (feature OFF) compiles unchanged
- [x] `--features daily_universe_fetcher` build compiles
- [x] wiring ratchet 3/3 green
- [x] clippy clean (feature), banned-pattern clean, plan-verify PASS
- [ ] CI all green

https://claude.ai/code/session_01PV5xzywyUHszxQ4qpEzij3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRxuAcTcWRQEpDNQQKTarN)_