### PR TITLE
fix(aws): deploy-aws accepts access-key creds + region fallback (unblocks every deploy)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -206,11 +206,18 @@ jobs:
           name: tickvault-binary
           path: ./dist/
 
-      - name: Configure AWS credentials via OIDC
+      - name: Configure AWS credentials (OIDC preferred, keys fallback)
+        # The OIDC role (AWS_ROLE_ARN) only exists AFTER the post-bootstrap
+        # security cleanup (BOOTSTRAP-ONE-TIME.md steps 4-5). Until then the
+        # operator has only AWS_ACCESS_KEY_ID/SECRET set — so this step MUST
+        # accept either. Mirrors seed-staging-ssm.yml so deploy works the
+        # moment the box exists, not only after the OIDC migration.
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION || 'ap-south-1' }}
           role-session-name: tv-github-deploy-${{ github.run_id }}
 
       - name: Upload both binaries to S3 staging bucket
@@ -218,10 +225,10 @@ jobs:
           chmod +x ./dist/tickvault ./dist/smoke_test
           aws s3 cp ./dist/tickvault \
             s3://tv-prod-cold/deploys/${{ github.sha }}/tickvault \
-            --region ${{ vars.AWS_REGION }}
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }}
           aws s3 cp ./dist/smoke_test \
             s3://tv-prod-cold/deploys/${{ github.sha }}/smoke_test \
-            --region ${{ vars.AWS_REGION }}
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }}
 
       - name: Run SSM command — download binaries + smoke test + atomic swap
         # Target path is /opt/tickvault (matches user-data.sh.tftpl step 4).
@@ -232,7 +239,7 @@ jobs:
         id: ssm
         run: |
           CMD_ID=$(aws ssm send-command \
-            --region ${{ vars.AWS_REGION }} \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
             --comment "tickvault deploy sha=${{ github.sha }}" \
@@ -276,14 +283,14 @@ jobs:
       - name: Wait for SSM command completion
         run: |
           aws ssm wait command-executed \
-            --region ${{ vars.AWS_REGION }} \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --command-id ${{ steps.ssm.outputs.command_id }} \
             --instance-id ${{ secrets.EC2_INSTANCE_ID }}
 
       - name: Fetch SSM command output
         run: |
           aws ssm get-command-invocation \
-            --region ${{ vars.AWS_REGION }} \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --command-id ${{ steps.ssm.outputs.command_id }} \
             --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
             --query '[Status,StandardOutputContent,StandardErrorContent]' \
@@ -296,14 +303,14 @@ jobs:
           FAIL=0
           for i in 1 2 3 4 5 6; do
             STATE=$(aws ssm send-command \
-              --region ${{ vars.AWS_REGION }} \
+              --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
               --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
               --document-name "AWS-RunShellScript" \
               --parameters 'commands=["systemctl is-active tickvault"]' \
               --query 'Command.CommandId' --output text)
             sleep 5
             RESULT=$(aws ssm get-command-invocation \
-              --region ${{ vars.AWS_REGION }} \
+              --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
               --command-id "$STATE" \
               --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
               --query 'StandardOutputContent' --output text | tr -d '[:space:]')
@@ -317,7 +324,7 @@ jobs:
           if [ "$FAIL" -eq 1 ]; then
             echo "ROLLBACK: tickvault is not active after deploy — rolling back"
             aws ssm send-command \
-              --region ${{ vars.AWS_REGION }} \
+              --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
               --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
               --document-name "AWS-RunShellScript" \
               --parameters 'commands=["set -euo pipefail","cd /opt/tickvault","if [ -f bin/tickvault.backup ]; then mv bin/tickvault.backup bin/tickvault; systemctl restart tickvault; fi"]'
@@ -331,8 +338,8 @@ jobs:
           # The SNS topic has a Telegram webhook subscription; publish
           # an INFO-level message so the operator sees the deploy land.
           aws sns publish \
-            --region ${{ vars.AWS_REGION }} \
-            --topic-arn arn:aws:sns:${{ vars.AWS_REGION }}:${{ secrets.AWS_ACCOUNT_ID }}:tv-prod-alerts \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
+            --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ secrets.AWS_ACCOUNT_ID }}:tv-prod-alerts \
             --subject "DLT deploy OK" \
             --message "commit=${{ github.sha }} ref=${{ github.ref }} actor=${{ github.actor }}"
 
@@ -340,7 +347,7 @@ jobs:
         if: failure()
         run: |
           aws sns publish \
-            --region ${{ vars.AWS_REGION }} \
-            --topic-arn arn:aws:sns:${{ vars.AWS_REGION }}:${{ secrets.AWS_ACCOUNT_ID }}:tv-prod-alerts \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
+            --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ secrets.AWS_ACCOUNT_ID }}:tv-prod-alerts \
             --subject "DLT deploy FAILED" \
             --message "commit=${{ github.sha }} ref=${{ github.ref }} actor=${{ github.actor }} run=${{ github.run_id }}"


### PR DESCRIPTION
## Summary

**Every `deploy-aws` run (#88–#95) is red** — and this is why. The deploy job's credential step used **OIDC only** (`role-to-assume: ${{ secrets.AWS_ROLE_ARN }}`), but the `preflight` gate passes on **`AWS_ACCESS_KEY_ID` alone**. An operator who has completed only the bootstrap (access keys set, OIDC role not yet migrated per `BOOTSTRAP-ONE-TIME.md` steps 4–5) therefore passes preflight, builds the ARM64 binary, then **dies at "Configure AWS credentials" with an empty `role-to-assume`** → red ✗ on every push.

The working `seed-staging-ssm.yml` already accepts **either** OIDC role **or** access keys. This makes `deploy-aws.yml` do the same.

## Changes
- **Credential step:** add `aws-access-key-id` / `aws-secret-access-key` fallback alongside `role-to-assume` (mirrors seed workflow). Deploy now works the moment the box exists, not only after the OIDC migration.
- **Region hardening:** default all 13 `${{ vars.AWS_REGION }}` sites to `${{ vars.AWS_REGION || 'ap-south-1' }}` so an unset repo *Variable* can't blank the `--region` flag.

## Items completed
- [x] deploy-aws credential step accepts keys OR OIDC
- [x] every `vars.AWS_REGION` has an `ap-south-1` fallback (13 sites)

## Test plan
- [x] `python3 yaml.safe_load` — valid; jobs `preflight/build/guard_market_hours/deploy` intact
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` — **23/23 pass** (asserts `configure-aws-credentials` + `role-to-assume` present — both retained)
- [x] 0 bare `vars.AWS_REGION }}` remaining

## Honest envelope
100% inside the tested envelope: this removes the **first** failure (credentials). The deploy still requires the S3 cold bucket, `EC2_INSTANCE_ID`, and `AWS_ACCOUNT_ID` secrets created by `terraform-apply.yml`; if any later step fails, the run logs will name it and it is a follow-up fix. No silent failure — the deploy job publishes a Telegram message on success **and** failure.

## Note on no-downtime / market-hours auto-deploy
The deploy **never stops the instance** — it swaps the app binary and restarts only the app process (~5s). The `guard_market_hours` job intentionally **blocks** deploys during 09:15–15:30 IST Mon–Fri so that ~5s app restart never lands mid-session. That's the safe single-instance design; true zero-downtime mid-market would need a second (blue/green) instance.

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_