### PR TITLE
feat(aws): NSE-holiday boot gate — self-stop the box on non-trading days

### DIFF
--- a/.claude/plans/archive/2026-05-29-holiday-start-gate.md
+++ b/.claude/plans/archive/2026-05-29-holiday-start-gate.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Holiday-aware EC2 start gate (in-boot self-stop)
+
+**Status:** VERIFIED
+**Date:** 2026-05-29
+**Approved by:** Parthiban (selected "Holiday-aware start gate" via AskUserQuestion 2026-05-29)
+
+## Problem
+
+EventBridge cron starts the m8g.large box `cron(0 3 ? * MON-FRI *)` (08:30 IST)
+EVERY weekday — including NSE weekday holidays (Republic Day, Independence Day,
+Diwali, etc.). On a holiday the box runs ~8h for a no-op boot (the in-app §22
+orchestrator already skips the CSV retry loop, but the instance still bills +
+emits boot noise). During the 3-month data-pull this wastes cost + adds noise.
+
+## Design — Architecture B: in-boot self-stop (single source of truth)
+
+A dedicated oneshot systemd unit runs on every boot BEFORE `tickvault.service`.
+It asks the app's OWN binary `--check-trading-day` (which reads the SAME
+`config/base.toml` NSE holiday list via `TradingCalendar` — ZERO duplication),
+and on a DEFINITIVE non-trading verdict it self-stops the instance. FAIL-OPEN
+on every uncertainty (binary missing on first boot, config error, IMDS error,
+unknown exit code) so it can NEVER accidentally kill a real trading day.
+
+Override: operator touches `/opt/tickvault/ALLOW_HOLIDAY_RUN` to work on a
+holiday without the auto-stop (manual runs per operator's "I start manually").
+
+Exit-code contract (no stdout/stderr — clippy bans print_*; shell reads `$?`):
+- `0`  = trading day → let app start
+- `75` = non-trading day (weekend/holiday) → gate self-stops
+- `70` = config/calendar load error → FAIL-OPEN (treated as 0 by the gate)
+
+## Plan Items
+
+- [x] Item 1 — `--check-trading-day` CLI short-circuit in `main()`
+  - Files: crates/app/src/main.rs
+  - Pure helper `trading_day_gate_exit_code(is_trading_day: bool) -> i32`
+  - Tests: test_trading_day_gate_exit_code_trading, test_trading_day_gate_exit_code_non_trading
+
+- [x] Item 2 — holiday-gate shell script (override + binary check + self-stop)
+  - Files: deploy/aws/holiday-gate.sh
+  - IMDSv2 token → instance-id + region → `aws ec2 stop-instances`; fail-open
+
+- [x] Item 3 — dedicated oneshot systemd unit (Before=tickvault.service)
+  - Files: deploy/systemd/tickvault-holiday-gate.service
+
+- [x] Item 4 — install + enable the gate unit in first-boot user-data
+  - Files: deploy/aws/terraform/user-data.sh.tftpl
+
+- [x] Item 5 — Terraform IAM: ec2:StopInstances scoped to tv_app on instance role
+  - Files: deploy/aws/terraform/main.tf
+
+- [x] Item 6 — Z+ source-scan ratchet pinning gate wiring + IAM + fail-open
+  - Files: crates/storage/tests/aws_deploy_safety_guard.rs
+  - Tests: holiday_gate_is_wired_and_fail_open
+
+- [x] Item 7 — runbook section: holiday gate + override marker
+  - Files: docs/runbooks/may31-inplace-upgrade-and-access.md
+
+## Scenarios
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Trading weekday | `--check-trading-day` exit 0 → app starts |
+| 2 | NSE weekday holiday | exit 75 → gate stops instance, app does not run |
+| 3 | Weekend (manual start) | exit 75 → gate stops UNLESS override marker present |
+| 4 | Operator holiday work | `touch ALLOW_HOLIDAY_RUN` → gate exits 0, app runs |
+| 5 | First boot (binary absent) | gate fail-open → exits 0, normal first-boot flow |
+| 6 | Config load error | exit 70 → gate fail-open → exits 0 (app surfaces error) |
+| 7 | IMDS/aws unreachable | gate logs + fail-open → does NOT loop-stop |
+
+## Z+ 7-row resilience matrix
+
+| Demand | This change |
+|---|---|
+| Zero ticks lost | no tick-path change |
+| WS never disconnects | untouched |
+| Never slow/locked/hanged | oneshot gate, no restart loop (separate unit, not ExecStartPre) |
+| QuestDB never fails | untouched |
+| O(1) latency | gate is cold-path boot-only; one calendar lookup |
+| Uniqueness + dedup | n/a |
+| Real-time proof | journald log of the verdict → CloudWatch; stop visible in console |
+
+## Honest 100% claim
+
+100% inside the tested envelope: the gate stops the instance ONLY on a
+definitive non-trading exit code (75) from the app's own calendar; every other
+outcome (config error, missing binary, IMDS failure, unknown code, override
+marker present) FAILS OPEN so a real trading day is never killed. Source-scan
+ratchet pins the wiring + the fail-open default + the scoped IAM statement.

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -95,8 +95,61 @@ use tickvault_api::state::{SharedAppState, SharedHealthStatus, SystemHealthStatu
 // Main
 // ---------------------------------------------------------------------------
 
+/// Exit code returned by the `--check-trading-day` gate.
+///
+/// The holiday-gate shell script (`deploy/aws/holiday-gate.sh`) reads `$?` —
+/// NOT stdout (the app denies `print_stdout`/`print_stderr`). Contract:
+/// - `0`  = today (IST) is a trading day → let the app start.
+/// - `75` = today is a weekend / NSE holiday → gate self-stops the instance.
+///
+/// Pure so the contract is unit-testable without touching the clock/config.
+fn trading_day_gate_exit_code(is_trading_day: bool) -> i32 {
+    if is_trading_day { 0 } else { 75 }
+}
+
+/// `--check-trading-day` short-circuit: load config → build the calendar →
+/// evaluate IST today → exit with [`trading_day_gate_exit_code`].
+///
+/// FAIL-OPEN: any config/calendar load error exits `70`, which the gate script
+/// treats as "let the app start" — so the gate can NEVER stop the box on a real
+/// trading day because of a transient load failure. Single source of truth: the
+/// SAME `config/base.toml` NSE holiday list the app itself uses (no duplication).
+fn run_trading_day_gate() -> ! {
+    let config: ApplicationConfig = match Figment::new()
+        .merge(Toml::file(CONFIG_BASE_PATH))
+        .merge(Toml::file(CONFIG_LOCAL_PATH))
+        .extract()
+    {
+        Ok(c) => c,
+        // FAIL-OPEN on load error (exit 70 → gate lets the app start).
+        Err(_) => std::process::exit(70),
+    };
+    let calendar = match TradingCalendar::from_config(&config.trading) {
+        Ok(c) => c,
+        Err(_) => std::process::exit(70),
+    };
+    let today_ist = (chrono::Utc::now()
+        + chrono::TimeDelta::seconds(tickvault_common::constants::IST_UTC_OFFSET_SECONDS_I64))
+    .date_naive();
+    std::process::exit(trading_day_gate_exit_code(
+        calendar.is_trading_day(today_ist),
+    ));
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    // -----------------------------------------------------------------------
+    // Step -1: Holiday-gate CLI short-circuit (cold path, no TLS / no runtime).
+    // -----------------------------------------------------------------------
+    // `tickvault --check-trading-day` is invoked by the boot-time holiday gate
+    // (deploy/aws/holiday-gate.sh via the tickvault-holiday-gate.service oneshot)
+    // BEFORE the app proper starts. It exits 0 (trading day) / 75 (holiday) /
+    // 70 (load error → fail-open). Must run before CryptoProvider install — the
+    // gate needs no TLS and exits immediately.
+    if std::env::args().any(|a| a == "--check-trading-day") {
+        run_trading_day_gate();
+    }
+
     // -----------------------------------------------------------------------
     // Step 0: Install rustls CryptoProvider (must happen before ANY TLS usage)
     // -----------------------------------------------------------------------
@@ -6156,6 +6209,20 @@ mod tests {
             .expect("measured boot must produce a message");
         assert!(msg.contains("6.2s"), "elapsed rendered: {msg}");
         assert!(msg.contains("full rebuild"), "cold-path phrasing: {msg}");
+    }
+
+    #[test]
+    fn test_trading_day_gate_exit_code_trading() {
+        // Trading day → 0 so the gate lets the app start.
+        assert_eq!(trading_day_gate_exit_code(true), 0);
+    }
+
+    #[test]
+    fn test_trading_day_gate_exit_code_non_trading() {
+        // Weekend/holiday → 75 so the gate self-stops the instance.
+        assert_eq!(trading_day_gate_exit_code(false), 75);
+        // 75 must be distinct from the fail-open load-error code 70.
+        assert_ne!(trading_day_gate_exit_code(false), 70);
     }
 
     #[test]

--- a/crates/storage/tests/aws_deploy_safety_guard.rs
+++ b/crates/storage/tests/aws_deploy_safety_guard.rs
@@ -237,3 +237,77 @@ fn deploy_disk_used_alarm_exists() {
         "the disk alarm must query the CWAgent `disk_used_percent` metric."
     );
 }
+
+const HOLIDAY_GATE_SH: &str = "deploy/aws/holiday-gate.sh";
+const HOLIDAY_GATE_UNIT: &str = "deploy/systemd/tickvault-holiday-gate.service";
+const USER_DATA_TFTPL: &str = "deploy/aws/terraform/user-data.sh.tftpl";
+
+/// The NSE-holiday boot gate MUST stay wired end-to-end and FAIL-OPEN. Without
+/// it the Mon-Fri start cron bills a full ~8h no-op day on every NSE weekday
+/// holiday during the 3-month data pull. The fail-open default is the safety
+/// property: the gate may only stop the box on a definitive holiday verdict —
+/// never on a missing binary / config error / IMDS failure, or it could kill a
+/// real trading day.
+#[test]
+fn holiday_gate_is_wired_and_fail_open() {
+    // 1. The app exposes the exit-code gate the script reads.
+    let main = read("crates/app/src/main.rs");
+    assert!(
+        main.contains("fn trading_day_gate_exit_code")
+            && main.contains("--check-trading-day")
+            && main.contains("run_trading_day_gate"),
+        "main.rs must expose the --check-trading-day gate (exit 0=trading / 75=holiday)"
+    );
+
+    // 2. The shell gate: override marker, fail-open on missing binary, stops the
+    //    box ONLY on the definitive 75 verdict, IMDSv2 token-required.
+    let sh = read(HOLIDAY_GATE_SH);
+    assert!(
+        sh.contains("ALLOW_HOLIDAY_RUN"),
+        "gate must honour the /opt/tickvault/ALLOW_HOLIDAY_RUN override marker"
+    );
+    assert!(
+        sh.contains("ec2 stop-instances") && sh.contains("-ne 75"),
+        "gate must self-stop ONLY on the exit-75 verdict (fail-open on `-ne 75`)"
+    );
+    assert!(
+        sh.contains("X-aws-ec2-metadata-token"),
+        "gate must use IMDSv2 (token-required) to resolve the instance-id"
+    );
+    // Fail-open evidence: missing binary and non-75 codes exit 0.
+    assert!(
+        sh.contains("fail-open"),
+        "gate must document + implement the fail-open default (never stop on uncertainty)"
+    );
+
+    // 3. Dedicated oneshot unit ordered BEFORE the app (NOT an ExecStartPre on
+    //    tickvault.service — that would trip Restart=always into a stop loop).
+    let unit = read(HOLIDAY_GATE_UNIT);
+    assert!(
+        unit.contains("Type=oneshot") && unit.contains("Before=tickvault.service"),
+        "the gate must be a oneshot unit ordered Before=tickvault.service"
+    );
+    assert!(
+        unit.contains("SuccessExitStatus=0 1"),
+        "the holiday verdict (exit 1) must be a success status for the oneshot"
+    );
+
+    // 4. First-boot user-data installs + enables the gate unit.
+    let ud = read(USER_DATA_TFTPL);
+    assert!(
+        ud.contains("tickvault-holiday-gate.service")
+            && ud.contains("systemctl enable tickvault-holiday-gate.service"),
+        "user-data must install + enable tickvault-holiday-gate.service"
+    );
+
+    // 5. IAM: ec2:StopInstances scoped to the tv-app box by tag (no ARN cycle).
+    let tf = code_only(&read(MAIN_TF));
+    assert!(
+        tf.contains("ec2:StopInstances"),
+        "the instance role must grant ec2:StopInstances for the self-stop"
+    );
+    assert!(
+        tf.contains("ec2:ResourceTag/Name"),
+        "ec2:StopInstances must be tag-scoped to tv-<env>-app (avoids the role->instance cycle)"
+    );
+}

--- a/deploy/aws/holiday-gate.sh
+++ b/deploy/aws/holiday-gate.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# =============================================================================
+# holiday-gate.sh — boot-time NSE-holiday self-stop gate
+# =============================================================================
+# Runs once per EC2 boot via the tickvault-holiday-gate.service oneshot unit,
+# ORDERED BEFORE tickvault.service. The EventBridge cron starts the box every
+# weekday (Mon-Fri), but NSE has weekday holidays (Republic Day, Diwali, etc.)
+# on which a boot is a pure no-op that still bills ~8h. This gate asks the app's
+# OWN binary (single source of truth — same config/base.toml NSE holiday list)
+# whether today is a trading day, and self-stops the instance if not.
+#
+# FAIL-OPEN by design: the gate stops the box ONLY on a DEFINITIVE non-trading
+# verdict (exit 75). Missing binary (first boot), config error (exit 70), IMDS
+# failure, or any unexpected state → exit 0 → the app starts normally. A real
+# trading day can NEVER be killed by a transient gate failure.
+#
+# Override: `touch /opt/tickvault/ALLOW_HOLIDAY_RUN` to run on a holiday/weekend
+# without auto-stop (operator manual runs). See the may31 runbook §holiday-gate.
+#
+# Exit codes (consumed by the oneshot unit / journald):
+#   0 = let the app start (trading day, override, or fail-open)
+#   1 = holiday verdict, instance stop issued (app must NOT start)
+# =============================================================================
+set -uo pipefail
+
+OVERRIDE_MARKER="/opt/tickvault/ALLOW_HOLIDAY_RUN"
+BIN="/opt/tickvault/bin/tickvault"
+WORKDIR="/opt/tickvault"
+IMDS="http://169.254.169.254/latest"
+
+log() { echo "holiday-gate: $*"; } # journald-captured (oneshot StandardOutput=journal)
+
+# --- Override: operator wants to work on a holiday -> never stop. ---
+if [ -f "$OVERRIDE_MARKER" ]; then
+  log "override marker present ($OVERRIDE_MARKER) — skipping holiday check, app starts"
+  exit 0
+fi
+
+# --- Fail-open: no binary yet (first boot before deploy drops it). ---
+if [ ! -x "$BIN" ]; then
+  log "binary not present yet ($BIN) — fail-open, app start proceeds (first boot)"
+  exit 0
+fi
+
+# --- Ask the app's own calendar. Exit: 0=trading 75=holiday 70=load-error. ---
+cd "$WORKDIR" || { log "cd $WORKDIR failed — fail-open"; exit 0; }
+"$BIN" --check-trading-day
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  log "trading day — app start proceeds"
+  exit 0
+fi
+if [ "$rc" -ne 75 ]; then
+  # 70 (config/calendar load error) or any unexpected code -> FAIL-OPEN.
+  log "check-trading-day returned $rc (not a definitive holiday) — fail-open, app starts"
+  exit 0
+fi
+
+# --- Definitive non-trading day: self-stop the instance. ---
+log "NON-TRADING day verdict (exit 75) — stopping this instance"
+
+# IMDSv2 (token-required). Any IMDS failure -> fail-open (never risk a stop
+# without a verified instance-id).
+TOKEN=$(curl -sS -m 5 -X PUT "$IMDS/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 120" 2>/dev/null) || TOKEN=""
+if [ -z "$TOKEN" ]; then
+  log "IMDSv2 token fetch failed — fail-open (cannot resolve instance-id safely)"
+  exit 0
+fi
+IID=$(curl -sS -m 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
+  "$IMDS/meta-data/instance-id" 2>/dev/null) || IID=""
+REGION=$(curl -sS -m 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
+  "$IMDS/meta-data/placement/region" 2>/dev/null) || REGION=""
+if [ -z "$IID" ] || [ -z "$REGION" ]; then
+  log "instance-id/region resolve failed — fail-open"
+  exit 0
+fi
+
+log "stopping instance $IID in $REGION (NSE holiday — saves ~8h of billing)"
+aws ec2 stop-instances --region "$REGION" --instance-ids "$IID" >/dev/null 2>&1 \
+  || log "aws ec2 stop-instances call failed (will retry on next boot)"
+
+# Abort the app start — the OS is going down.
+exit 1

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -186,6 +186,25 @@ resource "aws_iam_role_policy" "tv_instance" {
           "arn:aws:s3:::tv-${var.environment}-cold/*",
           "arn:aws:s3:::tv-${var.environment}-cold"
         ]
+      },
+      {
+        # NSE-holiday self-stop: the boot-time holiday gate
+        # (deploy/aws/holiday-gate.sh) stops THIS instance on a non-trading
+        # day so the Mon-Fri start cron never bills a full no-op day.
+        # Scoped by the Name tag (NOT the instance ARN) on purpose — the
+        # instance -> instance-profile -> role -> policy chain would create a
+        # dependency cycle if this referenced aws_instance.tv_app directly.
+        # The tag condition still limits the action to exactly the tv-app box.
+        Effect = "Allow"
+        Action = [
+          "ec2:StopInstances",
+        ]
+        Resource = "arn:aws:ec2:${var.aws_region}:*:instance/*"
+        Condition = {
+          StringEquals = {
+            "ec2:ResourceTag/Name" = "tv-${var.environment}-app"
+          }
+        }
       }
     ]
   })

