### PR TITLE
feat(aws): auto-deploy ONLY in pre-market (08:45 IST) + post-market (15:31 IST) windows

### DIFF
--- a/.github/workflows/deploy-aws-after-close.yml
+++ b/.github/workflows/deploy-aws-after-close.yml
@@ -1,34 +1,40 @@
 # =============================================================================
-# tickvault — auto-deploy after market close (Option B, zero-touch)
+# tickvault — auto-deploy in pre-market + post-market windows ONLY
 # =============================================================================
-# Goal: if a commit merged to main during market hours (09:15–15:30 IST Mon–Fri),
-# the deploy-aws.yml `guard_market_hours` job blocks it. This workflow re-fires
-# deploy-aws.yml at 15:31 IST (10:01 UTC) every weekday so the merge lands
-# automatically the moment the market closes — with ZERO downtime during the
-# trading session (the 5s app restart only ever happens after-hours).
+# Operator lock 2026-05-30: "only pre-market AND post-market alone only our
+# new codes merged ones should be deployed". Code-merge-driven deploys NEVER
+# fire during 09:15-15:30 IST trading hours via the auto path. (Instance
+# start/stop/restart remain on-demand via the AWS Console — separate concern.)
+#
+# Two crons, both Mon–Fri:
+#   • 03:15 UTC = 08:45 IST → PRE-MARKET window. Instance auto-starts at
+#     08:30 IST; this fires 15 minutes later, well before 09:15 market open.
+#   • 10:01 UTC = 15:31 IST → POST-MARKET window. ~1 minute after NSE close.
 #
 # Idempotent: before dispatching, we compare main's current HEAD against the
 # `head_sha` of the most recent SUCCESSFUL deploy-aws run on main. If equal,
 # nothing to deploy — exit clean (no spurious restart on quiet days).
 #
 # Triggers:
-#   - schedule: 10:01 UTC Mon–Fri (15:31 IST, ~1 minute after NSE close)
+#   - schedule: 03:15 + 10:01 UTC Mon–Fri
 #   - workflow_dispatch: manual operator override (just-in-case button)
 #
 # Honest envelope:
-#   - 09:15-15:30 IST blocked → 15:31 IST same-day deploy ✅
-#   - Weekend merge → Monday 15:31 IST deploy ✅
-#   - NSE holiday → next weekday 15:31 IST (holiday calendar TODO; today we
-#     re-dispatch every weekday — deploy-aws's own guard is a no-op outside
-#     market hours, so it just runs harmlessly on holiday afternoons)
-#   - No new commits → idempotent skip (no restart, no extra cost)
+#   - Merge during 09:15-15:30 IST → blocked → auto-fires at 15:31 IST same day ✅
+#   - Merge over the weekend → auto-fires Monday 08:45 IST (pre-market) ✅
+#   - Merge before 08:45 IST on a weekday → auto-fires same day 08:45 IST ✅
+#   - NSE holiday: cron fires; deploy-aws's own market-hours guard is a no-op
+#     outside trading hours, so the deploy runs harmlessly on holiday windows.
+#   - No new commits → idempotent skip (no restart, no extra cost).
 # =============================================================================
 
 name: deploy-aws-after-close
 
 on:
   schedule:
-    # 10:01 UTC = 15:31 IST. Mon–Fri only.
+    # 03:15 UTC = 08:45 IST (pre-market). 10:01 UTC = 15:31 IST (post-market).
+    # Mon–Fri only.
+    - cron: '15 3 * * 1-5'
     - cron: '1 10 * * 1-5'
   workflow_dispatch: {}
 

