### PR TITLE
feat(instrument): boot-timing proof + Telegram — real daily evidence of O(1) warm path

### DIFF
--- a/crates/app/src/daily_universe_boot.rs
+++ b/crates/app/src/daily_universe_boot.rs
@@ -44,6 +44,7 @@
 
 use core::future::Future;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
@@ -71,6 +72,10 @@ pub struct DailyUniverseBootOutcome {
     pub source_csv_sha256: String,
     /// The reconcile tally (the caller MUST inspect `reconcile.apply.errors`).
     pub reconcile: ReconcileRunOutcome,
+    /// Wall-clock of the whole instrument load (fetch→build→reconcile), ms.
+    /// Real-time proof of the O(1) warm path: a warm-skip boot is sub-second
+    /// regardless of universe size; a full rebuild is the batched seconds path.
+    pub elapsed_ms: u64,
 }
 
 /// Lowercase-hex SHA-256 of the CSV bytes — the `source_csv_sha256`
@@ -170,6 +175,12 @@ where
     Fetch: FnMut(u32) -> FetchFut,
     FetchFut: Future<Output = Result<Vec<u8>, CsvDownloadError>>,
 {
+    // Wall-clock the whole instrument load (fetch→build→reconcile). This is
+    // the real-time proof of the O(1) warm path: a warm-skip boot is
+    // sub-second regardless of universe size; a full rebuild is the batched
+    // seconds path. Surfaced via `elapsed_ms` + Telegram + Prometheus.
+    let boot_timer = Instant::now();
+
     // Capture provenance (sha + data-row count) of each fetched body. On
     // success the last capture is the body that built the universe.
     let captured: Arc<Mutex<Option<(String, i64)>>> = Arc::new(Mutex::new(None));
@@ -263,12 +274,14 @@ where
         dry_run,
         "daily-universe boot complete"
     );
+    let elapsed_ms = u64::try_from(boot_timer.elapsed().as_millis()).unwrap_or(u64::MAX);
     let outcome = DailyUniverseBootOutcome {
         attempts_used,
         universe_size,
         total_rows,
         source_csv_sha256,
         reconcile,
+        elapsed_ms,
     };
     Ok((outcome, universe))
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2525,6 +2525,20 @@ async fn main() -> Result<()> {
         });
     }
 
+    // Boot-timing proof Telegram (DailyUniverse scope only — sentinel-guarded
+    // so Indices4Only emits nothing). Reads the wall-clock stashed by
+    // `load_daily_universe_plan`; gives the operator REAL daily evidence the
+    // O(1) warm path is working: warm-skip boots are sub-second regardless of
+    // the applicable-F&O master size; a full rebuild is the batched-seconds
+    // cold path.
+    if let Some(message) = format_instrument_load_telegram(
+        INSTRUMENT_LOAD_ELAPSED_MS.load(std::sync::atomic::Ordering::Relaxed),
+        INSTRUMENT_LOAD_WARM_SKIPPED.load(std::sync::atomic::Ordering::Relaxed),
+        INSTRUMENT_LOAD_TOTAL_ROWS.load(std::sync::atomic::Ordering::Relaxed),
+    ) {
+        notifier.notify(NotificationEvent::Custom { message });
+    }
+
     // Only persist for CachedPlan (not yet persisted). FreshBuild already
     // persisted inside load_or_build_instruments — double-write creates
     // duplicate rows in the same timestamp second.
