### PR TITLE
fix(observability): record #O4 Valkey-removal as done + drop dead valkey-cli operator message

### DIFF
--- a/.claude/plans/active-plan-observability-cloudwatch-only.md
+++ b/.claude/plans/active-plan-observability-cloudwatch-only.md
@@ -103,15 +103,24 @@ ratchets updated, one PR at a time per `pr-completion-protocol.md` §H.
   - Tests: `docker compose config` valid; `cargo test -p tickvault-app
     -p tickvault-storage -p tickvault-common` (scoped) green.
 
-- [ ] **#O4 — Valkey removal — UNBLOCKED (operator decision 2026-05-20)**
-  - Valkey is LOAD-BEARING: (a) token cache, (b) dual-instance lock.
-  - **Operator decision 2026-05-20 — "Just remove valkey also":** the
-    dual-instance lock is **RETIRED**, not replaced. No file lock, no
-    QuestDB row. Acceptable because sandbox mode already skips the lock
-    and `dry_run = true` is the default — the lock only mattered in
-    live multi-host trading. Re-evaluate before `dry_run = false` if
-    multi-host deployment is ever on the table (note it in the live-go
-    checklist).
+- [x] **#O4 — Valkey removal — merged (PR #764, 2026-05-24)**
+  - Valkey was LOAD-BEARING: (a) token cache, (b) dual-instance lock.
+  - **As shipped (supersedes the 2026-05-20 "retire entirely" note):**
+    Valkey itself is fully removed (container, `valkey_cache.rs`,
+    `fetch_valkey_password`, `chaos_valkey_kill.rs`, the `[valkey]`
+    config, the Valkey token-cache layer). The token cache is now a
+    local FILE (`/tmp/tv-token-cache`, crash-recovery only); auth reads
+    SSM directly. The dual-instance lock was **MIGRATED to SSM** (not
+    retired) — `crates/core/src/instance_lock.rs` is now SSM-backed and
+    still load-bearing in boot Step 6a-prime, gated on
+    `trading_mode.is_live()` so it is inert under the `dry_run = true`
+    default. Operator decision 2026-05-30: KEEP the SSM lock (real
+    two-process safety guard, zero Valkey dependency, zero cost in
+    dry-run). The `Resilience01DualInstanceDetected` ErrorCode + its
+    RESILIENCE-01 runbook stay.
+  - Carry into the `dry_run = false` go-live checklist: the SSM lock
+    now provides the dual-instance guard; confirm it is exercised
+    before flipping live.
   - Token cache: dropped — the auth chain is cache → SSM → TOTP; SSM
     is the source of truth, so removal is graceful degradation.
   - Work: delete `valkey_cache.rs`; delete `instance_lock.rs` + its
@@ -172,11 +181,15 @@ ratchets updated, one PR at a time per `pr-completion-protocol.md` §H.
 | 3 | Operator wants a dashboard | CloudWatch console — no local Grafana |
 | 4 | An `error!` fires | routed to CloudWatch Logs (Telegram path re-pointed off Alertmanager) |
 
-## #O4 lock question — RESOLVED 2026-05-20
+## #O4 lock question — RESOLVED 2026-05-30 (supersedes the 2026-05-20 note)
 
-The dual-instance lock lived in Valkey. Operator decision 2026-05-20
-("Just remove valkey also"): **retire the dual-instance guard
-entirely** — option (c). No replacement infra. All 6 items #O1–#O6 are
-now unblocked; execute serially per §H. Carry one note into the
-`dry_run = false` go-live checklist: re-evaluate dual-instance
-protection if multi-host deployment is ever considered.
+The dual-instance lock originally lived in Valkey. The 2026-05-20 note
+proposed retiring it entirely with no replacement. What actually shipped
+in PR #764 was different and better: Valkey is gone, but the lock was
+**migrated to SSM** (`crates/core/src/instance_lock.rs`) rather than
+retired. Operator decision 2026-05-30: **KEEP the SSM lock** — it is a
+genuine two-process safety guard (prevents two instances racing the 24h
+JWT into DH-901), carries no Valkey dependency, and is inert under the
+`dry_run = true` default (gated on `trading_mode.is_live()`). The
+`Resilience01DualInstanceDetected` ErrorCode + RESILIENCE-01 runbook
+stay. #O4 is DONE; remaining serial items per §H are #O5 then #O6.

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -1891,7 +1891,7 @@ impl NotificationEvent {
             }
             Self::DualInstanceDetected { holder, lock_key } => {
                 let holder_line = if holder.is_empty() {
-                    "(holder identity not retrievable — Valkey may have raced; check `make doctor` or `valkey-cli GET <key>`)"
+                    "(holder identity not retrievable — the lock check raced; run `make doctor`)"
                         .to_string()
                 } else {
                     format!("Live peer: {holder}")


### PR DESCRIPTION
## Summary

#O4 (Valkey removal) of the CloudWatch-only migration **already shipped in PR #764 (2026-05-24)**, but the plan still showed it unchecked and described the dual-instance lock as "retired". In reality the lock was **migrated to SSM** (`crates/core/src/instance_lock.rs` is SSM-backed, still load-bearing in boot Step 6a-prime, inert under the `dry_run=true` default). This PR reconciles the plan with reality and fixes one stale operator-facing string.

Operator decision 2026-05-30: **keep the SSM lock** (genuine two-process safety guard; no Valkey dependency; zero cost in dry-run).

## Items completed
- [x] #O4-fix — mark #O4 done; correct "retired" → "migrated to SSM"; record keep-the-lock decision + go-live caveat in `active-plan-observability-cloudwatch-only.md`
- [x] #O4-fix — fix `DualInstanceDetected` fallback message: dead `valkey-cli GET <key>` guidance → `run make doctor` (`crates/core/src/notification/events.rs`)

## Zero-Loss Guarantee Charter check
- Logging/alerting: operator-facing message now points only at a live command (`make doctor`); plain-English per the 10 Telegram commandments.
- Testing: `cargo test -p tickvault-core --lib notification` → **119 passed**; the `!msg.contains("Valkey")` guard now holds.
- Code checks: banned-pattern scanner ✓, plan-verify ✓.
- Recovery / hot path / DEDUP / uniqueness: N/A — no runtime/data-path change (one operator string + a plan doc).
- Performance: N/A — not a hot path.

## Honest 100% claim
100% inside the tested envelope: the change is a plan-doc correction plus one operator-facing string edit; verified by the 119-test core notification suite and the two pre-push gates. No behavioral/runtime path is altered.

## Discovery context
Found via an adversarial 3-agent sweep (surface-map + security + hostile) launched to plan #O4; two agents independently confirmed Valkey was already gone and that the lock had been migrated to SSM rather than retired — so #O4's only remaining work was this reconciliation. Next serial items per §H: #O5 (guard/rule/script cleanup of remaining stale Grafana/Prom/Valkey doc-comments) then #O6 (docs sweep).

## Test plan
- [x] `cargo test -p tickvault-core --lib notification` green (119)
- [x] banned-pattern scanner clean
- [x] plan-verify clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01GWKzR8h5aULsFoar5HFwjX)_