--- a/.github/workflows/deploy-aws-after-close.yml
+++ b/.github/workflows/deploy-aws-after-close.yml
@@ -1,0 +1,99 @@
+# =============================================================================
+# tickvault — auto-deploy after market close (Option B, zero-touch)
+# =============================================================================
+# Goal: if a commit merged to main during market hours (09:15–15:30 IST Mon–Fri),
+# the deploy-aws.yml `guard_market_hours` job blocks it. This workflow re-fires
+# deploy-aws.yml at 15:31 IST (10:01 UTC) every weekday so the merge lands
+# automatically the moment the market closes — with ZERO downtime during the
+# trading session (the 5s app restart only ever happens after-hours).
+#
+# Idempotent: before dispatching, we compare main's current HEAD against the
+# `head_sha` of the most recent SUCCESSFUL deploy-aws run on main. If equal,
+# nothing to deploy — exit clean (no spurious restart on quiet days).
+#
+# Triggers:
+#   - schedule: 10:01 UTC Mon–Fri (15:31 IST, ~1 minute after NSE close)
+#   - workflow_dispatch: manual operator override (just-in-case button)
+#
+# Honest envelope:
+#   - 09:15-15:30 IST blocked → 15:31 IST same-day deploy ✅
+#   - Weekend merge → Monday 15:31 IST deploy ✅
+#   - NSE holiday → next weekday 15:31 IST (holiday calendar TODO; today we
+#     re-dispatch every weekday — deploy-aws's own guard is a no-op outside
+#     market hours, so it just runs harmlessly on holiday afternoons)
+#   - No new commits → idempotent skip (no restart, no extra cost)
+# =============================================================================
+
+name: deploy-aws-after-close
+
+on:
+  schedule:
+    # 10:01 UTC = 15:31 IST. Mon–Fri only.
+    - cron: '1 10 * * 1-5'
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-aws-after-close
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write   # required to dispatch deploy-aws.yml
+
+jobs:
+  retry-if-needed:
+    name: Re-fire deploy-aws if main has an undeployed commit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout (for git rev-parse)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+          ref: main
+
+      - name: Compare main HEAD vs last successful deploy
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          MAIN_SHA=$(git rev-parse HEAD)
+          echo "main HEAD = $MAIN_SHA"
+
+          # Pull the most recent SUCCESSFUL deploy-aws run on main.
+          # If there is none yet (fresh repo), we treat it as "deploy needed".
+          LAST_DEPLOYED=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/deploy-aws.yml/runs?branch=main&status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // ""')
+          echo "last successful deploy sha = ${LAST_DEPLOYED:-<none>}"
+
+          if [ -z "$LAST_DEPLOYED" ]; then
+            echo "No prior successful deploy on record — dispatching first deploy."
+            echo "dispatch=true" >> "$GITHUB_OUTPUT"
+          elif [ "$MAIN_SHA" != "$LAST_DEPLOYED" ]; then
+            echo "main has moved since last successful deploy — dispatching."
+            echo "dispatch=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "main is already deployed — nothing to do."
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch deploy-aws.yml on main
+        if: steps.check.outputs.dispatch == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy-aws.yml --ref main
+          echo "::notice::deploy-aws dispatched on main — watch Actions tab"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Auto-deploy after market close"
+            echo ""
+            if [ "${{ steps.check.outputs.dispatch }}" = "true" ]; then
+              echo "✅ Dispatched \`deploy-aws.yml\` on \`main\` — operator sees green/red on the deploy-aws run."
+            else
+              echo "ℹ️  \`main\` is already deployed — no action taken (idempotent)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -435,24 +435,29 @@ fn test_deploy_aws_workflow_uses_oidc() {
 }
 
 #[test]
