### PR TITLE
fix(instrument): match index F&O by exchange, not spot SID — recover ~16.8K dropped contracts

### DIFF
--- a/crates/core/src/instrument/daily_universe_orchestrator.rs
+++ b/crates/core/src/instrument/daily_universe_orchestrator.rs
@@ -44,7 +44,7 @@ use tickvault_common::error_code::ErrorCode;
 use super::csv_parser::{CsvParseError, parse_detailed_csv};
 use super::daily_universe::{BuildError, DailyUniverse, build_daily_universe};
 use super::fno_underlying_extractor::{
-    ExtractError, canonical_sid, collect_applicable_fno_contracts, extract_fno_underlyings,
+    ExtractError, collect_applicable_fno_contracts, extract_fno_underlyings,
 };
 use super::index_extractor::{IndexExtractError, extract_indices};
 
@@ -148,22 +148,14 @@ pub fn build_universe_from_bytes(bytes: &[u8]) -> Result<DailyUniverse, Orchestr
     let indices = extract_indices(&rows)?;
 
     // Step 3b: collect the applicable F&O CONTRACTS for the lifecycle master
-    // (operator lock 2026-05-29 Quote 5, §5). Tracked-index SIDs are resolved
-    // with the SAME canonicaliser as the underlying-resolution path so the
-    // FUTIDX/OPTIDX match is robust to CSV format drift. These rows are
+    // (operator lock 2026-05-29 Quote 5, §5). Stock F&O is matched by
+    // underlying→NSE_EQ resolution; index F&O is matched by EXCHANGE (NSE/BSE)
+    // because Dhan links index options/futures via a derivatives-domain
+    // underlying SID (NIFTY=26000, BANKNIFTY=26009, SENSEX=1, BANKEX=12) that
+    // is NOT the IDX_I spot SID — matching on the spot SID dropped every index
+    // contract (2026-05-29 ~17K-row miss, fixed here). These rows are
     // master-only — they NEVER enter `subscription_targets`.
-    let mut index_sids: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for r in &indices.nse_indices {
-        if let Some(c) = canonical_sid(&r.security_id) {
-            index_sids.insert(c);
-        }
-    }
-    if let Some(s) = &indices.bse_sensex
-        && let Some(c) = canonical_sid(&s.security_id)
-    {
-        index_sids.insert(c);
-    }
-    let fno_contracts = collect_applicable_fno_contracts(&rows, &fno, &index_sids);
+    let fno_contracts = collect_applicable_fno_contracts(&rows, &fno);
 
     // Step 4: build the unified universe (envelope check on the SUBSCRIPTION
     // set per §2 + §22; fno_contracts are master-only and not bounded).

--- a/crates/core/src/instrument/fno_underlying_extractor.rs
+++ b/crates/core/src/instrument/fno_underlying_extractor.rs
@@ -61,6 +61,13 @@ const NSE_EQ_SEGMENT: &str = "NSE_EQ";
 /// `universe_builder` Pass-3 behaviour, which skipped BSE stock futures.
 const NSE_EXCH_ID: &str = "NSE";
 
+/// `EXCH_ID` value for the Bombay Stock Exchange. In scope for INDEX
+/// derivatives only (SENSEX, BANKEX, SENSEX50, FOCIT options/futures) per the
+/// operator 2026-05-29 "everything incl BANKEX" scope — NOT for BSE single-
+/// stock F&O (operator: "BSE only SENSEX [index]"), which the stock path
+/// still excludes via its `NSE`-only gate.
+const BSE_EXCH_ID: &str = "BSE";
+
 /// Maximum number of dangling-reference samples carried in the rejection
 /// error for operator triage. Bounded so a fully-dangling CSV can't
 /// allocate a multi-thousand-entry Vec into the error/log chain.
@@ -247,6 +254,19 @@ fn is_in_scope_stock_derivative(instrument: &str, exch_id: &str) -> bool {
     is_stock_derivative(instrument) && exch_id.eq_ignore_ascii_case(NSE_EXCH_ID)
 }
 
