### PR TITLE
feat(deploy): optional SNS SMS alert leg (3rd fan-out channel)

### DIFF
--- a/deploy/aws/terraform/sns-subscriptions.tf
+++ b/deploy/aws/terraform/sns-subscriptions.tf
@@ -25,9 +25,24 @@ resource "aws_sns_topic_subscription" "operator_email" {
 
 # Telegram webhook is wired in `telegram-webhook-lambda.tf` (separate file
 # so the IAM role + Lambda + log group + self-error alarm + SNS subscription
-# stay co-located). Remaining 2 fan-out legs are still TODO:
-# - aws_sns_topic_subscription.operator_sms — protocol = "sms", endpoint = var.operator_phone
-# - aws_connect_outbound_voice_contact — for Critical-severity wake-up call
+# stay co-located).
+
+# SMS fan-out leg (3rd channel). OPTIONAL — created only when
+# var.operator_phone is set (E.164). Empty phone => count 0 => no SMS
+# subscription, no apply error. NOTE: India SMS delivery via SNS may need
+# the account moved out of the SMS sandbox + DLT sender-ID registration
+# (operator/AWS-account concern, not code). Cost budgeted in aws-budget.md
+# §6 (~100 msgs/mo).
+resource "aws_sns_topic_subscription" "operator_sms" {
+  count     = var.operator_phone == "" ? 0 : 1
+  topic_arn = aws_sns_topic.tv_alerts.arn
+  protocol  = "sms"
+  endpoint  = var.operator_phone
+}
+
+# Remaining fan-out leg still TODO (post-go-live — needs an AWS Connect
+# instance + contact flow, heavier than a single Terraform resource):
+# - aws_connect_outbound_voice_contact — Critical-severity wake-up call
 
 output "operator_email_subscription_status" {
   description = "Reminder: check your inbox for the SNS confirmation email and click the link to activate alarm delivery."

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -112,3 +112,14 @@ variable "operator_email" {
     error_message = "operator_email must be a valid email address (set via TF_VAR_operator_email=you@example.com)."
   }
 }
+
+variable "operator_phone" {
+  description = "Operator phone number in E.164 format (e.g. +919876543210) for the SNS SMS alert leg — the 3rd fan-out channel after Telegram + email. OPTIONAL: leave empty (\"\") to skip SMS (no subscription is created). Set via TF_VAR_operator_phone. India SMS via SNS may require moving the account out of the SMS sandbox + DLT sender-ID registration (operator/AWS-account concern, not code)."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.operator_phone == "" || can(regex("^\\+[1-9][0-9]{7,14}$", var.operator_phone))
+    error_message = "operator_phone must be empty or E.164 format (e.g. +919876543210)."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the **SMS** leg of the operator-charter §C "100% alerting" / aws-budget.md §6 4-channel fan-out (SMS + Telegram + Email + Connect). Today only **Telegram** (SNS→Lambda) + **Email** are wired — this adds SMS so Critical CloudWatch alarms reach you on a 3rd independent channel.

- `variables.tf`: new `operator_phone` (E.164, validated). **OPTIONAL** — default `""` so SMS is skipped when unset.
- `sns-subscriptions.tf`: `aws_sns_topic_subscription.operator_sms`, `count`-gated on `operator_phone != ""` (empty → 0 subscriptions, no apply error). Mirrors the existing fmt-clean `operator_email` block.

**Non-breaking + opt-in:** with `operator_phone` unset, `terraform apply` behaves exactly as before. To enable, set `TF_VAR_operator_phone=+91…`.

## Why now
You asked to "go ahead" on the optional alerting enhancement. This is the clean, low-risk one. The **Connect outbound-voice** 4th leg stays TODO post-go-live (needs a heavier AWS Connect instance + contact flow).

## Notes / honest caveats
- **India SMS via SNS** may require moving the account out of the SMS sandbox + DLT sender-ID registration — that's an operator/AWS-account step, not code.
- The terraform `fmt -check`/`validate` job is **gated behind `bootstrap_ready`**, so it's skipped on this PR (pre-bootstrap) and runs on your Saturday apply. The HCL mirrors the existing fmt-clean block; if `fmt -check` ever complains, `terraform fmt` fixes it.
- I could **not** run `terraform fmt/validate` locally (not installed in the sandbox) — flagging that honestly.

## Not in scope (deliberately)
- Binary 15 MB cap: not blindly bumped — it's self-enforced at deploy (loud failure, 1-line fix) and you can verify on your Mac (`cargo build --release --bin tickvault && stat -f%z target/release/tickvault`).
- AWS Connect outbound call (4th leg) — post-go-live.

## Test plan
- [x] No Rust changed; no guard pins SNS subscription counts (verified)
- [x] `operator_phone` defaults to "" → SMS resource not created (non-breaking)
- [ ] terraform fmt/validate (runs on post-bootstrap apply)

https://claude.ai/code/session_01PV5xzywyUHszxQ4qpEzij3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRxuAcTcWRQEpDNQQKTarN)_