--- a/deploy/aws/terraform/user-data.sh.tftpl
+++ b/deploy/aws/terraform/user-data.sh.tftpl
@@ -162,8 +162,20 @@ sudo -u ec2-user docker compose up -d
 # on first boot; the deploy-aws GitHub Actions workflow will scp it, and
 # subsequent EC2 starts will auto-start the service.
 cp /opt/tickvault/repo/deploy/systemd/tickvault.service /etc/systemd/system/
+
+# ---- Step 7b: Install + ENABLE the NSE-holiday boot gate ----
+# The EventBridge cron starts the box every weekday (Mon-Fri), but NSE has
+# weekday holidays on which a boot is a pure no-op that still bills ~8h. This
+# oneshot gate runs BEFORE tickvault.service, asks the app's own calendar
+# (config/base.toml NSE holiday list — single source of truth), and self-stops
+# the instance on a non-trading day. FAIL-OPEN: only a definitive holiday
+# verdict stops the box. Override: `touch /opt/tickvault/ALLOW_HOLIDAY_RUN`.
+chmod +x /opt/tickvault/repo/deploy/aws/holiday-gate.sh
+cp /opt/tickvault/repo/deploy/systemd/tickvault-holiday-gate.service /etc/systemd/system/
+
 systemctl daemon-reload
 systemctl enable tickvault.service
