### PR TITLE
perf(instrument): re-runnable warm-resubscribe latency proof (~0.3ms, measured)

### DIFF
--- a/crates/core/examples/warm_resubscribe_latency.rs
+++ b/crates/core/examples/warm_resubscribe_latency.rs
@@ -1,0 +1,111 @@
+//! Re-runnable latency proof for the same-day warm-resubscribe fast path.
+//!
+//! Measures the REAL wall-clock cost of recovering the subscription plan from
+//! the on-disk snapshot after a crash: load the date-keyed snapshot file →
+//! reconstruct the `DailyUniverse` → build the full subscription plan, at the
+//! live production scale of 331 SIDs (3 indices + 328 F&O underlyings).
+//!
+//! This exists because the charter demands "continuous proof and evidence
+//! generation" and "no hallucination" — the "~1ms warm resubscribe" figure
+//! must be a MEASURED fact, not a claim. Run it anytime:
+//!
+//! ```bash
+//! cargo run --example warm_resubscribe_latency \
+//!     --features daily_universe_fetcher --release
+//! ```
+//!
+//! Observed on the dev container (release): ~316 µs/iter — i.e. sub-millisecond.
+//! This is O(N) in the SID count (you must build N subscriptions) but constant
+//! per-SID; it replaces an O(N) + network-GET + DB-reconcile cold build
+//! (batched seconds) with a single bounded disk read + in-memory rebuild.
+
+#[cfg(not(feature = "daily_universe_fetcher"))]
+fn main() {
+    eprintln!(
+        "warm_resubscribe_latency requires --features daily_universe_fetcher; \
+         re-run with that flag."
+    );
+}
+
+#[cfg(feature = "daily_universe_fetcher")]
+fn main() {
+    use std::time::Instant;
+    use tickvault_core::instrument::csv_parser::CsvRow;
+    use tickvault_core::instrument::daily_universe::{
+        DailyUniverse, InstrumentRole, SubscriptionTarget,
+    };
+    use tickvault_core::instrument::instrument_snapshot::{
+        load_plan_snapshot_for_today, write_plan_snapshot,
+    };
+    use tickvault_core::instrument::subscription_planner::build_subscription_plan_from_daily_universe;
+
+    fn target(role: InstrumentRole, sid: &str, sym: &str) -> SubscriptionTarget {
+        SubscriptionTarget {
+            role,
+            csv_row: CsvRow {
+                security_id: sid.to_string(),
+                symbol_name: sym.to_string(),
+                ..CsvRow::default()
+            },
+        }
+    }
+
+    const INDICES: usize = 3;
+    const UNDERLYINGS: usize = 328;
+    let total_sids = INDICES + UNDERLYINGS;
+
+    let mut targets = Vec::with_capacity(total_sids);
+    targets.push(target(InstrumentRole::Index, "13", "NIFTY"));
+    targets.push(target(InstrumentRole::Index, "25", "BANKNIFTY"));
+    targets.push(target(InstrumentRole::Index, "51", "SENSEX"));
+    for i in 0..UNDERLYINGS {
+        targets.push(target(
+            InstrumentRole::FnoUnderlying,
+            &(10_000 + i).to_string(),
+            &format!("STK{i}"),
+        ));
+    }
+    let universe = DailyUniverse {
+        subscription_targets: targets,
+        fno_contracts: vec![],
+    };
+
+    // A unique far-future date so this never collides with a real snapshot.
+    let date = "2099-12-31";
+    if let Err(e) = write_plan_snapshot(&universe, date) {
+        eprintln!("setup write failed: {e}");
+        return;
+    }
+
+    let iters: u32 = 2000;
+    // Warm up (file cache + allocator) before timing.
+    for _ in 0..50 {
+        let _ = load_plan_snapshot_for_today(date);
+    }
+
+    let start = Instant::now();
+    let mut sink = 0usize;
+    for _ in 0..iters {
+        let Some(restored) = load_plan_snapshot_for_today(date) else {
+            eprintln!("load returned None during measurement");
+            return;
+        };
+        let plan = build_subscription_plan_from_daily_universe(&restored);
+        sink = sink.wrapping_add(plan.summary.total);
+    }
+    let per = start.elapsed() / iters;
+
+    println!("warm-resubscribe latency proof");
+    println!(
+        "  scale          : {total_sids} SIDs ({INDICES} indices + {UNDERLYINGS} underlyings)"
+    );
+    println!("  path           : load snapshot -> reconstruct universe -> build plan");
+    println!("  iterations     : {iters}");
+    println!("  per-iter        : {per:?}");
+    println!("  plan.total/iter: {}", sink / iters as usize);
+
+    // Best-effort cleanup of the proof artefact.
+    if let Some(path) = tickvault_core::instrument::instrument_snapshot::snapshot_path_for(date) {
+        let _ = std::fs::remove_file(path);
+    }
+}


### PR DESCRIPTION
## Summary

Discharges the no-hallucination debt on the "~1ms warm resubscribe" figure I'd been quoting **unmeasured**, with a MEASURED, re-runnable proof artefact (charter §4 no-hallucination + "continuous proof and evidence generation").

## Change

`crates/core/examples/warm_resubscribe_latency.rs` — measures the real fast-path cost (load 331-SID snapshot from disk → reconstruct `DailyUniverse` → build the full subscription plan) at live production scale. Run anytime:

```bash
cargo run --example warm_resubscribe_latency --features daily_universe_fetcher --release
```

## Real evidence (measured, release, dev container)

```
warm-resubscribe latency proof
  scale          : 331 SIDs (3 indices + 328 underlyings)
  path           : load snapshot -> reconstruct universe -> build plan
  iterations     : 2000
  per-iter       : 278.495µs
  plan.total/iter: 331
```

So the true warm-resubscribe latency is **~0.28–0.32 ms — sub-millisecond**, beating my earlier conservative "~1ms" estimate. It is O(N) in the SID count (you must build N subscriptions) but constant per-SID; it replaces an O(N) + network-GET + DB-reconcile cold build (batched seconds) with a single bounded disk read + in-memory rebuild.

## Honest envelope

Diagnostic example only — no production code, no behaviour change. Compiles **with and without** the feature (cfg-gated `main` prints a notice when the feature is off), so it never breaks a no-feature example build. CI does not run examples, so this is operator/dev-invoked proof, not an automated gate.

## Zero-Loss Guarantee Charter check

- [x] No-hallucination: replaces an unmeasured claim with a real measured number (pasted above)
- [x] Performance/O(1): documents the honest O(N)-per-SID, constant-per-SID cost — not faked as O(1)
- [x] No production code change; no new tick-drop path; no hot-path allocation (example-only)
- [x] N/A — tests/audit/monitoring/alerting (diagnostic example, no runtime event)

https://claude.ai/code/session_01FGRjG8NPhGh4KQmADySjLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGRjG8NPhGh4KQmADySjLn)_