### PR TITLE
fix(aws): repair failing infra guard (m8g.large/weekday crons) + aws-ami AL2023 arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,13 +317,12 @@ aws-bootstrap-check: ## Verify prerequisites for the first terraform apply
 	@echo ""
 	@echo "Next: run 'make aws-init' to initialize Terraform"
 
-aws-ami: ## Look up the latest Ubuntu 24.04 LTS AMI in ap-south-1 (export TF_VAR_ami_id)
-	@AMI=$$(aws ec2 describe-images \
+aws-ami: ## Look up the latest Amazon Linux 2023 arm64 AMI in ap-south-1 (export TF_VAR_ami_id)
+	@AMI=$$(aws ssm get-parameters \
 		--region ap-south-1 \
-		--owners 099720109477 \
-		--filters 'Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*' \
-		--query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text); \
-	echo "Latest Ubuntu 24.04 AMI in ap-south-1: $$AMI"; \
+		--names /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64 \
+		--query 'Parameters[0].Value' --output text); \
+	echo "Latest AL2023 arm64 AMI in ap-south-1: $$AMI"; \
 	echo "export TF_VAR_ami_id=$$AMI"
 
 aws-operator-cidr: ## Print your current public IP CIDR for TF_VAR_operator_cidr

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -100,18 +100,25 @@ fn test_terraform_instance_type_pinned() {
     let content =
         std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/variables.tf"))
             .expect("variables.tf must be readable"); // APPROVED: test
-    // Operator-lock 2026-05-18 (aws-budget.md): t4g.medium ONLY.
-    // Any reintroduction of c7i.xlarge / c8g.xlarge / other instance types
-    // fails this test.
+    // Operator-lock 2026-05-29 (daily-universe-scope-expansion-2026-05-27.md §7
+    // Quote 5): m8g.large ONLY (Graviton4, 8 GiB). SUPERSEDES the 2026-05-18
+    // t4g.medium + 2026-05-27 t4g.large locks. Any reintroduction of
+    // c7i.xlarge / c8g.xlarge / t4g.* as the PINNED type fails this test.
     assert!(
-        content.contains("\"t4g.medium\""),
-        "variables.tf must pin instance_type to t4g.medium (operator lock 2026-05-18, see aws-budget.md)"
+        content.contains("\"m8g.large\""),
+        "variables.tf must pin instance_type to m8g.large (operator lock 2026-05-29, see daily-universe-scope-expansion-2026-05-27.md §7)"
     );
     assert!(
-        content.contains("var.instance_type == \"t4g.medium\""),
+        content.contains("var.instance_type == \"m8g.large\""),
         "variables.tf must VALIDATE instance_type pinning"
     );
-    // Negative asserts — block the retired stack from ever returning.
+    // Negative asserts — block the retired stacks from ever returning as the
+    // validated default (t4g.medium/t4g.large may still appear in SUPERSEDES
+    // comments, so we only forbid them as the validation condition).
+    assert!(
+        !content.contains("var.instance_type == \"t4g.medium\""),
+        "t4g.medium retired as the pinned type (operator lock 2026-05-29)"
+    );
     assert!(
         !content.contains("c7i.xlarge"),
         "c7i.xlarge retired in operator-lock 2026-05-18"
@@ -126,26 +133,27 @@ fn test_terraform_instance_type_pinned() {
 fn test_terraform_eventbridge_schedules_match_budget() {
     let content = std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/main.tf"))
         .expect("main.tf must be readable"); // APPROVED: test
-    // Daily start: 08:00 IST = 02:30 UTC Mon-Sun (operator-lock 2026-05-18
-    // Option A — 7-day availability for BRUTEX work).
+    // Weekday start: 08:30 IST = 03:00 UTC Mon-Fri (operator-lock 2026-05-29,
+    // daily-universe-scope-expansion-2026-05-27.md §7 Quote 5 — trading
+    // weekdays only, 08:30-16:30 IST; SUPERSEDES the 2026-05-18 7-day cron).
     assert!(
-        content.contains("cron(30 2 * * ? *)"),
-        "main.tf missing daily start schedule (02:30 UTC every day)"
+        content.contains("cron(0 3 ? * MON-FRI *)"),
+        "main.tf missing weekday start schedule (03:00 UTC Mon-Fri = 08:30 IST)"
     );
-    // Daily stop: 17:00 IST = 11:30 UTC Mon-Sun.
+    // Weekday stop: 16:30 IST = 11:00 UTC Mon-Fri.
     assert!(
-        content.contains("cron(30 11 * * ? *)"),
-        "main.tf missing daily stop schedule (11:30 UTC every day)"
+        content.contains("cron(0 11 ? * MON-FRI *)"),
+        "main.tf missing weekday stop schedule (11:00 UTC Mon-Fri = 16:30 IST)"
     );
-    // Negative asserts — the 4-rule weekday/weekend split was consolidated
-    // to 2 daily rules per operator lock 2026-05-18.
+    // Negative asserts — the prior 7-day daily crons (02:30/11:30 UTC every
+    // day) were replaced by the weekday-only pair per operator lock 2026-05-29.
     assert!(
-        !content.contains("MON-FRI"),
-        "weekday-only schedule retired in operator-lock 2026-05-18"
+        !content.contains("cron(30 2 * * ? *)"),
+        "7-day daily start cron retired in operator-lock 2026-05-29 (weekday-only now)"
     );
     assert!(
-        !content.contains("SAT-SUN"),
-        "weekend-only schedule retired in operator-lock 2026-05-18"
+        !content.contains("cron(30 11 * * ? *)"),
+        "7-day daily stop cron retired in operator-lock 2026-05-29 (weekday-only now)"
     );
 }
 


### PR DESCRIPTION
## Summary

While polishing the AWS pipeline I found **two real pre-existing bugs** and fixed both. All evidence is from reliable `cargo test` / `make -n` exit codes + structured results (this session had intermittent shell-stdout rendering glitches, so I trusted only exit codes, the GitHub API, and `git log` — not raw stdout).

## Bug 1 — `aws_infra_wiring.rs` had 2 FAILING tests on `main`
Latent since #866, which moved the Terraform to m8g.large + weekday crons but didn't update the guard. CI smart-skips Rust tests on Terraform-only PRs, so it merged green and the failure sat undetected on main.
- `test_terraform_instance_type_pinned`: asserted `t4g.medium` → now `m8g.large` (operator lock 2026-05-29, daily-universe §7); negative-asserts `t4g` only as the *pinned/validated* type (it may still appear in SUPERSEDES comments)
- `test_terraform_eventbridge_schedules_match_budget`: asserted the old 7-day daily crons → now the weekday pair `cron(0 3 ? * MON-FRI *)` / `cron(0 11 ? * MON-FRI *)` (08:30 / 16:30 IST); negative-asserts the retired crons

**Proof:** `cargo test -p tickvault-common --test aws_infra_wiring` → **17 passed; 0 failed** (was 15 passed; 2 failed before).

## Bug 2 — `make aws-ami` produced an unbootable AMI
Queried **Ubuntu 24.04 amd64**, but `variables.tf` requires **AL2023 arm64** (m8g.large is Graviton4 — amd64 won't boot). Retargeted to the canonical AL2023 arm64 SSM public parameter `/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64`.

**Proof:** `make -n aws-ami` exit 0; ubuntu refs 0, al2023/arm64 refs present.

## Deferred to a follow-up (honest)
`make aws-deploy` (wrapper over the existing `aws-one-shot-bootstrap.sh`) + the `aws-deployment.md` stale infra-table refresh (t4g.medium/ALB/Valkey/EIP-required/100GB → current m8g.large/CloudWatch-only/no-EIP lock). Held for a clean follow-up rather than risking a tab-sensitive Makefile / 244-line doc edit during this session's intermittent tool-output instability.

## Zero-Loss Guarantee Charter check
- **O(1):** N/A — a guard test + a make target; no runtime/hot-path/DB code touched.
- **Real testing (no hallucination):** cargo test 17/0 + `make -n` exit 0; evidence is structured results, not shell stdout.
- **Code checks:** pre-push 12-gate battery passed on push (fmt + Dhan-locked-facts executed).

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` = 17 passed, 0 failed
- [x] `make -n aws-ami` exit 0 (Makefile parses; AL2023 arm64)
- [ ] CI all green (drives auto-merge)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_