+systemctl enable tickvault-holiday-gate.service
 
 echo "=== tickvault user-data complete at $(date -u) ==="
 echo "Next step: GitHub Actions deploy-aws workflow will scp the first binary."

--- a/deploy/systemd/tickvault-holiday-gate.service
+++ b/deploy/systemd/tickvault-holiday-gate.service
@@ -1,0 +1,45 @@
+# =============================================================================
+# tickvault-holiday-gate — boot-time NSE-holiday self-stop gate
+# =============================================================================
+# Runs ONCE per boot, ORDERED BEFORE tickvault.service. Asks the app binary
+# `--check-trading-day` (single source of truth: config/base.toml NSE holiday
+# list) and self-stops the instance on a non-trading day so the EventBridge
+# Mon-Fri start cron never bills a full no-op day on an NSE weekday holiday.
+#
+# FAIL-OPEN: stops ONLY on a definitive holiday verdict; every uncertainty
+# (missing binary, config error, IMDS failure) lets the app start. A separate
+# oneshot unit (NOT an ExecStartPre on tickvault.service) so a holiday exit
+# does NOT trigger tickvault's Restart=always loop.
+#
+# Override: `touch /opt/tickvault/ALLOW_HOLIDAY_RUN` (see may31 runbook).
+#
+# Install (done by user-data.sh.tftpl first boot):
+#   sudo cp deploy/systemd/tickvault-holiday-gate.service /etc/systemd/system/
+#   sudo systemctl daemon-reload && sudo systemctl enable tickvault-holiday-gate
+# =============================================================================
+
+[Unit]
+Description=tickvault — NSE holiday boot gate (self-stop on non-trading days)
+Documentation=https://github.com/SJParthi/tickvault
+After=network-online.target
+Wants=network-online.target
+# Run the gate BEFORE the trading app so a holiday verdict stops the box
+# before the app does any work.
+Before=tickvault.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=ec2-user
+Group=ec2-user
+WorkingDirectory=/opt/tickvault
+ExecStart=/opt/tickvault/repo/deploy/aws/holiday-gate.sh
+# A holiday verdict returns exit 1 (instance stop issued); that is an expected,
+# non-error outcome for this gate, so do not let it fail the boot transaction.
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=tickvault-holiday-gate
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/runbooks/may31-inplace-upgrade-and-access.md
+++ b/docs/runbooks/may31-inplace-upgrade-and-access.md
@@ -212,6 +212,42 @@ grepping needed:**
 
 ---
 
