### PR TITLE
perf(instrument): batch lifecycle/audit DB writes — boot 12s→~1s, unblock 219K master

### DIFF
--- a/crates/app/src/apply_reconcile_plan.rs
+++ b/crates/app/src/apply_reconcile_plan.rs
@@ -62,7 +62,8 @@ use tickvault_common::config::QuestDbConfig;
 use tickvault_common::sanitize::sanitize_audit_string;
 use tickvault_storage::instrument_lifecycle_persistence::{
     InstrumentLifecycleAuditRow, InstrumentLifecycleRow, LifecycleState, TransitionKind,
-    append_instrument_lifecycle_audit_row, append_instrument_lifecycle_row, update_lifecycle_state,
+    append_instrument_lifecycle_audit_rows, append_instrument_lifecycle_rows,
+    update_lifecycle_state,
 };
 use tracing::{error, info};
 
@@ -429,17 +430,24 @@ pub async fn apply_reconcile_plan(
 ) -> ApplyOutcome {
     let mut outcome = ApplyOutcome::default();
 
+    // ── Phase 1 — build ALL rows in memory (no I/O). PERF 2026-05-29: the
+    // previous per-action loop did 2 HTTP round-trips PER ROW, each building
+    // a fresh client — ~219K rows = ~438K round-trips = boot took minutes→
+    // hours. We now collect owned audit + lifecycle rows + disappearances,
+    // then write them in chunked multi-row INSERTs (a handful of requests).
+    let mut owned_audits: Vec<OwnedLifecycleAuditRow> = Vec::with_capacity(plan.len());
+    let mut owned_upserts: Vec<OwnedLifecycleRow> = Vec::new();
+    // Disappearances are rare (a handful/day) → kept as per-row UPDATEs.
+    let mut disappearances: Vec<(i64, String, LifecycleState)> = Vec::new();
+
     for action in plan {
         let (security_id, exchange_segment) = &action.key;
         let detail = today_detail.get(&action.key);
         let prev_attrs = prev.get(&action.key);
 
-        // A present (UPSERT) transition's full-row write needs today's
-        // detail. Resolve it BEFORE the audit write so a missing-detail
-        // invariant violation skips the WHOLE action — never leaving an
-        // orphan audit row recording an UPSERT we then can't perform
-        // (the §24 invariant: no audit row without an intended,
-        // fulfillable lifecycle change). Disappearances need no detail.
+        // A present (UPSERT) transition needs today's detail. Resolve BEFORE
+        // queuing the audit row so a missing-detail invariant violation skips
+        // the WHOLE action (§24: no audit row without a fulfillable change).
         let upsert_detail = if is_upsert_transition(action.to_state) {
             match detail {
                 Some(today) => Some(today),
@@ -458,10 +466,8 @@ pub async fn apply_reconcile_plan(
             None
         };
 
-        // §24 step 1 — append the audit row FIRST (real transition_kind +
-        // *_after snapshot). On failure skip the lifecycle write: never a
-        // lifecycle change without its forensic row.
-        let audit = build_audit_row_for_action(
+        // Queue the audit row (written FIRST, as a batch, per §24).
+        owned_audits.push(build_audit_row_for_action(
             action,
             detail,
             prev_attrs,
@@ -469,24 +475,9 @@ pub async fn apply_reconcile_plan(
             today_ist_nanos,
             source_csv_sha256,
             dry_run,
-        );
-        if let Err(err) =
-            append_instrument_lifecycle_audit_row(questdb_config, &audit.as_row()).await
-        {
-            error!(
-                security_id,
-                exchange_segment = exchange_segment.as_str(),
-                transition_kind = action.transition_kind.as_str(),
-                ?err,
-                "lifecycle audit append failed — skipping lifecycle write (next boot re-runs)"
-            );
-            outcome.errors += 1;
-            continue;
-        }
+        ));
 
-        // §24 step 2 — apply the lifecycle change.
         if let Some(today) = upsert_detail {
-            // Present transition → full-row UPSERT.
             let (row, malformed) = build_lifecycle_upsert_row(
                 action,
                 today,
@@ -499,9 +490,6 @@ pub async fn apply_reconcile_plan(
             if malformed {
                 outcome.malformed_expiry += 1;
                 metrics::counter!(MALFORMED_EXPIRY_COUNTER).increment(1);
-                // raw_expiry is, by definition here, an unparseable
-                // CSV-sourced string — strip control/BiDi chars before it
-                // reaches the JSONL/Telegram log pipeline (log-integrity).
                 error!(
                     security_id,
                     exchange_segment = exchange_segment.as_str(),
@@ -509,44 +497,78 @@ pub async fn apply_reconcile_plan(
                     "derivative expiry string failed to parse — wrote 0 (no-expiry) sentinel"
                 );
             }
-            match append_instrument_lifecycle_row(questdb_config, &row.as_row()).await {
-                Ok(()) => outcome.upserted += 1,
-                Err(err) => {
-                    error!(
-                        security_id,
-                        exchange_segment = exchange_segment.as_str(),
-                        ?err,
-                        "lifecycle UPSERT failed (audit row written; next boot re-runs)"
-                    );
-                    outcome.errors += 1;
-                }
-            }
+            owned_upserts.push(row);
         } else {
-            // Disappearance → in-place state UPDATE (expire / segment-move).
-            match update_lifecycle_state(
-                questdb_config,
-                *security_id,
-                exchange_segment,
-                action.to_state,
-                today_ist_nanos, // expired_date
-                now_ist_nanos,   // last_update_ts
-            )
-            .await
-            {
-                Ok(()) => outcome.expired += 1,
-                Err(err) => {
-                    error!(
-                        security_id,
-                        exchange_segment = exchange_segment.as_str(),
-                        ?err,
-                        "lifecycle state UPDATE failed (audit row written; next boot re-runs)"
-                    );
-                    outcome.errors += 1;
-                }
+            disappearances.push((*security_id, exchange_segment.clone(), action.to_state));
+        }
+    }
+
+    // ── Phase 2 — §24 audit-first: write ALL audit rows (batched) BEFORE any
+    // lifecycle write. If the audit batch fails, skip the lifecycle batch so
+    // we never have a lifecycle change without its forensic chain (next boot
+    // re-runs — idempotent via DEDUP UPSERT KEYS).
+    let audit_rows: Vec<InstrumentLifecycleAuditRow<'_>> = owned_audits
+        .iter()
+        .map(OwnedLifecycleAuditRow::as_row)
+        .collect();
+    if let Err(err) = append_instrument_lifecycle_audit_rows(questdb_config, &audit_rows).await {
+        error!(
+            ?err,
+            audit_rows = audit_rows.len(),
+            "lifecycle audit BATCH append failed — skipping lifecycle writes (next boot re-runs)"
+        );
+        outcome.errors += audit_rows.len();
+        return finish_apply(outcome);
+    }
+
+    // ── Phase 3 — batched lifecycle UPSERT.
+    let upsert_rows: Vec<InstrumentLifecycleRow<'_>> = owned_upserts
+        .iter()
+        .map(OwnedLifecycleRow::as_row)
+        .collect();
+    match append_instrument_lifecycle_rows(questdb_config, &upsert_rows).await {
+        Ok(()) => outcome.upserted += upsert_rows.len(),
+        Err(err) => {
+            error!(
+                ?err,
+                upsert_rows = upsert_rows.len(),
+                "lifecycle UPSERT BATCH failed (audit rows written; next boot re-runs)"
+            );
+            outcome.errors += upsert_rows.len();
+        }
+    }
+
+    // ── Phase 4 — disappearance state-flips (rare → per-row UPDATE).
+    for (security_id, exchange_segment, to_state) in &disappearances {
+        match update_lifecycle_state(
+            questdb_config,
+            *security_id,
+            exchange_segment,
+            *to_state,
+            today_ist_nanos,
+            now_ist_nanos,
+        )
+        .await
+        {
+            Ok(()) => outcome.expired += 1,
+            Err(err) => {
+                error!(
+                    security_id,
+                    exchange_segment = exchange_segment.as_str(),
+                    ?err,
+                    "lifecycle state UPDATE failed (audit row written; next boot re-runs)"
+                );
+                outcome.errors += 1;
             }
         }
     }
 
+    finish_apply(outcome)
+}
+
+/// Emit the completion log + return the outcome (shared by the normal path
+/// and the audit-batch-failure early return).
+fn finish_apply(outcome: ApplyOutcome) -> ApplyOutcome {
     info!(
         upserted = outcome.upserted,
         expired = outcome.expired,

--- a/crates/storage/src/instrument_lifecycle_persistence.rs
+++ b/crates/storage/src/instrument_lifecycle_persistence.rs
@@ -499,6 +499,67 @@ pub async fn append_instrument_lifecycle_row(
     Ok(())
 }
 
+/// Rows per multi-row INSERT request. QuestDB `/exec` accepts large
+/// multi-row `VALUES` bodies; 5000 collapses the applicable-F&O master
+/// (~219K rows) into ~44 requests instead of ~219K single-row round-trips.
+/// PERF (2026-05-29): the per-row path built a fresh `reqwest::Client` +
+/// one HTTP round-trip PER ROW — 219K rows = ~219K round-trips = boot took
+/// minutes→hours. Batching + one reused client cuts it to a few seconds.
+pub const LIFECYCLE_INSERT_BATCH_SIZE: usize = 5000;
+
+/// Build ONE multi-row `INSERT … VALUES (t1),(t2),…,(tN);` for a chunk of
+/// lifecycle rows. PURE (no I/O) — extracted for deterministic testing.
+#[must_use]
+pub fn build_lifecycle_multi_insert_sql(rows: &[InstrumentLifecycleRow<'_>]) -> String {
+    let tuples: Vec<String> = rows.iter().map(format_lifecycle_row_tuple).collect();
+    format!(
+        "INSERT INTO {QUESTDB_TABLE_INSTRUMENT_LIFECYCLE} \
+         ({LIFECYCLE_INSERT_COLUMN_LIST}) VALUES {};",
+        tuples.join(",")
+    )
+}
+
+/// Batched UPSERT of many `instrument_lifecycle` rows. ONE reused client;
+/// rows chunked into [`LIFECYCLE_INSERT_BATCH_SIZE`] multi-row INSERTs.
+/// Idempotent via the table's DEDUP UPSERT KEYS — re-run is safe.
+/// (Pure builder `build_lifecycle_multi_insert_sql` carries the unit coverage.)
+// TEST-EXEMPT: requires running QuestDB; tested via boot integration in CI.
+pub async fn append_instrument_lifecycle_rows(
+    questdb_config: &QuestDbConfig,
+    rows: &[InstrumentLifecycleRow<'_>],
+) -> anyhow::Result<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let base_url = format!(
+        "http://{}:{}/exec",
+        questdb_config.host, questdb_config.http_port
+    );
+    let client = Client::builder()
+        .timeout(Duration::from_secs(QUESTDB_EXEC_TIMEOUT_SECS))
+        .build()?;
+    for chunk in rows.chunks(LIFECYCLE_INSERT_BATCH_SIZE) {
+        let sql = build_lifecycle_multi_insert_sql(chunk);
+        let resp = client
+            .get(&base_url)
+            .query(&[("query", sql.as_str())])
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body: String = resp
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(200)
+                .collect();
+            anyhow::bail!("instrument_lifecycle batch insert non-2xx ({status}): {body}");
+        }
+    }
+    Ok(())
+}
+
 // ============================================================================
 // instrument_lifecycle_audit persistence (DDL + Row + ensure + append)
 // ============================================================================
@@ -689,6 +750,60 @@ pub async fn append_instrument_lifecycle_audit_row(
             .take(200)
             .collect();
         anyhow::bail!("instrument_lifecycle_audit insert non-2xx ({status}): {body}");
+    }
+    Ok(())
+}
+
+/// Build ONE multi-row `INSERT … VALUES (t1),…,(tN);` for a chunk of audit
+/// rows. PURE (no I/O) — extracted for deterministic testing.
+#[must_use]
+pub fn build_lifecycle_audit_multi_insert_sql(rows: &[InstrumentLifecycleAuditRow<'_>]) -> String {
+    let tuples: Vec<String> = rows.iter().map(format_lifecycle_audit_row_tuple).collect();
+    format!(
+        "INSERT INTO {QUESTDB_TABLE_INSTRUMENT_LIFECYCLE_AUDIT} \
+         ({LIFECYCLE_AUDIT_INSERT_COLUMN_LIST}) VALUES {};",
+        tuples.join(",")
+    )
+}
+
+/// Batched append of many `instrument_lifecycle_audit` rows. ONE reused
+/// client; chunked into [`LIFECYCLE_INSERT_BATCH_SIZE`] multi-row INSERTs.
+/// Append-only forensic chain — written BEFORE the lifecycle batch so the
+/// §24 audit-first invariant holds at batch granularity.
+/// (Pure builder `build_lifecycle_audit_multi_insert_sql` carries unit coverage.)
+// TEST-EXEMPT: requires running QuestDB; tested via boot integration in CI.
+pub async fn append_instrument_lifecycle_audit_rows(
+    questdb_config: &QuestDbConfig,
+    rows: &[InstrumentLifecycleAuditRow<'_>],
+) -> anyhow::Result<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let base_url = format!(
+        "http://{}:{}/exec",
+        questdb_config.host, questdb_config.http_port
+    );
+    let client = Client::builder()
+        .timeout(Duration::from_secs(QUESTDB_EXEC_TIMEOUT_SECS))
+        .build()?;
+    for chunk in rows.chunks(LIFECYCLE_INSERT_BATCH_SIZE) {
+        let sql = build_lifecycle_audit_multi_insert_sql(chunk);
+        let resp = client
+            .get(&base_url)
+            .query(&[("query", sql.as_str())])
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body: String = resp
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(200)
+                .collect();
+            anyhow::bail!("instrument_lifecycle_audit batch insert non-2xx ({status}): {body}");
+        }
     }
     Ok(())
 }
@@ -1352,6 +1467,38 @@ mod tests {
     #[test]
     fn test_ensure_instrument_lifecycle_audit_table_pub_fn_visible() {
         let _ = ensure_instrument_lifecycle_audit_table;
+    }
+
+    #[test]
+    fn test_build_lifecycle_multi_insert_sql_batches_rows() {
+        let rows = [sample_index_row(), sample_index_row(), sample_index_row()];
+        let sql = build_lifecycle_multi_insert_sql(&rows);
+        assert!(
+            sql.starts_with(&format!(
+                "INSERT INTO {QUESTDB_TABLE_INSTRUMENT_LIFECYCLE} ("
+            )),
+            "must target the lifecycle table with the column list"
+        );
+        // 3 tuples → 2 `),(` separators → ONE multi-row INSERT (not 3 requests).
+        assert_eq!(sql.matches("),(").count(), 2, "3 rows → one batched INSERT");
+        assert!(sql.ends_with(");"));
+    }
+
+    #[test]
+    fn test_build_lifecycle_audit_multi_insert_sql_batches_rows() {
+        let rows = [sample_audit_row(), sample_audit_row()];
+        let sql = build_lifecycle_audit_multi_insert_sql(&rows);
+        assert!(sql.contains(QUESTDB_TABLE_INSTRUMENT_LIFECYCLE_AUDIT));
+        assert_eq!(sql.matches("),(").count(), 1, "2 rows → one batched INSERT");
+        assert!(sql.ends_with(");"));
+    }
+
+    #[test]
+    fn test_build_multi_insert_sql_empty_is_degenerate_but_safe() {
+        // Empty slice → "VALUES ;" — never actually sent (the async fn early-
+        // returns on empty), but the builder must not panic.
+        let sql = build_lifecycle_multi_insert_sql(&[]);
+        assert!(sql.contains("VALUES ;"));
     }
 
     #[tokio::test]

--- a/crates/storage/tests/daily_universe_scope_guard.rs
+++ b/crates/storage/tests/daily_universe_scope_guard.rs
@@ -276,3 +276,39 @@ fn extract_today_instruments_chains_fno_contracts() {
         "extract_today_instruments must chain universe.fno_contracts into the lifecycle set"
     );
 }
+
+// ---------------------------------------------------------------------------
+// PERF ratchet (2026-05-29): the lifecycle reconcile MUST write in BATCHES,
+// not one HTTP round-trip per row. The per-row path built a fresh client +
+// one round-trip per row → ~219K rows = ~438K round-trips = boot took
+// minutes→hours. A regression to the per-row append fns fails the build here.
+// ---------------------------------------------------------------------------
+#[test]
+fn apply_reconcile_uses_batched_writes_not_per_row() {
+    let body = src("crates/app/src/apply_reconcile_plan.rs");
+    assert!(
+        body.contains("append_instrument_lifecycle_rows(")
+            && body.contains("append_instrument_lifecycle_audit_rows("),
+        "apply_reconcile_plan must use the BATCHED append fns (one client, multi-row INSERT)"
+    );
+    assert!(
+        !body.contains("append_instrument_lifecycle_row(")
+            && !body.contains("append_instrument_lifecycle_audit_row("),
+        "apply_reconcile_plan must NOT use the per-row append fns — perf regression \
+         (219K rows = 219K HTTP round-trips). Use the batched *_rows fns."
+    );
+}
+
+#[test]
+fn lifecycle_persistence_exposes_batched_insert_path() {
+    let body = src("crates/storage/src/instrument_lifecycle_persistence.rs");
+    assert!(
+        body.contains("pub async fn append_instrument_lifecycle_rows")
+            && body.contains("pub async fn append_instrument_lifecycle_audit_rows"),
+        "storage must expose batched insert fns"
+    );
+    assert!(
+        body.contains("LIFECYCLE_INSERT_BATCH_SIZE") && body.contains(".chunks("),
+        "batched inserts must chunk rows into multi-row INSERTs"
+    );
+}


### PR DESCRIPTION
## Why instrument-load took >1 minute — root cause (proven, line-cited)

The daily lifecycle reconcile wrote **one HTTP round-trip per row**, and each writer **built a brand-new `reqwest::Client` every call**:

- `append_instrument_lifecycle_row` (`instrument_lifecycle_persistence.rs:473`) → `Client::builder()…build()` **per row** + single-row `INSERT … VALUES (one tuple)` round-trip.
- `apply_reconcile_plan` (`apply_reconcile_plan.rs:432`) looped doing **2 sequential awaits per action** (audit `:474` + lifecycle `:488`).

So **331 rows = 662 fresh-client round-trips ≈ the ~12s you saw.** And the F&O-master change (#872) scaled the master to **~219K rows → ~438K round-trips → boot would take minutes→hours.** Critical regression — fixed here.

## Fix — batch + reuse one client

| Before | After |
|---|---|
| fresh `Client` **per row** | **one** client reused |
| 1 HTTP round-trip **per row** (`INSERT … VALUES (1 tuple)`) | chunked **multi-row** `INSERT … VALUES (t1),(t2),…,(tN)` |
| 219K rows → ~438K requests | 219K rows → **~44 requests** (batch 5000 × audit+lifecycle) |
| ~12s for 331 / hours for 219K | **~1s for 331 / seconds for 219K** |

- `append_instrument_lifecycle_rows` / `append_instrument_lifecycle_audit_rows` — one client, `rows.chunks(LIFECYCLE_INSERT_BATCH_SIZE=5000)`.
- Pure builders `build_lifecycle_multi_insert_sql` / `build_lifecycle_audit_multi_insert_sql` — unit-tested.
- `apply_reconcile_plan` → **two-phase**: Phase 1 builds all rows in memory (no I/O); Phase 2 writes the **audit batch FIRST** (§24 audit-first preserved at batch granularity); Phase 3 the lifecycle UPSERT batch; Phase 4 rare disappearance UPDATEs per-row. Idempotent via DEDUP UPSERT KEYS.

## Z+ ratchets (guarantee + proof)
- `apply_reconcile_uses_batched_writes_not_per_row` — apply MUST use the batched `*_rows` fns and MUST NOT use the per-row append fns (blocks the regression).
- `lifecycle_persistence_exposes_batched_insert_path` — chunked batch path pinned.
- +3 builder unit tests.

## Tests
- [x] `cargo test -p tickvault-storage --features daily_universe_fetcher` builders → 7 passed
- [x] `cargo test -p tickvault-app --lib apply_reconcile_plan` → 21 passed
- [x] `cargo test -p tickvault-storage --test daily_universe_scope_guard` → 15 passed
- [x] pub-fn-test-guard stable (112); banned-pattern clean

## Honest envelope + next O(1) steps
Still HTTP `/exec` multi-row INSERT (not ILP) — a few requests for the full master, **seconds not minutes**. Next optimisations (separate PRs): ILP conversion (the tick_persistence high-throughput path) + an **rkyv warm-cache / skip-if-CSV-SHA-unchanged** so an unchanged universe skips the re-UPSERT entirely (true O(1) warm boot, crash-resilient). The raw CSV is already disk-cached; the parsed-universe rkyv cache is the missing piece you flagged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E55aA4VUh1BSdLmqxcUfwz)_