+/// An index derivative (FUTIDX/OPTIDX) is in scope when it trades on an
+/// EQUITY-index exchange — NSE or BSE. Index F&O cannot be matched by the
+/// IDX_I spot SecurityId because Dhan references the index via a separate
+/// derivatives-domain SID (NIFTY=26000, BANKNIFTY=26009, SENSEX=1, BANKEX=12,
+/// VERIFIED on the live 2026-05-28 Detailed CSV), so we gate by exchange
+/// instead. MCX commodity-index derivatives (MCXBULLDEX/MCXMETLDEX) are
+/// EXCLUDED here per the operator no-commodity lock — only NSE + BSE equity
+/// indices are in scope ("everything incl BANKEX", operator 2026-05-29).
+#[must_use]
+fn is_equity_index_exchange(exch_id: &str) -> bool {
+    exch_id.eq_ignore_ascii_case(NSE_EXCH_ID) || exch_id.eq_ignore_ascii_case(BSE_EXCH_ID)
+}
+
 /// Dhan ships placeholder TEST contracts in the instrument master whose
 /// `UNDERLYING_SECURITY_ID` is synthetic and never resolves to a real
 /// `NSE_EQ` row. Skip them (mirrors the deleted `universe_builder` Pass-3
@@ -306,20 +326,30 @@ fn is_index_derivative(instrument: &str) -> bool {
 pub fn collect_applicable_fno_contracts(
     rows: &[CsvRow],
     fno: &FnoUnderlyingExtraction,
-    index_sids: &HashSet<String>,
 ) -> Vec<CsvRow> {
     let mut contracts: Vec<CsvRow> = Vec::new();
     for row in rows {
         if is_test_instrument(&row.symbol_name, &row.underlying_symbol) {
             continue;
         }
-        let Some(canonical) = canonical_security_id(&row.underlying_security_id) else {
-            continue;
-        };
         let applicable = if is_in_scope_stock_derivative(&row.instrument, &row.exch_id) {
-            fno.unique_underlying_ids.contains(&canonical)
+            // Stock F&O: underlying MUST resolve to a tracked NSE_EQ spot.
+            // Dhan links stock options to the cash-equity SecurityId, e.g.
+            // HDFCBANK option → underlying 1333 = HDFCBANK NSE_EQ spot. A
+            // non-numeric/empty underlying yields None → excluded.
+            canonical_security_id(&row.underlying_security_id)
+                .is_some_and(|canonical| fno.unique_underlying_ids.contains(&canonical))
         } else if is_index_derivative(&row.instrument) {
-            index_sids.contains(&canonical)
+            // Index F&O: Dhan links these via a DERIVATIVES-domain underlying
+            // SID (NIFTY=26000, BANKNIFTY=26009, SENSEX=1, BANKEX=12) that is
+            // NOT the IDX_I spot SID (NIFTY=13, BANKNIFTY=25, SENSEX=51) —
+            // VERIFIED against the live 2026-05-28 Detailed CSV. Matching on
+            // the index spot id therefore dropped EVERY index option/future
+            // (the 2026-05-29 ~17K-row miss). Operator scope 2026-05-29
+            // ("everything incl BANKEX") = ALL NSE + BSE equity-index F&O, so
+            // we gate by EXCHANGE. MCX commodity-index derivatives
+            // (MCXBULLDEX/MCXMETLDEX) stay excluded per the no-commodity lock.
+            is_equity_index_exchange(&row.exch_id)
         } else {
             false
         };
@@ -772,48 +802,63 @@ mod tests {
     }
 
     #[test]
-    fn collect_applicable_fno_contracts_keeps_stock_and_index_excludes_rest() {
+    fn collect_applicable_fno_contracts_keeps_stock_and_nse_bse_index_excludes_rest() {
+        // 2026-05-29 fix: index F&O is matched by EXCHANGE (NSE/BSE), NOT by
+        // the IDX_I spot SID — Dhan links index options via a derivatives-
+        // domain underlying SID (NIFTY=26000, SENSEX=1) that never equals the
+        // spot SID (13/51). MCX commodity-index stays excluded.
         let fno = fno_with_underlying("2885"); // RELIANCE tracked underlying
-        let mut index_sids = HashSet::new();
-        index_sids.insert("13".to_string()); // NIFTY tracked index
 
         let rows = vec![
-            // ✅ applicable stock derivatives (underlying 2885 resolves)
+            // ✅ stock derivatives whose underlying 2885 resolves to NSE_EQ
             deriv_row("FUTSTK", "NSE", "2885", "RELIANCE26JUNFUT"),
             deriv_row("OPTSTK", "NSE", "2885", "RELIANCE26JUN2800CE"),
-            // ✅ applicable index derivatives (underlying 13 = NIFTY tracked)
-            deriv_row("FUTIDX", "NSE", "13", "NIFTY26JUNFUT"),
-            deriv_row("OPTIDX", "NSE", "13", "NIFTY26JUN24000CE"),
+            // ✅ NSE index F&O — derivatives-domain underlying SID 26000/26009
+            //    (NOT spot 13/25); matched purely by exch=NSE now.
+            deriv_row("FUTIDX", "NSE", "26000", "NIFTY26JUNFUT"),
+            deriv_row("OPTIDX", "NSE", "26000", "NIFTY26JUN24000CE"),
+            deriv_row("OPTIDX", "NSE", "26009", "BANKNIFTY26JUN50000CE"),
+            // ✅ BSE index F&O — SENSEX (underlying 1) + BANKEX (underlying 12)
+            deriv_row("OPTIDX", "BSE", "1", "SENSEX26JUN80000CE"),
+            deriv_row("OPTIDX", "BSE", "12", "BANKEX26JUN60000CE"),
             // ❌ stock derivative whose underlying is NOT tracked
             deriv_row("OPTSTK", "NSE", "99999", "UNTRACKED26JUN100CE"),
-            // ❌ index derivative whose underlying index is NOT tracked
-            deriv_row("OPTIDX", "NSE", "25", "BANKNIFTY26JUN50000CE"),
-            // ❌ currency F&O — excluded entirely
+            // ❌ MCX commodity-index F&O — excluded (no-commodity lock)
+            deriv_row("OPTIDX", "MCX", "568", "MCXBULLDEX26JUN100CE"),
+            // ❌ currency / commodity F&O — not stock/index derivatives
             deriv_row("OPTCUR", "NSE", "13", "USDINR26JUN90CE"),
-            // ❌ commodity F&O — excluded entirely
             deriv_row("FUTCOM", "MCX", "13", "GOLD26JUNFUT"),
             // ❌ TEST placeholder — excluded
             deriv_row("OPTSTK", "NSE", "2885", "TESTSTK26JUN100CE"),
         ];
 
-        let got = collect_applicable_fno_contracts(&rows, &fno, &index_sids);
-        assert_eq!(got.len(), 4, "exactly the 4 applicable contracts");
+        let got = collect_applicable_fno_contracts(&rows, &fno);
         let symbols: Vec<&str> = got.iter().map(|r| r.symbol_name.as_str()).collect();
+        assert_eq!(
+            got.len(),
+            7,
+            "2 stock + 3 NSE-index + 2 BSE-index; got {symbols:?}"
+        );
         assert!(symbols.contains(&"RELIANCE26JUNFUT"));
         assert!(symbols.contains(&"RELIANCE26JUN2800CE"));
         assert!(symbols.contains(&"NIFTY26JUNFUT"));
         assert!(symbols.contains(&"NIFTY26JUN24000CE"));
+        assert!(symbols.contains(&"BANKNIFTY26JUN50000CE"));
+        assert!(symbols.contains(&"SENSEX26JUN80000CE"));
+        assert!(symbols.contains(&"BANKEX26JUN60000CE"));
+        // MCX commodity-index must NOT leak in.
+        assert!(!symbols.contains(&"MCXBULLDEX26JUN100CE"));
     }
 
     #[test]
-    fn collect_applicable_fno_contracts_empty_when_nothing_tracked() {
+    fn collect_applicable_fno_contracts_excludes_untracked_stock_and_mcx_index() {
         let fno = fno_with_underlying("2885");
-        let index_sids = HashSet::new();
-        // Index derivative but no index tracked, stock derivative untracked.
         let rows = vec![
-            deriv_row("FUTIDX", "NSE", "13", "NIFTY26JUNFUT"),
+            // untracked stock underlying → excluded
             deriv_row("FUTSTK", "NSE", "77777", "OTHER26JUNFUT"),
+            // MCX commodity-index → excluded (only NSE/BSE equity-index in scope)
+            deriv_row("OPTIDX", "MCX", "568", "MCXBULLDEX26JUN100CE"),
         ];
-        assert!(collect_applicable_fno_contracts(&rows, &fno, &index_sids).is_empty());
+        assert!(collect_applicable_fno_contracts(&rows, &fno).is_empty());
     }
 }

--- a/crates/core/tests/fno_extraction_verification.rs
+++ b/crates/core/tests/fno_extraction_verification.rs
@@ -1,0 +1,139 @@
+//! Real-code verification of the F&O extraction over the Dhan Detailed CSV.
+//!
+//! The operator's guarantee demand (2026-05-29): "did you really go through
+//! the entire CSV row by row, column by column?" — answered here by running the
+//! ACTUAL production pipeline (`parse_detailed_csv` → `extract_fno_underlyings`
+//! → `collect_applicable_fno_contracts`) over CSV bytes and asserting the
+//! per-instrument-type breakdown. NOT hand-built `CsvRow`s, NOT awk — the real
+//! code over every row.
+//!
+//! Two tests:
+//!  1. `fno_extraction_captures_nse_bse_index_and_resolved_stock_fno` — a
+//!     CI-safe synthetic CSV that encodes the exact 2026-05-29 bug shape
+//!     (index F&O underlying SID 26000/26009/1/12 ≠ spot 13/25/51) and proves
+//!     the fix end-to-end through the real parser. Ratchet: fails the build if
+//!     index F&O is ever dropped again.
+//!  2. `verify_real_csv_breakdown` (`#[ignore]`) — operator-run over the real
+//!     ~219K-row file. Prints the full captured breakdown vs the raw CSV so the
+//!     operator can confirm completeness on the actual snapshot:
+//!       TICKVAULT_VERIFY_CSV=/path/to/api-scrip-master-detailed.csv \
+//!         cargo test -p tickvault-core --features daily_universe_fetcher \
+//!         --test fno_extraction_verification -- --ignored --nocapture
+
+#![cfg(feature = "daily_universe_fetcher")]
+
+use std::collections::BTreeMap;
+
+use tickvault_core::instrument::csv_parser::{CsvRow, parse_detailed_csv};
+use tickvault_core::instrument::fno_underlying_extractor::{
+    collect_applicable_fno_contracts, extract_fno_underlyings,
+};
+
+/// Count captured contracts grouped by raw `INSTRUMENT` type.
+fn breakdown_by_instrument(contracts: &[CsvRow]) -> BTreeMap<String, usize> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for row in contracts {
+        *counts.entry(row.instrument.clone()).or_default() += 1;
+    }
+    counts
+}
+
+const HEADER: &str =
+    "SECURITY_ID,EXCH_ID,SEGMENT,INSTRUMENT,SYMBOL_NAME,UNDERLYING_SECURITY_ID,UNDERLYING_SYMBOL";
+
+#[test]
+fn fno_extraction_captures_nse_bse_index_and_resolved_stock_fno() {
+    // A representative slice of the real Detailed-CSV SHAPE — crucially with
+    // the index-underlying-SID quirk that broke extraction: NIFTY option's
+    // UNDERLYING_SECURITY_ID is 26000 (NOT the IDX_I spot 13), SENSEX is 1,
+    // BANKEX is 12. Run through the REAL parser + extractor.
+    let mut csv = String::from(HEADER);
+    csv.push('\n');
+    // NSE_EQ spot for RELIANCE so its stock F&O underlying resolves.
+    csv.push_str("2885,NSE,E,EQUITY,RELIANCE,,\n");
+    // Index spots (IDX_I) — realistic context.
+    csv.push_str("13,NSE,I,INDEX,NIFTY,13,NIFTY\n");
+    csv.push_str("51,BSE,I,INDEX,SENSEX,51,SENSEX\n");
+    // Stock F&O for RELIANCE (underlying 2885 resolves to the NSE_EQ spot).
+    csv.push_str("40001,NSE,D,FUTSTK,RELIANCE26JUNFUT,2885,RELIANCE\n");
+    csv.push_str("40002,NSE,D,OPTSTK,RELIANCE26JUN2800CE,2885,RELIANCE\n");
+    // NSE index F&O — derivatives-domain underlying SID (NOT spot 13/25).
+    csv.push_str("35000,NSE,D,OPTIDX,NIFTY26JUN24000CE,26000,NIFTY\n");
+    csv.push_str("35001,NSE,D,FUTIDX,NIFTY26JUNFUT,26000,NIFTY\n");
+    csv.push_str("35002,NSE,D,OPTIDX,BANKNIFTY26JUN50000CE,26009,BANKNIFTY\n");
+    // BSE index F&O — SENSEX (underlying 1) + BANKEX (underlying 12).
+    csv.push_str("12001,BSE,D,OPTIDX,SENSEX26JUN80000CE,1,SENSEX\n");
+    csv.push_str("12002,BSE,D,OPTIDX,BANKEX26JUN60000CE,12,BANKEX\n");
+    // MCX commodity-index F&O — MUST be excluded (no-commodity lock).
+    csv.push_str("90001,MCX,D,OPTIDX,MCXBULLDEX26JUN100CE,568,MCXBULLDEX\n");
+    // Currency F&O — excluded (not a stock/index derivative).
+    csv.push_str("90002,NSE,D,OPTCUR,USDINR26JUN90CE,13,USDINR\n");
+
+    let rows = parse_detailed_csv(csv.as_bytes()).expect("parse");
+    let fno = extract_fno_underlyings(&rows).expect("extract underlyings");
+    let contracts = collect_applicable_fno_contracts(&rows, &fno);
+    let b = breakdown_by_instrument(&contracts);
+
+    // Index F&O captured (THE fix): 4 OPTIDX (NIFTY, BANKNIFTY, SENSEX, BANKEX)
+    // + 1 FUTIDX (NIFTY). Pre-fix these were ALL dropped (0).
+    assert_eq!(
+        *b.get("OPTIDX").unwrap_or(&0),
+        4,
+        "NSE+BSE index options: {b:?}"
+    );
+    assert_eq!(
+        *b.get("FUTIDX").unwrap_or(&0),
+        1,
+        "NSE index futures: {b:?}"
+    );
+    // Stock F&O for the resolved underlying.
+    assert_eq!(*b.get("OPTSTK").unwrap_or(&0), 1, "stock options: {b:?}");
+    assert_eq!(*b.get("FUTSTK").unwrap_or(&0), 1, "stock futures: {b:?}");
+
+    let syms: Vec<&str> = contracts.iter().map(|r| r.symbol_name.as_str()).collect();
+    // MCX commodity-index + currency must NOT leak in.
+    assert!(
+        !syms.iter().any(|s| s.contains("MCXBULLDEX")),
+        "MCX excluded: {syms:?}"
+    );
+    assert!(
+        !syms.iter().any(|s| s.contains("USDINR")),
+        "currency excluded: {syms:?}"
+    );
+}
+
+#[test]
+#[ignore = "operator-run: set TICKVAULT_VERIFY_CSV=/path/to/api-scrip-master-detailed.csv"]
+fn verify_real_csv_breakdown() {
+    let Ok(path) = std::env::var("TICKVAULT_VERIFY_CSV") else {
+        eprintln!("set TICKVAULT_VERIFY_CSV to a Dhan Detailed CSV path to run this");
+        return;
+    };
+    let bytes = std::fs::read(&path).expect("read CSV file");
+    let rows = parse_detailed_csv(&bytes).expect("parse CSV");
+    let fno = extract_fno_underlyings(&rows).expect("extract underlyings");
+    let contracts = collect_applicable_fno_contracts(&rows, &fno);
+    let b = breakdown_by_instrument(&contracts);
+
+    eprintln!(
+        "=== applicable F&O master (REAL code over {} CSV rows) ===",
+        rows.len()
+    );
+    let mut total = 0usize;
+    for (kind, count) in &b {
+        eprintln!("  {kind:<8} = {count}");
+        total += *count;
+    }
+    eprintln!("  -------------------------");
+    eprintln!("  TOTAL contracts          = {total}");
+    eprintln!(
+        "  resolved NSE underlyings = {}",
+        fno.unique_underlying_ids.len()
+    );
+
+    // Sanity: after the fix, index F&O MUST be present (it was 0 pre-fix).
+    assert!(
+        *b.get("OPTIDX").unwrap_or(&0) > 0,
+        "index options MUST be captured after the 2026-05-29 fix"
+    );
+}


### PR DESCRIPTION
## Summary — the count was wrong; the operator was right

The `instrument_lifecycle` master had **79,190** rows; it should be ~90K–1 lakh. Verified against the live 2026-05-28 Detailed CSV (**219,338 rows**): **every index option/future was being silently dropped.**

**Root cause:** `collect_applicable_fno_contracts` matched index F&O (FUTIDX/OPTIDX) by `index_sids.contains(underlying_security_id)`, where `index_sids` held the IDX_I **spot** SecurityIds (NIFTY=13, BANKNIFTY=25, SENSEX=51). But Dhan links index F&O via a **derivatives-domain** underlying SID — NIFTY=`26000`, BANKNIFTY=`26009`, SENSEX=`1`, BANKEX=`12` — which never equals the spot SID. So the check was always false → **all 16,809 NSE+BSE index contracts dropped.**

## Fix

Index F&O is now matched by **exchange** (`is_equity_index_exchange` = NSE | BSE), per operator scope 2026-05-29 ("everything incl BANKEX"). MCX commodity-index (MCXBULLDEX/MCXMETLDEX, 646 rows) stays excluded (no-commodity lock). Stock F&O unchanged (underlying→NSE_EQ resolution; BSE single-stock F&O excluded per "BSE only SENSEX"). The fragile `index_sids` spot-SID building is removed.

## Real-CSV proof (new harness over all 219,338 rows)

| | before | after |
|---|---|---|
| OPTIDX | **0** | **16,782** |
| FUTIDX | **0** | **27** |
| OPTSTK | ~73K | 73,576 |
| FUTSTK | — | 629 |
| **TOTAL contracts** | ~78,859 | **91,014** |

+ 331 indices/spots = **~91,345 master rows** — matches the operator's estimate.

## The guarantee harness (answers "go through every row")

`crates/core/tests/fno_extraction_verification.rs` runs the **real** pipeline (`parse_detailed_csv → extract_fno_underlyings → collect_applicable_fno_contracts`):
- **CI ratchet** — synthetic CSV encoding the exact `26000 ≠ 13` quirk + MCX/currency exclusion; fails the build if index F&O is ever dropped again.
- **Operator-run** (`#[ignore]`): `TICKVAULT_VERIFY_CSV=/path … --ignored --nocapture` prints the full per-type breakdown over the real ~219K file.

## Z+ / charter

- **Uniqueness/dedup:** unchanged — `instrument_lifecycle` DEDUP UPSERT KEYS `(security_id, exchange_segment)` (I-P1-11); contract rows carry distinct SecurityIds.
- **Bugs/scenarios:** the dropped-index-F&O class is now ratcheted; MCX/currency/BSE-stock exclusions all asserted.

## Honest claim

100% inside the tested envelope: index F&O captured for all NSE+BSE equity indices (verified 16,809 rows on the real CSV), MCX commodity-index excluded, stock F&O complete (74,205 of 74,223 NSE rows; remainder = test placeholders). Ratchet + real-file harness prevent regression.

## Test plan
- [x] `cargo test -p tickvault-core --features daily_universe_fetcher --lib fno_underlying_extractor::tests` (22 green)
- [x] synthetic harness green; real-CSV harness verified (OPTIDX 0→16,782)
- [x] banned-pattern clean · pub-fn-test-guard stable (112) · pub-fn-wiring-guard clean · fmt clean

https://claude.ai/code/session_01E55aA4VUh1BSdLmqxcUfwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01E55aA4VUh1BSdLmqxcUfwz)_