### PR TITLE
feat(aws): AWS control-panel workflow — operate everything from anywhere, no terminal

### DIFF
--- a/.github/workflows/aws-control.yml
+++ b/.github/workflows/aws-control.yml
@@ -1,0 +1,231 @@
+# =============================================================================
+# AWS control panel — start / stop / reboot / status / restart / deploy
+# =============================================================================
+# ONE workflow to operate the whole AWS deployment with ZERO terminal commands.
+# Trigger it from anywhere:
+#   - GitHub web/mobile: Actions -> "AWS Control" -> Run workflow -> pick action
+#   - Claude (chat/code/cowork/IntelliJ): the claude-mobile-command workflow can
+#     dispatch this, or Claude calls `gh workflow run aws-control.yml -f action=...`
+#
+# Every action runs in GitHub Actions using the AWS creds already in repo
+# Secrets — nothing typed on a laptop, nothing exposed. Each action is explicit
+# and idempotent. Destructive/market-hours-sensitive actions (stop, reboot,
+# restart-app) honour a market-hours guard unless `force=yes`.
+#
+# Actions:
+#   status          - print instance state + app/QuestDB health (read-only)
+#   start           - start the EC2 instance (idempotent)
+#   stop            - stop the EC2 instance (market-hours guarded)
+#   reboot          - reboot the EC2 instance (market-hours guarded)
+#   restart-app     - systemctl restart tickvault (via SSM; market-hours guarded)
+#   restart-questdb - restart the QuestDB docker container (via SSM)
+#   seed-secrets    - copy /tickvault/dev/* -> /tickvault/staging/* (idempotent)
+#   deploy          - dispatch the full deploy-aws build+ship+restart pipeline
+# =============================================================================
+
+name: AWS Control
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'What to do'
+        required: true
+        type: choice
+        options:
+          - status
+          - start
+          - stop
+          - reboot
+          - restart-app
+          - restart-questdb
+          - seed-secrets
+          - deploy
+      force:
+        description: 'Override the market-hours guard? (yes/no)'
+        required: false
+        default: 'no'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write   # needed to dispatch deploy-aws.yml for action=deploy
+
+concurrency:
+  group: aws-control
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-south-1
+
+jobs:
+  preflight:
+    name: Check creds present
+    runs-on: ubuntu-24.04
+    outputs:
+      ready: ${{ steps.c.outputs.ready }}
+    steps:
+      - id: c
+        env:
+          OIDC: ${{ secrets.AWS_ROLE_ARN }}
+          KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        run: |
+          if [ -n "$OIDC" ] || [ -n "$KEY" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::error::No AWS creds in repo Secrets (AWS_ROLE_ARN or AWS_ACCESS_KEY_ID)."
+          fi
+
+  control:
+    name: ${{ github.event.inputs.action }}
+    runs-on: ubuntu-24.04
+    needs: preflight
+    if: needs.preflight.outputs.ready == 'true'
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: tv-aws-control-${{ github.run_id }}
+
+      - name: Resolve instance id
+        id: iid
+        run: |
+          set -euo pipefail
+          IID="${{ secrets.EC2_INSTANCE_ID }}"
+          if [ -z "$IID" ]; then
+            # Fall back to the Name tag if the secret isn't set.
+            IID=$(aws ec2 describe-instances --region "$AWS_REGION" \
+                    --filters "Name=tag:Name,Values=tv-prod-app" \
+                              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+                    --query 'Reservations[0].Instances[0].InstanceId' --output text)
+          fi
+          [ -n "$IID" ] && [ "$IID" != "None" ] || { echo "::error::Could not resolve instance id"; exit 1; }
+          echo "id=$IID" >> "$GITHUB_OUTPUT"
+          echo "Instance: $IID"
+
+      - name: Market-hours guard (IST 09:15-15:30 Mon-Fri)
+        id: guard
+        run: |
+          set -euo pipefail
+          action="${{ github.event.inputs.action }}"
+          force="${{ github.event.inputs.force }}"
+          # Only stop/reboot/restart-app interrupt a live session.
+          case "$action" in
+            stop|reboot|restart-app) sensitive=1 ;;
+            *) sensitive=0 ;;
+          esac
+          if [ "$sensitive" = "1" ] && [ "$force" != "yes" ]; then
+            # IST = UTC+5:30. Market window UTC 03:45-10:00, Mon-Fri.
+            mins=$(( ( $(date -u +%H) * 60 + $(date -u +%M) ) ))
+            dow=$(date -u +%u)  # 1=Mon..7=Sun
+            if [ "$dow" -le 5 ] && [ "$mins" -ge 225 ] && [ "$mins" -le 600 ]; then
+              echo "::error::'$action' blocked during market hours (09:15-15:30 IST Mon-Fri). Re-run with force=yes if truly needed."
+              exit 1
+            fi
+          fi
+          echo "guard passed (action=$action force=$force)"
+
+      - name: status
+        if: github.event.inputs.action == 'status'
+        run: |
+          set -euo pipefail
+          IID=${{ steps.iid.outputs.id }}
+          echo "### EC2 state"
+          aws ec2 describe-instances --region "$AWS_REGION" --instance-ids "$IID" \
+            --query 'Reservations[0].Instances[0].{State:State.Name,Type:InstanceType,AZ:Placement.AvailabilityZone,LaunchTime:LaunchTime}' --output table
+          echo "### App + QuestDB health (via SSM, best-effort)"
+          CMD=$(aws ssm send-command --region "$AWS_REGION" --instance-ids "$IID" \
+            --document-name AWS-RunShellScript \
+            --parameters 'commands=["systemctl is-active tickvault || true","docker ps --format \"{{.Names}} {{.Status}}\" | grep -i quest || true"]' \
+            --query Command.CommandId --output text 2>/dev/null || echo "")
+          if [ -n "$CMD" ]; then
+            sleep 4
+            aws ssm get-command-invocation --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" \
+              --query StandardOutputContent --output text 2>/dev/null || echo "(instance may be stopped — start it first)"
+          fi
+
+      - name: start
+        if: github.event.inputs.action == 'start'
+        run: |
+          IID=${{ steps.iid.outputs.id }}
+          aws ec2 start-instances --region "$AWS_REGION" --instance-ids "$IID" >/dev/null
+          aws ec2 wait instance-running --region "$AWS_REGION" --instance-ids "$IID"
+          echo "Started $IID — running."
+
+      - name: stop
+        if: github.event.inputs.action == 'stop'
+        run: |
+          IID=${{ steps.iid.outputs.id }}
+          aws ec2 stop-instances --region "$AWS_REGION" --instance-ids "$IID" >/dev/null
+          aws ec2 wait instance-stopped --region "$AWS_REGION" --instance-ids "$IID"
+          echo "Stopped $IID."
+
+      - name: reboot
+        if: github.event.inputs.action == 'reboot'
+        run: |
+          IID=${{ steps.iid.outputs.id }}
+          aws ec2 reboot-instances --region "$AWS_REGION" --instance-ids "$IID"
+          echo "Reboot issued for $IID."
+
+      - name: restart-app
+        if: github.event.inputs.action == 'restart-app'
+        run: |
+          set -euo pipefail
+          IID=${{ steps.iid.outputs.id }}
+          CMD=$(aws ssm send-command --region "$AWS_REGION" --instance-ids "$IID" \
+            --document-name AWS-RunShellScript \
+            --parameters 'commands=["systemctl restart tickvault","sleep 5","systemctl is-active --quiet tickvault && echo RESTARTED-OK || (echo FAIL; exit 1)"]' \
+            --query Command.CommandId --output text)
+          aws ssm wait command-executed --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" || true
+          aws ssm get-command-invocation --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" \
+            --query StandardOutputContent --output text
+
+      - name: restart-questdb
+        if: github.event.inputs.action == 'restart-questdb'
+        run: |
+          set -euo pipefail
+          IID=${{ steps.iid.outputs.id }}
+          CMD=$(aws ssm send-command --region "$AWS_REGION" --instance-ids "$IID" \
+            --document-name AWS-RunShellScript \
+            --parameters 'commands=["cd /opt/tickvault/repo/deploy/docker && docker compose restart questdb && docker ps --format \"{{.Names}} {{.Status}}\" | grep -i quest"]' \
+            --query Command.CommandId --output text)
+          aws ssm wait command-executed --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" || true
+          aws ssm get-command-invocation --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" \
+            --query StandardOutputContent --output text
+
+      - name: seed-secrets
+        if: github.event.inputs.action == 'seed-secrets'
+        run: |
+          set -euo pipefail
+          names=$(aws ssm get-parameters-by-path --path /tickvault/dev --recursive \
+                    --region "$AWS_REGION" --query 'Parameters[].Name' --output text)
+          [ -n "$names" ] || { echo "::error::no /tickvault/dev/* params"; exit 1; }
+          n=0
+          for name in $names; do
+            newname="/tickvault/staging/${name#/tickvault/dev/}"
+            ptype=$(aws ssm get-parameter --name "$name" --region "$AWS_REGION" --query 'Parameter.Type' --output text)
+            value=$(aws ssm get-parameter --name "$name" --with-decryption --region "$AWS_REGION" --query 'Parameter.Value' --output text)
+            aws ssm put-parameter --name "$newname" --type "$ptype" --value "$value" --overwrite --region "$AWS_REGION" >/dev/null
+            n=$((n+1)); echo "  seeded $name -> $newname ($ptype)"
+          done
+          echo "Seeded $n parameters dev -> staging."
+
+      - name: deploy
+        if: github.event.inputs.action == 'deploy'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run deploy-aws.yml --repo "${{ github.repository }}" --ref main
+          echo "Dispatched deploy-aws.yml (build -> ship -> smoke -> restart). Watch it in the Actions tab."
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## AWS Control: \`${{ github.event.inputs.action }}\` ✅" >> "$GITHUB_STEP_SUMMARY"
+          echo "Instance: ${{ steps.iid.outputs.id }} | region: ${AWS_REGION} | force: ${{ github.event.inputs.force }}" >> "$GITHUB_STEP_SUMMARY"

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -251,6 +251,40 @@ fn test_terraform_eventbridge_schedules_match_budget() {
 }
 
 #[test]
