### PR TITLE
feat(aws): CloudWatch operator dashboard + secure SSM access guide

### DIFF
--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -130,6 +130,40 @@ fn test_terraform_instance_type_pinned() {
 }
 
 #[test]
+fn test_cloudwatch_operator_dashboard_exists() {
+    // The CloudWatch-only runtime has NO Grafana — the operator dashboard is a
+    // native CloudWatch dashboard (deploy/aws/terraform/dashboard.tf). It must
+    // exist + chart only metrics the CW agent actually scrapes (the allowlist
+    // in user-data prometheus.yaml) + reference real alarm resources, so a
+    // terraform apply doesn't fail and no widget is empty.
+    let dash = std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/dashboard.tf"))
+        .expect("dashboard.tf must be readable"); // APPROVED: test
+    assert!(
+        dash.contains("resource \"aws_cloudwatch_dashboard\" \"operator\""),
+        "dashboard.tf must declare the operator CloudWatch dashboard"
+    );
+    // A few signal metrics that MUST be charted (and are in the scrape allowlist).
+    for metric in &[
+        "tv_realtime_guarantee_score",
+        "tv_questdb_disconnected_seconds",
+        "tv_token_remaining_seconds",
+        "tv_aggregator_seals_emitted_total",
+    ] {
+        assert!(
+            dash.contains(metric),
+            "operator dashboard must chart {metric} (a scraped Tickvault/Prod metric)"
+        );
+    }
+    // The dashboard_url output lets the operator jump straight to it.
+    let outputs = std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/outputs.tf"))
+        .expect("outputs.tf must be readable"); // APPROVED: test
+    assert!(
+        outputs.contains("dashboard_url"),
+        "outputs.tf must expose dashboard_url for one-click console access"
+    );
+}
+
+#[test]
 fn test_terraform_instance_iam_allows_staging_ssm_prefix() {
     // The app reads its secrets under the SSM prefix selected by
     // TV_ENVIRONMENT (systemd unit) = "staging" for the 3-month data-pull

--- a/deploy/aws/terraform/dashboard.tf
+++ b/deploy/aws/terraform/dashboard.tf
@@ -1,0 +1,242 @@
+# =============================================================================
+# CloudWatch Dashboard — single operator visual page
+# =============================================================================
+# One pane the operator opens in the AWS Console (from any browser / phone /
+# IntelliJ) to watch the whole system: app health, market-data flow, resource
+# usage, and the live alarm states. No local Macbook / Grafana needed — this
+# IS the visualization layer for the CloudWatch-only runtime.
+#
+# Free tier: 3 dashboards. This is dashboard #1.
+#
+# Metric source: the CloudWatch agent scrapes the app's :9091 /metrics endpoint
+# every 60s and publishes the allowlisted tv_* metrics under the
+# "Tickvault/Prod" namespace (see user-data.sh.tftpl prometheus.yaml). EC2
+# CPU comes from AWS/EC2; disk from the CWAgent namespace. Only metrics that
+# are actually scraped are charted here — no empty widgets.
+#
+# Open it: AWS Console -> CloudWatch -> Dashboards -> tv-<env>-operator
+# Or via outputs.tf `dashboard_url`.
+# =============================================================================
+
+locals {
+  dash_namespace = "Tickvault/Prod"
+  dash_region    = var.aws_region
+}
+
+resource "aws_cloudwatch_dashboard" "operator" {
+  dashboard_name = "tv-${var.environment}-operator"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      # ----- Row 0: headline text -----
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 2
+        properties = {
+          markdown = "# tickvault — operator dashboard (${var.environment})\nLive view of app health, market-data flow, and resource usage. Metrics scraped from the app every 60s. Alarms at the bottom turn red on breach and page Telegram/Email/SMS."
+        }
+      },
+
+      # ----- Row 1: the single most important signal -----
+      {
+        type   = "metric"
+        x      = 0
+        y      = 2
+        width  = 8
+        height = 6
+        properties = {
+          title   = "Real-time guarantee score (1.0 = all healthy)"
+          region  = local.dash_region
+          view    = "gauge"
+          metrics = [[local.dash_namespace, "tv_realtime_guarantee_score"]]
+          yAxis   = { left = { min = 0, max = 1 } }
+          period  = 60
+          stat    = "Average"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 2
+        width  = 8
+        height = 6
+        properties = {
+          title   = "Token remaining (seconds until JWT expiry)"
+          region  = local.dash_region
+          view    = "timeSeries"
+          metrics = [[local.dash_namespace, "tv_token_remaining_seconds"]]
+          period  = 60
+          stat    = "Minimum"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 2
+        width  = 8
+        height = 6
+        properties = {
+          title   = "QuestDB disconnected (seconds — 0 = healthy)"
+          region  = local.dash_region
+          view    = "timeSeries"
+          metrics = [[local.dash_namespace, "tv_questdb_disconnected_seconds"]]
+          period  = 60
+          stat    = "Maximum"
+        }
+      },
+
+      # ----- Row 2: market-data flow + WebSocket health -----
+      {
+        type   = "metric"
+        x      = 0
+        y      = 8
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Candle seals emitted (data flowing during market hours)"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [[local.dash_namespace, "tv_aggregator_seals_emitted_total", { stat = "Sum" }]]
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 8
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Instruments silent (tick-gap — 0 = all streaming)"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [[local.dash_namespace, "tv_tick_gap_instruments_silent"]]
+          period = 60
+          stat   = "Maximum"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 8
+        width  = 8
+        height = 6
+        properties = {
+          title  = "WebSocket health"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [
+            [local.dash_namespace, "tv_websocket_pool_all_dead", { label = "pool all dead (1=bad)" }],
+            [local.dash_namespace, "tv_websocket_failed_connections_count", { label = "failed conns" }],
+            [local.dash_namespace, "tv_order_update_ws_active", { label = "order-update WS active (1=good)" }]
+          ]
+          period = 60
+          stat   = "Maximum"
+        }
+      },
+
+      # ----- Row 3: data-integrity / loss signals -----
+      {
+        type   = "metric"
+        x      = 0
+        y      = 14
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Tick spill dropped (0 = no loss)"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [[local.dash_namespace, "tv_spill_dropped_total", { stat = "Sum" }]]
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 14
+        width  = 8
+        height = 6
+        properties = {
+          title  = "DLQ ticks (recoverable overflow — 0 = none)"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [[local.dash_namespace, "tv_dlq_ticks_total", { stat = "Sum" }]]
+          period = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 14
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Clock skew (seconds vs trusted source)"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [[local.dash_namespace, "tv_clock_skew_seconds"]]
+          period = 60
+          stat   = "Maximum"
+        }
+      },
+
+      # ----- Row 4: host resources -----
+      {
+        type   = "metric"
+        x      = 0
+        y      = 20
+        width  = 12
+        height = 6
+        properties = {
+          title  = "EC2 CPU utilization (%)"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.tv_app.id]]
+          period = 60
+          stat   = "Average"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 20
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Root disk used (%)"
+          region = local.dash_region
+          view   = "timeSeries"
+          metrics = [[{ expression = "SELECT MAX(disk_used_percent) FROM \"CWAgent\" WHERE InstanceId = '${aws_instance.tv_app.id}' AND path = '/'", label = "disk used %", id = "diskpct" }]]
+          period = 300
+        }
+      },
+
+      # ----- Row 5: live alarm status strip -----
+      {
+        type   = "alarm"
+        x      = 0
+        y      = 26
+        width  = 24
+        height = 4
+        properties = {
+          title = "Live alarm status (red = firing -> Telegram/Email/SMS already paged)"
+          alarms = [
+            aws_cloudwatch_metric_alarm.ws_pool_all_dead.arn,
+            aws_cloudwatch_metric_alarm.questdb_disconnected.arn,
+            aws_cloudwatch_metric_alarm.token_remaining_low.arn,
+            aws_cloudwatch_metric_alarm.tick_gap_instruments_silent.arn,
+            aws_cloudwatch_metric_alarm.realtime_guarantee_critical.arn,
+            aws_cloudwatch_metric_alarm.spill_dropped.arn,
+            aws_cloudwatch_metric_alarm.dlq_ticks.arn,
+            aws_cloudwatch_metric_alarm.clock_skew_high.arn,
+            aws_cloudwatch_metric_alarm.high_cpu.arn,
+            aws_cloudwatch_metric_alarm.disk_used_high.arn
+          ]
+        }
+      }
+    ]
+  })
+}

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -39,3 +39,8 @@ output "ssm_session_command" {
   description = "One-liner to open a Session Manager shell (no SSH key needed)"
   value       = "aws ssm start-session --region ${var.aws_region} --target ${aws_instance.tv_app.id}"
 }
