### PR TITLE
feat: GO-LIVE — flip prod default to DailyUniverse 250-SID scope (PR-3)

### DIFF
--- a/config/base.toml
+++ b/config/base.toml
@@ -236,13 +236,15 @@ allowed_origins = ["http://localhost:3000", "http://localhost:3001"]
 # 218 NSE_EQ F&O underlying stocks in Quote mode. NO derivatives, NO greeks,
 # NO depth-20, NO depth-200, NO movers pipeline, NO Phase 2 dispatcher.
 #
-# Scope is the SOURCE OF TRUTH for the 2-WS lock per
-# `.claude/rules/project/websocket-connection-scope-lock.md` and charter §I.
-# `indices_4_only` is the ONLY legal value after PR #7b — the legacy
-# `full_universe` / `indices_only_all_expiries` / `indices_underlyings_only`
-# variants have been retired. Adding a new scope requires operator
-# re-approval recorded in the rule file with a dated quote.
-scope = "indices_4_only"
+# Scope is the SOURCE OF TRUTH for the WS subscription per
+# `.claude/rules/project/daily-universe-scope-expansion-2026-05-27.md`
+# (supersedes the 2026-05-15 4-SID lock). GO-LIVE 2026-05-28: `daily_universe`
+# is the operator-locked production scope — ~250 SIDs (all NSE indices + 1 BSE
+# SENSEX + unique F&O underlying spots), Quote mode, fail-closed §4. The
+# 2-WebSocket lock (1 main-feed + 1 order-update) is UNCHANGED. The only other
+# legal value is `indices_4_only` (the retired 4-SID scope, kept for rollback).
+# Adding a new scope requires operator re-approval recorded in the rule file.
+scope = "daily_universe"
 feed_mode = "Full"
 subscribe_stock_equities = true
 stock_atm_strikes_above = 25

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -50,11 +50,15 @@ core_affinity = { workspace = true }
 sha2 = { workspace = true, optional = true }
 
 [features]