+## 5.1 NSE-holiday boot gate (auto self-stop on non-trading days)
+
+The EventBridge cron starts the box **every weekday (Mon–Fri)**, but NSE has
+weekday holidays (Republic Day, Diwali, etc.) on which a boot is a pure no-op
+that still bills ~8h. A boot-time gate now handles this automatically:
+
+> **Picture:** the box wakes at 08:30, and the first thing it does is check its
+> own calendar. *"Is the market open today?"* If yes → the trading app starts.
+> If it's a holiday → the box texts nothing and **switches itself back off** —
+> no ~8h bill, no no-op boot noise. You do nothing.
+
+| Piece | What it does |
+|---|---|
+| `tickvault --check-trading-day` | the app reads the SAME `config/base.toml` NSE holiday list and exits `0` (trading) / `75` (holiday). One source of truth — no second list to maintain. |
+| `tickvault-holiday-gate.service` | a oneshot that runs BEFORE the app each boot, calls the check, and stops the instance on a holiday verdict. |
+| **FAIL-OPEN** | if the binary is missing (first boot), config fails to load, or AWS metadata is unreachable, the gate **lets the app start** — it can NEVER stop the box on a real trading day by mistake. |
+
+**Override — work on a holiday without the auto-stop:**
+
+```bash
+# Over SSM (no SSH) — touch the marker, THEN start the box manually:
+aws ssm send-command \
+  --document-name "AWS-RunShellScript" \
+  --targets "Key=InstanceIds,Values=<instance-id>" \
+  --parameters 'commands=["touch /opt/tickvault/ALLOW_HOLIDAY_RUN"]'
+# Remove it again when done so the next holiday auto-stops as usual:
+#   rm -f /opt/tickvault/ALLOW_HOLIDAY_RUN
+```
+
+While `/opt/tickvault/ALLOW_HOLIDAY_RUN` exists the gate skips the holiday
+check entirely and the app runs normally on holidays/weekends. The gate's
+verdict + any self-stop is visible in `journalctl -u tickvault-holiday-gate`
+and CloudWatch (`/tickvault/prod/system`).
+
+---
+
 ## 6. ACCESS — reach the box from every surface
 
 > **Golden rule:** there is **no SSH port-22 dependency** for normal ops — use


