### PR TITLE
feat(aws): self-firing seed (daily cron) + Cowork dispatch (zero clicks)

### DIFF
--- a/.github/workflows/claude-mobile-command.yml
+++ b/.github/workflows/claude-mobile-command.yml
@@ -44,7 +44,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  actions: read
+  actions: write   # lets Claude Cowork dispatch aws-control / deploy / seed workflows on request
 
 jobs:
   execute:

--- a/.github/workflows/seed-staging-ssm.yml
+++ b/.github/workflows/seed-staging-ssm.yml
@@ -20,7 +20,11 @@ name: seed-staging-ssm
 
 on:
   workflow_dispatch: {}
-  # Auto-run when this workflow file itself changes on main (first landing).
+  # Self-fire DAILY at 02:25 UTC (07:55 IST) — just before the box auto-starts
+  # at 08:30 IST — so staging secrets are always fresh with ZERO clicks.
+  schedule:
+    - cron: '25 2 * * *'
+  # Also auto-run when this workflow file itself changes on main.
   push:
     branches: [main]
     paths:

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -251,6 +251,29 @@ fn test_terraform_eventbridge_schedules_match_budget() {
 }
 
 #[test]
+fn test_seed_staging_ssm_self_fires_and_cowork_can_dispatch() {
+    // Zero-click automation: the seed workflow self-fires on a daily cron (no
+    // human clicks "Run workflow"), and Claude Cowork (claude-mobile-command)
+    // has actions:write so it can dispatch aws-control / deploy / seed on
+    // request. Both pinned so the self-firing automation can't silently regress.
+    let seed =
+        std::fs::read_to_string(workspace_root().join(".github/workflows/seed-staging-ssm.yml"))
+            .expect("seed-staging-ssm.yml must be readable"); // APPROVED: test
+    assert!(
+        seed.contains("schedule:") && seed.contains("cron:"),
+        "seed-staging-ssm.yml must self-fire on a cron schedule (zero-click)"
+    );
+    let mobile = std::fs::read_to_string(
+        workspace_root().join(".github/workflows/claude-mobile-command.yml"),
+    )
+    .expect("claude-mobile-command.yml must be readable"); // APPROVED: test
+    assert!(
+        mobile.contains("actions: write"),
+        "claude-mobile-command must have actions:write so Cowork can dispatch AWS workflows"
+    );
+}
+
+#[test]
 fn test_aws_control_workflow_covers_all_operations() {
     // Full automation: a single dispatchable workflow operates the whole AWS
     // deployment (start/stop/reboot/status/restart-app/restart-questdb/


### PR DESCRIPTION
## Summary

**Zero-click automation** — nobody presses "Run workflow" for routine ops anymore.

1. **`seed-staging-ssm.yml`** — added daily cron `25 2 * * *` (07:55 IST, just before the 08:30 IST box auto-start) so staging secrets refresh themselves every day, automatically. Still dispatchable on demand + auto on file change.
2. **`claude-mobile-command.yml`** — granted `actions: write` so **Claude Cowork can dispatch** `aws-control` / `deploy` / `seed` workflows when you ask in plain English (the "tell Claude → it clicks" path).

## The full picture now
- Deploys → auto-fire on PR merge
- Box → auto start/stop daily (EventBridge)
- Secrets → **auto-seed daily** (this PR) + on merge
- Any AWS op (start/stop/reboot/deploy/restart) → from GitHub mobile, OR **Claude Cowork on request**

The Actions-tab manual click is no longer required for routine operation. (The one-time SNS email confirmation remains the only AWS-mandated human step.)

## Zero-Loss Guarantee Charter check
- **Security:** unchanged — uses existing repo-Secret creds; secret values never logged; market-hours guard intact.
- **O(1):** N/A — CI workflows + guard test; no runtime/hot-path/DB code.
- **Real testing:** `cargo test -p tickvault-common --test aws_infra_wiring` = **23 passed, 0 failed** (new guard pins the cron + Cowork dispatch perm); both YAMLs valid; banned-pattern + fmt clean.

## Test plan
- [x] `aws_infra_wiring` = 23 passed (self-fire guard added)
- [x] seed cron present; claude-mobile-command has actions:write; both YAML valid
- [ ] CI green (drives auto-merge)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_