@@ -4613,6 +4627,58 @@ async fn main() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// Boot-timing proof — real-time evidence the O(1) warm path is working
+// ---------------------------------------------------------------------------
+//
+// `load_daily_universe_plan` (Step 6c) writes the whole instrument-load
+// wall-clock here so the caller (which DOES hold the `notifier`) can emit a
+// single operator-facing Telegram line each boot. Sentinel `u64::MAX` =
+// "not measured this boot" (e.g. the Indices4Only scope never runs the
+// daily-universe fetch), so the caller suppresses the Telegram in that case.
+//
+// Why globals and not a return-value thread: `load_instruments` and its
+// match arms return `(plan, universe, needs_persist)` shared across two boot
+// paths + two scopes; widening that tuple for one observability field would
+// touch every arm. A trio of atomics set in one place + read in one place is
+// the smaller, lower-risk surface.
+static INSTRUMENT_LOAD_ELAPSED_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(u64::MAX);
+static INSTRUMENT_LOAD_WARM_SKIPPED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+static INSTRUMENT_LOAD_TOTAL_ROWS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Formats the operator-facing boot-timing Telegram line.
+///
+/// Returns `None` when `elapsed_ms == u64::MAX` (the sentinel meaning "not
+/// measured this boot" — e.g. the Indices4Only scope skips the daily-universe
+/// fetch entirely), so the caller emits nothing in that case.
+///
+/// Plain-English, auto-driver-readable per the 10 Telegram commandments: no
+/// library names, no file paths, no version numbers — just "how long + warm
+/// or cold + how many rows".
+fn format_instrument_load_telegram(
+    elapsed_ms: u64,
+    warm_skipped: bool,
+    total_rows: u64,
+) -> Option<String> {
+    if elapsed_ms == u64::MAX {
+        return None;
+    }
+    // Integer seconds-with-one-decimal without float formatting surprises.
+    let secs_whole = elapsed_ms / 1000;
+    let secs_tenths = (elapsed_ms % 1000) / 100;
+    let detail = if warm_skipped {
+        "universe unchanged — reused the existing list (no rebuild needed)"
+    } else {
+        "full rebuild — fresh list pulled and saved"
+    };
+    Some(format!(
+        "📦 Instrument load: {secs_whole}.{secs_tenths}s ✅ — {detail} ({total_rows} rows on file)"
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // Helper: Load instruments (shared by fast and slow boot paths)
 // ---------------------------------------------------------------------------
 
@@ -4759,6 +4825,29 @@ async fn load_daily_universe_plan(
         expired = outcome.reconcile.apply.expired,
         "subscription plan ready (DailyUniverse — ~250 SIDs, Quote mode)"
     );
+
+    // Boot-timing proof: REAL evidence the O(1) warm path is working in
+    // production every day. A warm-skip boot (CSV SHA unchanged vs the last
+    // fetch-audit row) is sub-second regardless of the ~219K applicable-F&O
+    // master size; a full rebuild is the batched-seconds cold path. Surfaced
+    // three ways — structured INFO log (daily proof), Prometheus gauges
+    // (graphable trend), and a Telegram line emitted by the caller.
+    let elapsed_ms = outcome.elapsed_ms;
+    let warm_skipped = outcome.reconcile.warm_skipped;
+    let total_rows = u64::try_from(outcome.total_rows).unwrap_or(0);
+    info!(
+        elapsed_ms,
+        warm_skipped,
+        total_rows,
+        universe_size = outcome.universe_size,
+        "instrument load timing (O(1) warm-path proof)"
+    );
+    metrics::gauge!("tv_instrument_load_duration_ms").set(elapsed_ms as f64);
+    metrics::gauge!("tv_instrument_load_warm_skipped").set(if warm_skipped { 1.0 } else { 0.0 });
+    metrics::gauge!("tv_instrument_load_total_rows").set(total_rows as f64);
+    INSTRUMENT_LOAD_ELAPSED_MS.store(elapsed_ms, std::sync::atomic::Ordering::Relaxed);
+    INSTRUMENT_LOAD_WARM_SKIPPED.store(warm_skipped, std::sync::atomic::Ordering::Relaxed);
+    INSTRUMENT_LOAD_TOTAL_ROWS.store(total_rows, std::sync::atomic::Ordering::Relaxed);
 
     Ok((Some(plan), None, false))
 }
@@ -6048,6 +6137,39 @@ mod tests {
 
         assert!(should_fast_boot(true, true));
         assert!(!should_fast_boot(false, true));
+    }
+
+    #[test]
+    fn test_format_instrument_load_telegram_warm_skip() {
+        let msg = format_instrument_load_telegram(412, true, 219_431)
+            .expect("measured boot must produce a message");
+        assert!(msg.contains("0.4s"), "elapsed rendered: {msg}");
+        assert!(msg.contains("unchanged"), "warm-skip phrasing: {msg}");
+        assert!(msg.contains("219431"), "row count: {msg}");
+        // Telegram commandments: no library names / file paths.
+        assert!(!msg.contains("rkyv") && !msg.contains(".rs") && !msg.contains("QuestDB"));
+    }
+
+    #[test]
+    fn test_format_instrument_load_telegram_full_rebuild() {
+        let msg = format_instrument_load_telegram(6234, false, 219_431)
+            .expect("measured boot must produce a message");
+        assert!(msg.contains("6.2s"), "elapsed rendered: {msg}");
+        assert!(msg.contains("full rebuild"), "cold-path phrasing: {msg}");
+    }
+
+    #[test]
+    fn test_format_instrument_load_telegram_sentinel_suppressed() {
+        // u64::MAX == "not measured this boot" (e.g. Indices4Only scope) →
+        // no Telegram at all.
+        assert!(format_instrument_load_telegram(u64::MAX, false, 0).is_none());
+    }
+
+    #[test]
+    fn test_format_instrument_load_telegram_sub_100ms() {
+        // A warm-skip can be tens of ms — render as 0.0s, never panic.
+        let msg = format_instrument_load_telegram(37, true, 4).expect("message");
+        assert!(msg.contains("0.0s"), "sub-100ms rendered: {msg}");
     }
 
     #[test]

--- a/crates/storage/tests/daily_universe_scope_guard.rs
+++ b/crates/storage/tests/daily_universe_scope_guard.rs
@@ -352,3 +352,45 @@ fn storage_exposes_o1_warm_primitives() {
         "storage must read the last fetch-audit SHA in one bounded SELECT"
     );
 }
+
+#[test]
+fn boot_timing_proof_is_measured_and_surfaced() {
+    // The whole instrument load (fetch→build→reconcile) MUST be wall-clocked
+    // and carried back on the boot outcome, so the O(1) warm path has REAL
+    // daily evidence (not just a code-comment claim).
+    let boot = src("crates/app/src/daily_universe_boot.rs");
+    assert!(
+        boot.contains("use std::time::Instant;")
+            && boot.contains("let boot_timer = Instant::now();")
+            && boot.contains("pub elapsed_ms: u64"),
+        "run_daily_universe_boot must time the load and expose elapsed_ms"
+    );
+    assert!(
+        boot.contains("u64::try_from(boot_timer.elapsed().as_millis())"),
+        "elapsed_ms must be set from the boot_timer in the outcome construction"
+    );
+
+    // main.rs must surface the timing 3 ways: structured INFO log, Prometheus
+    // gauges (graphable trend), and an operator-facing Telegram line.
+    let main = src("crates/app/src/main.rs");
+    assert!(
+        main.contains("tv_instrument_load_duration_ms")
+            && main.contains("tv_instrument_load_warm_skipped")
+            && main.contains("tv_instrument_load_total_rows"),
+        "main.rs must emit the 3 boot-timing Prometheus gauges"
+    );
+    assert!(
+        main.contains("fn format_instrument_load_telegram")
+            && main.contains("NotificationEvent::Custom { message }"),
+        "main.rs must emit a boot-timing Telegram line via the pure formatter"
+    );
+    assert!(
+        main.contains("O(1) warm-path proof"),
+        "the structured INFO log must label the O(1) warm-path proof"
+    );
+    // Sentinel-guard: Indices4Only (no daily fetch) must emit no Telegram.
+    assert!(
+        main.contains("if elapsed_ms == u64::MAX") || main.contains("== u64::MAX"),
+        "the formatter must suppress the Telegram when timing was not measured"
+    );
+}


### PR DESCRIPTION
## Summary

The O(1) warm-boot path landed in #875 (batched writes) + #876 (SHA-skip warm boot), but its claim was only a code comment. This PR makes the warm path **prove itself in production every boot** by wall-clocking the whole instrument load (fetch→build→reconcile) and surfacing the number three ways. A warm-skip boot is sub-second regardless of the ~219K applicable-F&O master size; a full rebuild is the batched-seconds cold path — now the operator sees which one happened, how long it took, and how many rows are on file, on every boot.

## Items completed

- [x] Wall-clock the load in `run_daily_universe_boot` (`Instant::now()` → `elapsed_ms` on `DailyUniverseBootOutcome`)
- [x] Structured INFO log (`"instrument load timing (O(1) warm-path proof)"`) with `elapsed_ms` + `warm_skipped` + `total_rows`
- [x] 3 Prometheus gauges: `tv_instrument_load_duration_ms`, `tv_instrument_load_warm_skipped`, `tv_instrument_load_total_rows`
- [x] Operator-facing Telegram line via pure formatter `format_instrument_load_telegram` (plain English, no jargon)
- [x] Sentinel guard (`u64::MAX` = not measured) → Indices4Only scope emits no Telegram
- [x] 4 formatter unit tests + Z+ source-scan ratchet `boot_timing_proof_is_measured_and_surfaced`

## Telegram wording (auto-driver readable)

- Warm: `📦 Instrument load: 0.4s ✅ — universe unchanged — reused the existing list (no rebuild needed) (219431 rows on file)`
- Cold: `📦 Instrument load: 6.2s ✅ — full rebuild — fresh list pulled and saved (219431 rows on file)`

No library names, no file paths, no version numbers — per the 10 Telegram commandments.

## Z+ 7-row resilience matrix

| Demand | This PR |
|---|---|
| Zero ticks lost | observability-only; no tick-path change |
| WS never disconnects | untouched |
| Never slow/locked/hanged | pure formatter + 3 relaxed atomic stores; zero hot-path cost |
| QuestDB never fails | untouched |
| O(1) latency | this PR is the **real-time proof** the warm path is O(1) — sub-second regardless of master size |
| Uniqueness + dedup | untouched (lifecycle DEDUP intact) |
| Real-time proof | INFO log + 3 Prometheus gauges + Telegram per boot |

## Honest 100% claim

100% inside the tested envelope, with ratcheted regression coverage: the boot wall-clock is measured around the full fetch→build→reconcile span and carried on the typed outcome; the warm path (CSV SHA unchanged vs the last fetch-audit row) early-returns `warm_skipped=true` and is sub-second because it does 2 bounded DB requests (read-last-SHA + single active-scoped `last_seen` UPDATE) regardless of the ~219K-row master. Source-scan ratchet `boot_timing_proof_is_measured_and_surfaced` fails the build if the timer, gauges, formatter, INFO label, or sentinel guard are removed. This is observability of the O(1) path, not a new O(1) guarantee — #875/#876 own that.

## Test plan

- [x] `cargo test -p tickvault-app --bin tickvault format_instrument_load` (4 green)
- [x] `cargo test -p tickvault-storage --test daily_universe_scope_guard` (18 green)
- [x] `cargo check -p tickvault-app` (default + `--features daily_universe_fetcher`)
- [x] banned-pattern scanner clean
- [x] pub-fn-test-guard stable (112)

https://claude.ai/code/session_01E55aA4VUh1BSdLmqxcUfwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01E55aA4VUh1BSdLmqxcUfwz)_