-# Sub-PR #10b-ζ-2 of the 2026-05-27 daily-universe expansion: forwards
-# the daily_universe_fetcher gate to core (the INSTR-FETCH runner) and
-# storage (the instrument_fetch_audit writer) so the app-side audit-write
-# seam compiles against both. Dormant by default per rule §21 — the boot
-# callsite + feature flip land in the final Sub-PR #10 boot orchestrator.
+# GO-LIVE (PR-3, 2026-05-28): daily_universe_fetcher is now in `default` per
+# the operator full-go-live approval ("250 SIDs + new scope as production AND
+# local, everywhere"; boot fail-closed §4 "Block until CSV"). The §21
+# sequencing is satisfied — the fetcher chain + boot wiring (PR-1 #852) +
+# scope-aware subscription (PR-2 #853) all merged first. Paired with
+# `config/base.toml [subscription] scope = "daily_universe"`.
+default = ["daily_universe_fetcher"]
+# Forwards the gate to core (the INSTR-FETCH runner) and storage (the
+# instrument_fetch_audit writer) so the app-side audit-write seam compiles.
 daily_universe_fetcher = [
     "dep:sha2",
     "tickvault-core/daily_universe_fetcher",

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4718,13 +4718,19 @@ async fn load_daily_universe_plan(
     // and `today-midnight` are consistent.
     let now_utc = chrono::Utc::now();
     let offset_nanos = i64::from(IST_UTC_OFFSET_SECONDS) * 1_000_000_000;
-    let now_ist_nanos = now_utc.timestamp_nanos_opt().unwrap_or(0) + offset_nanos;
+    // Fail-closed on a clock outside the representable nanos range
+    // (~1677..2262) rather than silently stamping epoch-0 audit rows
+    // (PR-2 security review LOW). Unreachable in practice; never lies.
+    let now_ist_nanos = now_utc
+        .timestamp_nanos_opt()
+        .context("Step 6c: system clock outside representable nanosecond range")?
+        + offset_nanos;
     let now_ist = now_utc + chrono::TimeDelta::seconds(i64::from(IST_UTC_OFFSET_SECONDS));
     let today_ist_nanos = now_ist
         .date_naive()
         .and_hms_opt(0, 0, 0)
         .and_then(|midnight| midnight.and_utc().timestamp_nanos_opt())
-        .unwrap_or(now_ist_nanos);
+        .context("Step 6c: IST midnight outside representable nanosecond range")?;
 
     let downloader = Arc::new(CsvDownloader::new().context("Step 6c: CsvDownloader init failed")?);
     let fetch_fn = move |_attempt: u32| {


### PR DESCRIPTION
## Summary

**GO-LIVE PR-3 of 3** — the prod activation. Per your full-go-live approval ("250 SIDs + new scope as production AND local, everywhere"; fail-closed §4 "Block until CSV"). §21 sequencing satisfied: the fetcher chain + boot wiring (PR-1 #852) + scope-aware subscription (PR-2 #853) all merged first.

Two coupled changes (+ a folded-in LOW fix orphaned from PR-2's merge):
- **`crates/app/Cargo.toml`**: `default = ["daily_universe_fetcher"]` (was empty) → the fetcher + boot Step-6c + scope-aware planner compile into the default app build + binary.
- **`config/base.toml`**: `[subscription] scope` `"indices_4_only"` → `"daily_universe"` → runtime activates the ~250-SID universe (all NSE indices + SENSEX + F&O underlying spots), Quote mode, fail-closed. `indices_4_only` retained as the rollback value.
- **`main.rs`** (cherry-picked PR-2 LOW): IST-nanos `timestamp_nanos_opt().context(?)` instead of silent `unwrap_or(0)`.

**Effect on merge:** every default `cargo run` / prod binary now downloads the Dhan CSV at boot, builds the universe, persists `instrument_lifecycle` + `*_audit`, and the WS subscribes 250 SIDs. **The 2-WebSocket lock (1 main-feed + 1 order-update) is UNCHANGED.** Rollback = revert this commit.

## Sequence (GO-LIVE complete on merge)

| PR | Status |
|---|---|
| PR-1 #852 | merged — boot Step-6c wiring (fail-closed §4) |
| PR-2 #853 | merged — scope-aware 250-SID subscription |
| **PR-3 (this)** | **flips prod default ON + scope=daily_universe → 250 SIDs LIVE everywhere** |

## Z+ hostile blast-radius review (before merge)

**Verdict: SAFE for CI — no CRITICAL/HIGH.** Verified by compiling/running, not just reading.
- core/storage/common/trading/api nextest jobs use their *own* crate defaults (feature still OFF there) → unaffected. App job gains 11 fast daily_universe_boot tests (stub fetch + `127.0.0.1:1` instant-refuse → no network, no 90s-cap hang; all pass in 10s).
- No guard asserts feature-OFF/scope=indices_4_only: `feature_flag_rollback_guard` checks runtime `[features]` (FeaturesConfig), not Cargo features; `test_subscription_scope_default_is_indices4only` tests the enum `Default`, not the TOML; `indices4only_scope_lock_guard` scans for *retired* variants only (DailyUniverse is active, not retired); `daily_universe_scope_guard` has no config-TOML scope pin.
- `--no-default-features` compiles clean (the `not(feature)` bail is a runtime branch); no CI job uses it.
- **MEDIUM (deploy-only, NOT this PR's CI):** the release `--bin tickvault` 15MB cap in `deploy-aws.yml` now includes `sha2` + the fetcher chain. Won't redden this PR; will be verified during the AWS-readiness cutover (one-line cap bump if needed).

## Local verification
- [x] default build (now feature-on) compiles
- [x] app daily_universe 11/11, pipeline_smoke 10/10
- [x] scope-lock 4/4, daily_universe_scope_guard 10/10, feature_flag_rollback 39/39, wiring 3/3
- [x] clippy clean (no main.rs/Cargo warnings), banned-pattern clean
- [ ] CI all green

## Honest 100% claim
100% inside the tested envelope, ratcheted: GO-LIVE flips default+scope so the ~250-SID DailyUniverse runs prod+local, fail-closed §4 (boot blocks until a fresh CSV is in hand). Rollback = revert. **Deploy-time caveat:** release binary size vs the 15MB AWS cap is verified separately before the Monday AWS cutover (deploy job, not this PR).

https://claude.ai/code/session_01PV5xzywyUHszxQ4qpEzij3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRxuAcTcWRQEpDNQQKTarN)_