+fn test_aws_control_workflow_covers_all_operations() {
+    // Full automation: a single dispatchable workflow operates the whole AWS
+    // deployment (start/stop/reboot/status/restart-app/restart-questdb/
+    // seed-secrets/deploy) from anywhere — GitHub web/mobile or a Claude session
+    // — with zero terminal commands. Must exist, expose every action, guard
+    // market hours on session-interrupting actions, and never echo a secret.
+    let wf = std::fs::read_to_string(workspace_root().join(".github/workflows/aws-control.yml"))
+        .expect("aws-control.yml must be readable"); // APPROVED: test
+    for action in &[
+        "status",
+        "start",
+        "stop",
+        "reboot",
+        "restart-app",
+        "restart-questdb",
+        "seed-secrets",
+        "deploy",
+    ] {
+        assert!(
+            wf.contains(&format!("action == '{action}'")),
+            "aws-control.yml must implement the '{action}' action"
+        );
+    }
+    assert!(
+        wf.contains("Market-hours guard"),
+        "aws-control.yml must guard session-interrupting actions against market hours"
+    );
+    assert!(
+        !wf.contains("echo \"$value\"") && !wf.contains("echo $value"),
+        "aws-control.yml must NEVER echo a decrypted secret value"
+    );
+}
+
+#[test]
 fn test_terraform_s3_lifecycle_matches_sebi_retention() {
     let content = std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/main.tf"))
         .expect("main.tf must be readable"); // APPROVED: test


### PR DESCRIPTION
## Summary

**Operate the entire AWS deployment from anywhere, zero terminal commands** — the operator's "entire automation, triggerable from GitHub / Claude / IntelliJ" demand. One workflow (`.github/workflows/aws-control.yml`) does it all via the AWS creds already in repo Secrets:

`status` · `start` · `stop` · `reboot` · `restart-app` · `restart-questdb` · `seed-secrets` · `deploy`

**Trigger from:**
- GitHub **web or mobile app**: Actions → "AWS Control" → Run workflow → pick action
- **Any Claude session** (chat/code/cowork/IntelliJ) via the existing `claude-mobile-command` workflow, or `gh workflow run aws-control.yml -f action=...`

No laptop, no terminal, no typed commands.

## Safety
- **Market-hours guard**: `stop`/`reboot`/`restart-app` (the session-interrupting actions) are blocked 09:15–15:30 IST Mon-Fri unless `force=yes` — can't accidentally kill a live session.
- **Secret-safe**: `seed-secrets` pipes `get-parameter` → `put-parameter`; values **never echoed**.
- Instance id from `EC2_INSTANCE_ID` secret with `tv-prod-app` Name-tag fallback.
- `deploy` dispatches the full `deploy-aws.yml` build → ship → smoke → restart pipeline.

## Context — the full automation picture
The system already had `claude-mobile-command.yml` (command tickvault in plain English from GitHub mobile), `terraform-apply.yml` + `deploy-aws.yml` (auto-fire on push to main), EventBridge start/stop crons, and the `seed-staging-ssm.yml` from #903. This adds the explicit one-tap control panel on top, so every operation has a named, safe, idempotent action.

## Zero-Loss Guarantee Charter check
- **Security:** uses existing repo-Secret creds; secret values never logged; market-hours guard on destructive actions; every run audited in GitHub Actions + CloudTrail.
- **O(1):** N/A — CI workflow + guard test; no runtime/hot-path/DB code.
- **Real testing:** `cargo test -p tickvault-common --test aws_infra_wiring` = **22 passed, 0 failed** (new guard pins all 8 actions + market guard + no-secret-echo); YAML valid; banned-pattern + fmt clean.

## Test plan
- [x] `aws_infra_wiring` = 22 passed (control-panel guard added)
- [x] all 8 actions implemented; market-hours guard on stop/reboot/restart-app; no secret echo
- [ ] CI green (drives auto-merge)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_