### PR TITLE
fix(config): TV_ENVIRONMENT drives config + SSM; AWS runs staging (no real orders)

### DIFF
--- a/crates/app/src/boot_helpers.rs
+++ b/crates/app/src/boot_helpers.rs
@@ -45,6 +45,57 @@ pub const OFF_HOURS_CONNECTION_STAGGER_MS: u64 = 1000;
 /// Local override config file path (git-ignored, optional).
 pub const CONFIG_LOCAL_PATH: &str = "config/local.toml";
 
+/// Resolves the deployment environment name for config-file selection.
+///
+/// Precedence (first non-empty wins): `TV_ENVIRONMENT` → `ENVIRONMENT` → `"dev"`.
+/// This is the SAME precedence used by
+/// `tickvault_core::auth::secret_manager::resolve_environment`, so the
+/// config-file env and the SSM secret prefix (`/tickvault/<env>/...`) always
+/// agree — the deployed box's `TV_ENVIRONMENT=staging` selects BOTH
+/// `config/staging.toml` AND `/tickvault/staging/...` secrets.
+pub fn resolve_config_env() -> String {
+    std::env::var("TV_ENVIRONMENT")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var("ENVIRONMENT")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        })
+        .unwrap_or_else(|| "dev".to_string())
+}
+
+/// Returns the per-environment config override path (`config/<env>.toml`) to
+/// merge BETWEEN base and local, or `None` when no override applies.
+///
+/// `None` is returned for `dev` and `local` so existing local-dev behaviour
+/// (base + local only) is byte-identical — there is no `config/dev.toml`, and
+/// `config/local.toml` is already merged separately. For any other env
+/// (`staging`, `production`, `sandbox`) the matching `config/<env>.toml` is
+/// returned. The env name is sanitised to a strict `[a-z0-9-]` allowlist so a
+/// malicious env var can never traverse paths.
+pub fn config_env_path(env: &str) -> Option<String> {
+    let normalized = env.trim().to_ascii_lowercase();
+    // dev/local: no dedicated override file (base + local already cover it).
+    if normalized.is_empty() || normalized == "dev" || normalized == "local" {
+        return None;
+    }
+    // Strict allowlist — reject anything that could traverse the filesystem.
+    if !normalized
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return None;
+    }
+    // `prod` is an accepted alias for the canonical `production.toml`.
+    let file_stem = if normalized == "prod" {
+        "production"
+    } else {
+        normalized.as_str()
+    };
+    Some(format!("config/{file_stem}.toml"))
+}
+
 // ---------------------------------------------------------------------------
 // IST timestamp formatter for tracing-subscriber
 // ---------------------------------------------------------------------------