+
+output "dashboard_url" {
+  description = "Direct URL to the CloudWatch operator dashboard (open in any browser)"
+  value       = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#dashboards/dashboard/${aws_cloudwatch_dashboard.operator.dashboard_name}"
+}

--- a/docs/runbooks/aws-access-from-anywhere.md
+++ b/docs/runbooks/aws-access-from-anywhere.md
@@ -1,0 +1,156 @@
+# Access tickvault on AWS from anywhere — securely
+
+> **What this gives you:** open the **QuestDB web console** and the **app API**
+> in your own browser (Mac / IntelliJ / phone-with-laptop) while they run on
+> the AWS box — **without exposing anything to the public internet**. The
+> tunnel is authenticated by your AWS login (IAM) and encrypted end-to-end via
+> AWS Systems Manager (SSM). No SSH key, no public IP, no open ports.
+>
+> **Why not a plain public URL?** The QuestDB web console has **no password** —
+> a public URL would let anyone who finds the IP read all your market data and
+> run queries, right next to your broker credentials. SSM port-forwarding gives
+> the identical "open it in my browser" experience with zero exposure. This is
+> the recommended, secure way and works from anywhere with the AWS CLI.
+
+---
+
+## One-time prerequisites (on whatever laptop you use)
+
+```bash
+brew install awscli                 # AWS CLI v2
+# the Session Manager plugin (needed for port-forwarding):
+#   https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+aws configure                       # region = ap-south-1, your IAM keys
+aws sts get-caller-identity         # must print your account
+```
+
+Instance id: **`i-0b956d0209231a48b`** (`tv-prod-app`). Region: `ap-south-1`.
+
+---
+
+## 1. The CloudWatch dashboard — no tunnel needed
+
+The visual operator page (app health, market-data flow, alarms) is in the AWS
+Console — open it from **any browser, even your phone**, just by logging into
+AWS:
+
+> AWS Console → CloudWatch → Dashboards → **`tv-prod-operator`**
+
+Or get the direct URL after deploy:
+```bash
+cd deploy/aws/terraform && terraform output dashboard_url
+```
+
+This needs **no tunnel** — it's a native AWS console page. Logs, metrics,
+alarms, and the live alarm-status strip are all there.
+
+---
+
+## 2. QuestDB web console (browse/query your market data)
+
+QuestDB's console runs on the box at `127.0.0.1:9000` (localhost-only = secure).
+Tunnel it to your laptop:
+
+```bash
+aws ssm start-session \
+  --region ap-south-1 \
+  --target i-0b956d0209231a48b \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["9000"],"localPortNumber":["9000"]}'
+```
+
+Leave that running, then open **http://localhost:9000** in your browser — it's
+the live QuestDB console on the AWS box. Run SQL, browse `ticks`,
+`candles_*`, `option_chain_minute_snapshot`, the instrument lifecycle, etc.
+
+Press `Ctrl+C` in the terminal to close the tunnel when done.
+
+---
+
+## 3. App REST API (health, stats, quotes)
+
+The app API runs on **port 3002 in staging** (3001 in prod). Tunnel it:
+
+```bash
+aws ssm start-session \
+  --region ap-south-1 \
+  --target i-0b956d0209231a48b \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["3002"],"localPortNumber":["3002"]}'
+```
+
+Then on your laptop (the API needs the bearer token from
+`/tickvault/staging/api/bearer-token`):
+```bash
+TOKEN=$(aws ssm get-parameter --region ap-south-1 \
+  --name /tickvault/staging/api/bearer-token --with-decryption \
+  --query Parameter.Value --output text)
+
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:3002/health
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:3002/api/stats
+```
+
+> Note: the app API DOES have bearer-token auth, so unlike the QuestDB console
+> it *could* be safely exposed publicly later if you ever want a raw URL — but
+> the tunnel is simpler and needs no extra infra.
+
+---
+
+## 4. A shell on the box (logs, systemctl, make doctor)
+
+No SSH key needed — Session Manager:
+```bash
+aws ssm start-session --region ap-south-1 --target i-0b956d0209231a48b
+#   inside the box:
+#     systemctl status tickvault --no-pager
+#     journalctl -u tickvault -n 100 --no-pager
+#     cd /opt/tickvault && cat data/logs/errors.summary.md
+```
+
+Or the repo's Makefile shortcuts (from `~/tickvault`):
+```bash
+make aws-ssm            # interactive shell
+make aws-ssm-command    # tails the last 50 app-log lines
+make aws-outputs        # instance_id, dashboard_url, etc.
+make aws-cost           # current month bill estimate
+```
+
+---
+
+## 5. Logs — three ways, all from AWS
+
+1. **CloudWatch Logs** (from any browser): Console → CloudWatch → Log groups →
+   `/tickvault/prod/app` and `/tickvault/prod/system`.
+2. **On the box**: `journalctl -u tickvault -f` (live) via `make aws-ssm`.
+3. **Structured ERROR summary**: `data/logs/errors.summary.md` on the box.
+
+---
+
+## Security posture (what's locked down)
+
+| Layer | State |
+|---|---|
+| Secrets | Encrypted in SSM Parameter Store (SecureString); never in repo/logs |
+| QuestDB console (:9000) | localhost-only on the box; reachable ONLY via your SSM tunnel |
+| App API (:3002) | localhost-only + bearer-token auth |
+| SSH (:22) | locked to your operator IP CIDR only |
+| Public internet | nothing exposed without auth; no open DB/API ports |
+| Instance metadata | IMDSv2 required |
+| Access audit | every SSM session is logged in CloudTrail (who/when/what) |
+
+**The "from anywhere" you wanted = AWS Console (dashboard/logs/alarms) + SSM
+tunnels (QuestDB/API).** Works from Mac, IntelliJ terminal, or any laptop with
+the AWS CLI — fully independent of your local Macbook, fully secure.
+
+---
+
+## Want a true public URL later?
+
+Two safe options (NOT the raw QuestDB console — it has no auth):
+- **App API behind the bearer token** on the Elastic IP (when EIP is enabled
+  for live trading) — already authenticated.
+- A small auth proxy in front of QuestDB — a future enhancement if you want
+  browser access without the CLI tunnel.
+
+Ask and I'll wire either — but the SSM tunnel above already gives you secure
+browser access from anywhere today.