-fn test_deploy_aws_after_close_workflow_exists_and_fires_at_1531_ist() {
-    // Option B (operator lock 2026-05-30): if a merge to main lands during
-    // market hours (09:15-15:30 IST Mon-Fri), guard_market_hours blocks the
-    // deploy. This auto-retry workflow re-fires deploy-aws.yml at 15:31 IST
-    // every weekday so the blocked deploy lands the moment the market closes
-    // — true zero-downtime-during-market without the cost of blue/green.
+fn test_deploy_aws_after_close_workflow_fires_in_premarket_and_postmarket_only() {
+    // Operator lock 2026-05-30: "only pre-market AND post-market alone only
+    // our new codes merged ones should be deployed". Code-merge-driven
+    // deploys NEVER auto-fire during 09:15-15:30 IST trading hours.
+    //   - pre-market cron  = 03:15 UTC = 08:45 IST (after 08:30 instance boot)
+    //   - post-market cron = 10:01 UTC = 15:31 IST (after 15:30 NSE close)
     let path = ".github/workflows/deploy-aws-after-close.yml";
     require_file_exists(
         path,
-        "auto-deploy-after-market-close workflow (Option B, zero-touch)",
+        "auto-deploy in pre-market + post-market windows (operator lock 2026-05-30)",
     );
     let content = std::fs::read_to_string(workspace_root().join(path))
         .expect("deploy-aws-after-close.yml must be readable"); // APPROVED: test
 
-    // 15:31 IST = 10:01 UTC. Mon-Fri only (cron day-of-week = 1-5).
+    assert!(
+        content.contains("15 3 * * 1-5"),
+        "deploy-aws-after-close.yml must include pre-market cron \
+         03:15 UTC Mon-Fri (08:45 IST)"
+    );
     assert!(
         content.contains("1 10 * * 1-5"),
-        "deploy-aws-after-close.yml cron must be 10:01 UTC Mon-Fri (15:31 IST)"
+        "deploy-aws-after-close.yml must include post-market cron \
+         10:01 UTC Mon-Fri (15:31 IST)"
     );
     // Must dispatch deploy-aws.yml — that's the whole point.
     assert!(

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -435,6 +435,45 @@ fn test_deploy_aws_workflow_uses_oidc() {
 }
 
 #[test]
+fn test_deploy_aws_after_close_workflow_exists_and_fires_at_1531_ist() {
+    // Option B (operator lock 2026-05-30): if a merge to main lands during
+    // market hours (09:15-15:30 IST Mon-Fri), guard_market_hours blocks the
+    // deploy. This auto-retry workflow re-fires deploy-aws.yml at 15:31 IST
+    // every weekday so the blocked deploy lands the moment the market closes
+    // — true zero-downtime-during-market without the cost of blue/green.
+    let path = ".github/workflows/deploy-aws-after-close.yml";
+    require_file_exists(
+        path,
+        "auto-deploy-after-market-close workflow (Option B, zero-touch)",
+    );
+    let content = std::fs::read_to_string(workspace_root().join(path))
+        .expect("deploy-aws-after-close.yml must be readable"); // APPROVED: test
+
+    // 15:31 IST = 10:01 UTC. Mon-Fri only (cron day-of-week = 1-5).
+    assert!(
+        content.contains("1 10 * * 1-5"),
+        "deploy-aws-after-close.yml cron must be 10:01 UTC Mon-Fri (15:31 IST)"
+    );
+    // Must dispatch deploy-aws.yml — that's the whole point.
+    assert!(
+        content.contains("gh workflow run deploy-aws.yml"),
+        "deploy-aws-after-close.yml must dispatch deploy-aws.yml via gh CLI"
+    );
+    // Idempotency: must compare main HEAD against last successful deploy SHA
+    // so quiet days don't trigger a spurious 5s app restart.
+    assert!(
+        content.contains("head_sha"),
+        "deploy-aws-after-close.yml must compare against last successful \
+         deploy head_sha (idempotency — no spurious restart on quiet days)"
+    );
+    // Required permission to dispatch another workflow.
+    assert!(
+        content.contains("actions: write"),
+        "deploy-aws-after-close.yml must request actions:write to dispatch deploy-aws.yml"
+    );
+}
+
+#[test]
 fn test_dep_freshness_workflow_cron_schedule() {
     let content = std::fs::read_to_string(
         workspace_root().join(".github/workflows/dep-freshness-nightly.yml"),


### PR DESCRIPTION
## Summary

**Operator lock 2026-05-30** — verbatim:
> "only pre-market AND post-market alone only our new codes merged ones should be deployed dude okay meanwhile whenever we need we should start or stop or restart the instance dude okay?"

This adds **strictly auto-deploy in two windows, never during 09:15–15:30 IST market hours**:

| Cron (UTC) | IST | Window | Why |
|---|---|---|---|
| `15 3 * * 1-5` | **08:45 IST** | pre-market | Box auto-starts at 08:30 IST → deploy 15 min later → ready well before 09:15 NSE open |
| `1 10 * * 1-5` | **15:31 IST** | post-market | ~1 min after NSE close → safest no-tick window |

Instance **start/stop/restart remain on-demand via AWS Console** (separate concern, unchanged).

## How it works (mechanically)

1. Cron fires at 08:45 or 15:31 IST.
2. Reads `main` HEAD.
3. Reads `head_sha` of the most recent **successful** `deploy-aws` run on `main` via `gh api`.
4. If different → `gh workflow run deploy-aws.yml --ref main` (kicks off the real deploy with all its safety gates).
5. If same → exits clean (no spurious restart, no cost).

The dispatched `deploy-aws.yml` still goes through `preflight → build → guard_market_hours → deploy → 60s health monitor → rollback on failure` — nothing about its safety changes.

## Coverage table

| Scenario | Behaviour |
|---|---|
| Merge during 09:15–15:30 IST | Blocked by guard, auto-deploys at **15:31 IST same day** |
| Merge over weekend | Auto-deploys **Monday 08:45 IST** (pre-market) |
| Merge before 08:45 IST on a weekday | Auto-deploys **same day 08:45 IST** |
| Merge between 15:31 IST and midnight | Auto-deploys **next weekday 08:45 IST** (pre-market) |
| NSE holiday | Cron fires; `guard_market_hours` is a no-op outside trading hours, deploy lands harmlessly |
| No new commits | Idempotent skip, zero restart |

## Items completed
- [x] New workflow `.github/workflows/deploy-aws-after-close.yml`
- [x] Two crons: 03:15 UTC + 10:01 UTC, Mon–Fri
- [x] Idempotency: SHA comparison vs last successful deploy
- [x] Guard test pins both crons + dispatch command + idempotency + permission

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` — **24/24 pass** (added 1, previously 23)
- [x] `python3 yaml.safe_load` — valid, triggers = `[schedule, workflow_dispatch]`, crons = `['15 3 * * 1-5', '1 10 * * 1-5']`
- [x] No banned patterns; no secret echo; no instance start/stop/restart from this workflow

## Honest envelope
100% inside the tested envelope: the cron schedule + idempotency check + dispatch flow are all source-pinned by the guard test. Beyond the envelope: NSE holiday calendar awareness is NOT yet wired (cron still fires on Republic Day etc.) — but `deploy-aws`'s own market-hours guard is a no-op outside trading hours, so the worst that happens is a harmless dispatch on a holiday afternoon. No silent failure modes — `deploy-aws` publishes Telegram on success and failure.

## What this does NOT do
- ❌ Does not deploy during 09:15–15:30 IST (operator-locked out)
- ❌ Does not touch instance start/stop/restart (AWS Console only)
- ❌ Does not remove the existing operator emergency override (`workflow_dispatch with confirm_market_hours=yes`) — that path is still available if you ever truly need it, but it is OFF the auto path

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_