@@ -444,6 +495,91 @@ pub fn drain_replayed_order_updates_to_broadcast(
 mod tests {
     use super::*;
     use std::net::SocketAddr;
+
+    // -----------------------------------------------------------------------
+    // resolve_config_env — env-var precedence (TV_ENVIRONMENT > ENVIRONMENT > dev)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_config_env_defaults_to_dev_when_unset() {
+        // Process-global env vars are racy across parallel tests, so this test
+        // only asserts the DEFAULT branch under a serialized lock that clears
+        // both vars. The precedence ordering itself is pinned by the pure
+        // `config_env_path` tests below + the documented contract.
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: single-threaded section under ENV_LOCK; restored before unlock.
+        let saved_tv = std::env::var("TV_ENVIRONMENT").ok();
+        let saved_env = std::env::var("ENVIRONMENT").ok();
+        unsafe {
+            std::env::remove_var("TV_ENVIRONMENT");
+            std::env::remove_var("ENVIRONMENT");
+        }
+        assert_eq!(resolve_config_env(), "dev");
+        unsafe {
+            match saved_tv {
+                Some(v) => std::env::set_var("TV_ENVIRONMENT", v),
+                None => std::env::remove_var("TV_ENVIRONMENT"),
+            }
+            match saved_env {
+                Some(v) => std::env::set_var("ENVIRONMENT", v),
+                None => std::env::remove_var("ENVIRONMENT"),
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // config_env_path — per-environment override selection + path-traversal safety
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_config_env_path_dev_and_local_return_none() {
+        // dev/local must NOT add an override file — base + local already cover
+        // local development, so behaviour stays byte-identical.
+        assert_eq!(config_env_path("dev"), None);
+        assert_eq!(config_env_path("local"), None);
+        assert_eq!(config_env_path(""), None);
+        assert_eq!(config_env_path("  "), None);
+        assert_eq!(config_env_path("DEV"), None); // case-insensitive
+    }
+
+    #[test]
+    fn test_config_env_path_staging_maps_to_staging_toml() {
+        // The 3-month data-pull phase runs staging = sandbox/dry_run config.
+        assert_eq!(
+            config_env_path("staging"),
+            Some("config/staging.toml".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_env_path_prod_aliases_to_production_toml() {
+        // Both "prod" and "production" resolve to the canonical production.toml.
+        assert_eq!(
+            config_env_path("prod"),
+            Some("config/production.toml".to_string())
+        );
+        assert_eq!(
+            config_env_path("production"),
+            Some("config/production.toml".to_string())
+        );
+        assert_eq!(
+            config_env_path("PROD"),
+            Some("config/production.toml".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_env_path_rejects_path_traversal() {
+        // A hostile env var must never escape config/ — anything outside the
+        // strict [a-z0-9-] allowlist returns None (falls back to base+local).
+        assert_eq!(config_env_path("../secrets"), None);
+        assert_eq!(config_env_path("..%2fetc%2fpasswd"), None);
+        assert_eq!(config_env_path("prod/../../etc"), None);
+        assert_eq!(config_env_path("a b"), None);
+        assert_eq!(config_env_path("prod.toml"), None); // dot not allowed
+    }
 
     // -----------------------------------------------------------------------
     // build_app_log_filter_directive

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -163,8 +163,17 @@ async fn main() -> Result<()> {
     // -----------------------------------------------------------------------
     // Step 1: Load and validate configuration
     // -----------------------------------------------------------------------
-    let config: ApplicationConfig = Figment::new()
-        .merge(Toml::file(CONFIG_BASE_PATH))
+    // Merge order (last-write-wins): base.toml → config/<env>.toml → local.toml.
+    // The per-environment override is selected by TV_ENVIRONMENT (preferred) /
+    // ENVIRONMENT, the SAME variable secret_manager uses for the SSM prefix, so
+    // config + secrets always agree. For dev/local there is no override file,
+    // so this is byte-identical to the previous base + local behaviour.
+    let config_env = tickvault_app::boot_helpers::resolve_config_env();
+    let mut config_figment = Figment::new().merge(Toml::file(CONFIG_BASE_PATH));
+    if let Some(env_path) = tickvault_app::boot_helpers::config_env_path(&config_env) {
+        config_figment = config_figment.merge(Toml::file(env_path));
+    }
+    let config: ApplicationConfig = config_figment
         .merge(Toml::file(CONFIG_LOCAL_PATH))
         .extract()
         .context("failed to load configuration from config/base.toml")?;

--- a/crates/core/src/auth/secret_manager.rs
+++ b/crates/core/src/auth/secret_manager.rs
@@ -45,13 +45,30 @@ fn validate_environment(env: &str) -> Result<String, ApplicationError> {
     Ok(env.to_string())
 }
 
-/// Returns the SSM environment from the `ENVIRONMENT` env var,
-/// falling back to `DEFAULT_SSM_ENVIRONMENT` ("dev").
+/// Returns the SSM environment from the `TV_ENVIRONMENT` env var (preferred,
+/// set by the systemd unit on AWS), falling back to the legacy `ENVIRONMENT`
+/// var, then to `DEFAULT_SSM_ENVIRONMENT` ("dev").
+///
+/// Precedence (first non-empty wins): `TV_ENVIRONMENT` → `ENVIRONMENT` → `"dev"`.
+/// Unifying on `TV_ENVIRONMENT` keeps the SSM secret prefix
+/// (`/tickvault/<env>/...`) consistent with the config-file env selection in
+/// `boot_helpers::resolve_config_env` — both read the same variable, so the
+/// deployed box's `TV_ENVIRONMENT=staging` drives BOTH the config merge and
+/// the SSM prefix. The legacy `ENVIRONMENT` fallback preserves existing local
+/// dev behaviour.
 ///
 /// Validates that the environment string contains only alphanumeric
 /// characters and hyphens to prevent path traversal.
 pub fn resolve_environment() -> Result<String, ApplicationError> {
-    let env = std::env::var("ENVIRONMENT").unwrap_or_else(|_| DEFAULT_SSM_ENVIRONMENT.to_string());
+    let env = std::env::var("TV_ENVIRONMENT")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var("ENVIRONMENT")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        })
+        .unwrap_or_else(|| DEFAULT_SSM_ENVIRONMENT.to_string());
     validate_environment(&env)
 }
 

--- a/deploy/systemd/tickvault.service
+++ b/deploy/systemd/tickvault.service
@@ -40,7 +40,14 @@ WatchdogSec=60
 
 # Environment
 Environment=RUST_LOG=info
-Environment=TV_ENVIRONMENT=prod
+# TV_ENVIRONMENT selects BOTH config/<env>.toml AND the /tickvault/<env>/ SSM
+# prefix (read by boot_helpers::resolve_config_env + secret_manager).
+# staging = sandbox/data-pull (dry_run=true, sandbox.dhan.co, no real orders) —
+# the locked config for the 3-month no-orders monitoring phase.
+# DO NOT change to "prod" until going live: production.toml sets dry_run=false +
+# real api.dhan.co + requires the registered static EIP (enable_eip=true). See
+# config/production.toml + config/staging.toml.
+Environment=TV_ENVIRONMENT=staging
 
 # Resource limits
 LimitNOFILE=65536


### PR DESCRIPTION
## Summary

A deep-check of the live Mac boot (operator ran the app successfully — clean boot, Dhan auth OK, 331-SID universe, option-chain snapshots persisting) revealed a **real env-wiring gap with a money-safety dimension**, now fixed.

**The gap:** the AWS systemd unit set `TV_ENVIRONMENT=prod`, but **nothing read it.**
- `main.rs` merged only `base.toml` + `local.toml` → `config/production.toml` was **never loaded** (dead).
- `secret_manager` read a **different** var (`ENVIRONMENT`, default `dev`) → the box used the `/tickvault/dev/*` SSM prefix.

So the deployed box would silently run the `base.toml` sandbox config under the wrong SSM prefix, and `production.toml` (the only file that arms real money) was unreachable.

## The fix — unify the env var, route AWS to the SAFE staging config
Per operator lock (verbatim 2026-05-30): **no real orders for 3 months — monitoring + fetching + storing to DB only.**

- `secret_manager::resolve_environment()`: precedence `TV_ENVIRONMENT` → `ENVIRONMENT` → `dev`
- `boot_helpers::resolve_config_env()` (same precedence) + `config_env_path()` → merges `config/<env>.toml` **between** base and local; `dev`/`local` → `None` (local behaviour byte-identical); strict `[a-z0-9-]` allowlist blocks path traversal; `prod` aliases to `production.toml`
- `main.rs` Step 1: merge `base → config/<env>.toml → local`, env from `TV_ENVIRONMENT`
- **systemd: `TV_ENVIRONMENT=prod` → `staging`**

**Why staging is safe (triple-locked, no real orders possible):** `staging.toml` sets `dry_run=true`, `mode=sandbox`, and `sandbox_only_until=2099-12-31` — live promotion is **mechanically impossible** even on a misedit. `production.toml` (dry_run=false, real `api.dhan.co`, EIP-required) stays **DORMANT** until a deliberate live cutover (set `TV_ENVIRONMENT=prod` + enable + Dhan-register the EIP).

## Zero-Loss Guarantee Charter check
- **Money safety:** AWS now runs sandbox/data-pull; `production.toml` cannot load without an explicit env flip + EIP. No order path is reachable.
- **O(1):** N/A — boot-time config selection (cold path); no hot-path/DB code.
- **Real testing (no hallucination):** `cargo test -p tickvault-app --lib boot_helpers::tests` = **109 passed, 0 failed** (5 new config-env tests incl. path-traversal + default-env); `secret_manager` resolve_environment test green; `cargo build -p tickvault-app -p tickvault-core` ok; fmt + full 12-gate pre-push battery green.
- **Security:** path-traversal allowlist test pins that a hostile `TV_ENVIRONMENT` can't escape `config/`.

## Test plan
- [x] 5 config-env unit tests pass (staging→staging.toml, prod→production.toml, dev/local→None, traversal rejected, default=dev)
- [x] build (app+core) ok; fmt clean; pub-fn-test guard satisfied
- [x] systemd unit pins `TV_ENVIRONMENT=staging` with a documented "don't change to prod until live" comment
- [ ] CI all green (drives auto-merge)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_