### PR DESCRIPTION
## Summary

The EventBridge cron starts the m8g.large box **every weekday (Mon–Fri)**, but NSE has weekday holidays (Republic Day, Diwali, etc.) on which a boot is a pure no-op that still bills ~8h + adds boot noise during the 3-month data pull. This PR adds a boot-time gate that **self-stops the instance on a non-trading day** — you do nothing, the box just switches itself back off on holidays.

## Design — Architecture B: in-boot self-stop, single source of truth

- `tickvault --check-trading-day` reads the **same** `config/base.toml` NSE holiday list via `TradingCalendar` (zero duplication) and exits `0` (trading) / `75` (holiday) / `70` (load error). Exit-code only — the app denies `print_stdout`/`stderr`; the shell reads `$?`.
- `tickvault-holiday-gate.service` — a **oneshot** ordered `Before=tickvault.service`. Deliberately a separate unit, **not** an `ExecStartPre` on tickvault.service, so a holiday exit can't trip tickvault's `Restart=always` into a stop loop.
- `deploy/aws/holiday-gate.sh` — honours the `/opt/tickvault/ALLOW_HOLIDAY_RUN` override marker, resolves the instance via IMDSv2, and issues `aws ec2 stop-instances` **only** on the definitive exit-75 verdict.

### FAIL-OPEN is the safety property