### PR DESCRIPTION
## Summary

Delivers "everything visible + reachable from AWS, from anywhere, with NO public exposure" — the two pieces the operator selected.

### 1. CloudWatch operator dashboard (`deploy/aws/terraform/dashboard.tf`)
A native CloudWatch dashboard `tv-<env>-operator` — the CloudWatch-only runtime's visualization layer (replaces Grafana). Opens in **any browser / phone**, no tunnel. 5 rows of the **real scraped `Tickvault/Prod` metrics**:
- Real-time guarantee score (gauge) + token-expiry + QuestDB-disconnected
- Market-data flow: candle seals, silent-instrument count, WebSocket health
- Loss signals: spill-dropped, DLQ ticks, clock skew
- Host: EC2 CPU + root disk %
- **Live alarm-status strip** (red = firing → already paged Telegram/Email/SMS)

Only metrics in the CW-agent scrape allowlist are charted (no empty widgets); all 10 alarm refs resolve to real resources. `outputs.tf` gains `dashboard_url` for one-click open.

### 2. Secure access guide (`docs/runbooks/aws-access-from-anywhere.md`)
Open the **QuestDB web console (:9000)** + **app API (:3002 staging)** + a box shell + logs from any laptop/IntelliJ via **SSM port-forwarding** — IAM-authenticated, encrypted, **zero public ports**. Explains why a raw public QuestDB URL is unsafe (the console has no auth) and that the SSM tunnel gives identical browser access securely. Includes the full security-posture table.

## Why SSM tunnel, not public URL
QuestDB's web console has **no authentication** — a public URL would expose all market data + sit next to broker creds. SSM port-forward = same "open in my browser from anywhere" experience, zero exposure. (The app API *does* have bearer auth, so it could be public later if wanted.)

## Zero-Loss Guarantee Charter check
- **Security:** nothing newly exposed — dashboard is native AWS console; QuestDB/API stay localhost-only reachable only via IAM-authed SSM tunnels; every session audited in CloudTrail.
- **O(1):** N/A — Terraform + docs + a guard test; no runtime/hot-path/DB code.
- **Real testing:** `cargo test -p tickvault-common --test aws_infra_wiring` = **20 passed, 0 failed** (new dashboard guard); all 10 alarm refs resolve to real resources (verified); fmt clean.

## Test plan
- [x] `aws_infra_wiring` = 20 passed (dashboard guard added)
- [x] all dashboard alarm refs resolve to existing alarm resources
- [x] dashboard charts only scrape-allowlisted metrics; `dashboard_url` output added
- [ ] CI green (drives auto-merge)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_