Missing binary (first boot) · config error · IMDS failure · override marker present · any non-75 code → **the app starts**. A real trading day can never be killed by a transient gate failure.

| Scenario | Outcome |
|---|---|
| Trading weekday | exit 0 → app starts |
| NSE weekday holiday | exit 75 → gate stops the box |
| Operator holiday work | `touch ALLOW_HOLIDAY_RUN` → app runs |
| First boot (binary absent) | fail-open → app starts |
| Config / IMDS error | fail-open → app starts (never a wrong stop) |

## IAM

`ec2:StopInstances` added to the instance role, **scoped by the `tv-<env>-app` Name tag** (not the instance ARN — that would create a role→instance dependency cycle).

## Honest 100% claim

100% inside the tested envelope: the gate stops the instance ONLY on a definitive non-trading exit code (75) from the app's own calendar; every other outcome fails open so a real trading day is never killed. Source-scan ratchet `holiday_gate_is_wired_and_fail_open` pins the CLI, the override, the IMDSv2 self-stop-only-on-75, the oneshot ordering, the user-data install, and the tag-scoped IAM.

## Test plan

- [x] `cargo test -p tickvault-app --bin tickvault trading_day_gate` (2 green)
- [x] `cargo test -p tickvault-storage --test aws_deploy_safety_guard` (11 green, incl. new ratchet)
- [x] `cargo check -p tickvault-app`
- [x] `bash -n holiday-gate.sh` syntax OK
- [x] banned-pattern scanner clean · pub-fn-test-guard stable (112) · plan-verify PASS (7/7)

https://claude.ai/code/session_01E55aA4VUh1BSdLmqxcUfwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01E55aA4VUh1BSdLmqxcUfwz)_