### PR TITLE
fix(aws): SSM-manage the EC2 instance + derive account id at runtime (unblocks deploy)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -20,9 +20,11 @@
 #   4. Existing rollback path triggers on failed smoke test.
 #
 # Secrets required (GitHub repo > Settings > Secrets and variables > Actions):
-#   AWS_ROLE_ARN                — OIDC role assumed by the workflow
-#   AWS_ACCOUNT_ID              — used in the role ARN template
+#   AWS_ROLE_ARN                — OIDC role assumed by the workflow (optional if
+#                                 access keys are set; preflight accepts either)
 #   EC2_INSTANCE_ID             — the tv-prod-app instance ID from tf output
+#   (AWS_ACCOUNT_ID is NO LONGER required — derived at runtime via
+#    `aws sts get-caller-identity`, see the "Resolve AWS account id" step.)
 #
 # Variables (repo > Settings > Secrets and variables > Variables):
 #   AWS_REGION                  — ap-south-1
@@ -231,6 +233,16 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'ap-south-1' }}
           role-session-name: tv-github-deploy-${{ github.run_id }}
 
+      - name: Resolve AWS account id at runtime
+        # Derive the account id from the live credentials instead of relying on
+        # the AWS_ACCOUNT_ID GitHub secret (which was empty -> SNS publish failed
+        # with `Invalid parameter: AccountId` in deploy-aws run #98). This removes
+        # a manual-setup dependency entirely: the SNS topic ARN for the Telegram
+        # notify steps is built from this value. Runs early (right after creds)
+        # so its output is available to the `if: failure()` notify step too.
+        id: acct
+        run: echo "id=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_OUTPUT"
+
       - name: Upload both binaries to S3 staging bucket
         run: |
           chmod +x ./dist/tickvault ./dist/smoke_test
@@ -350,7 +362,7 @@ jobs:
           # an INFO-level message so the operator sees the deploy land.
           aws sns publish \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
-            --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ secrets.AWS_ACCOUNT_ID }}:tv-prod-alerts \
+            --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ steps.acct.outputs.id }}:tv-prod-alerts \
             --subject "DLT deploy OK" \
             --message "commit=${{ github.sha }} ref=${{ github.ref }} actor=${{ github.actor }}"
 
@@ -359,6 +371,6 @@ jobs:
         run: |
           aws sns publish \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
-            --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ secrets.AWS_ACCOUNT_ID }}:tv-prod-alerts \
+            --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ steps.acct.outputs.id }}:tv-prod-alerts \
             --subject "DLT deploy FAILED" \
             --message "commit=${{ github.sha }} ref=${{ github.ref }} actor=${{ github.actor }} run=${{ github.run_id }}"

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -308,6 +308,49 @@ fn test_aws_control_workflow_covers_all_operations() {
 }
 
 #[test]
+fn test_terraform_instance_role_has_ssm_managed_core() {
+    // Regression 2026-05-30 (deploy-aws run #98): `aws ssm send-command` failed
+    // with `InvalidInstanceId: Instances not in a valid state for account`. The
+    // EC2 instance role had inline ssm:GetParameter perms (for the app to read
+    // secrets) but NOT AmazonSSMManagedInstanceCore, so the SSM *agent* could
+    // not register the box as a managed instance. The deploy pushes the binary
+    // via SSM, so this attachment is mandatory. (Session Manager tunnels in
+    // docs/runbooks/aws-access-from-anywhere.md also depend on it.)
+    let content = std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/main.tf"))
+        .expect("main.tf must be readable"); // APPROVED: test
+    assert!(
+        content.contains("AmazonSSMManagedInstanceCore"),
+        "main.tf must attach AmazonSSMManagedInstanceCore to the EC2 instance \
+         role — required for `aws ssm send-command` (the deploy mechanism) to \
+         reach the box; without it send-command fails InvalidInstanceId."
+    );
+}
+
+#[test]
+fn test_deploy_aws_resolves_account_id_at_runtime() {
+    // Regression 2026-05-30 (deploy-aws run #98): the Telegram-notify steps used
+    // ${{ secrets.AWS_ACCOUNT_ID }} which was empty -> SNS publish failed with
+    // `Invalid parameter: AccountId`. The account id is now derived at runtime
+    // via `aws sts get-caller-identity`, removing the manual-secret dependency.
+    let content =
+        std::fs::read_to_string(workspace_root().join(".github/workflows/deploy-aws.yml"))
+            .expect("deploy-aws.yml must be readable"); // APPROVED: test
+    assert!(
+        content.contains("aws sts get-caller-identity --query Account"),
+        "deploy-aws.yml must derive the AWS account id at runtime"
+    );
+    assert!(
+        content.contains("steps.acct.outputs.id"),
+        "deploy-aws.yml SNS topic ARNs must use the runtime-derived account id"
+    );
+    assert!(
+        !content.contains("secrets.AWS_ACCOUNT_ID"),
+        "deploy-aws.yml must NOT reference the empty AWS_ACCOUNT_ID secret \
+         (it caused the SNS `Invalid parameter: AccountId` failure)."
+    );
+}
+
+#[test]
 fn test_terraform_s3_lifecycle_matches_sebi_retention() {
     let content = std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/main.tf"))
         .expect("main.tf must be readable"); // APPROVED: test

--- a/deploy/aws/terraform/dashboard.tf
+++ b/deploy/aws/terraform/dashboard.tf
@@ -96,11 +96,11 @@ resource "aws_cloudwatch_dashboard" "operator" {
         width  = 8
         height = 6
         properties = {
-          title  = "Candle seals emitted (data flowing during market hours)"
-          region = local.dash_region
-          view   = "timeSeries"
+          title   = "Candle seals emitted (data flowing during market hours)"
+          region  = local.dash_region
+          view    = "timeSeries"
           metrics = [[local.dash_namespace, "tv_aggregator_seals_emitted_total", { stat = "Sum" }]]
-          period = 300
+          period  = 300
         }
       },
       {
@@ -110,12 +110,12 @@ resource "aws_cloudwatch_dashboard" "operator" {
         width  = 8
         height = 6
         properties = {
-          title  = "Instruments silent (tick-gap — 0 = all streaming)"
-          region = local.dash_region
-          view   = "timeSeries"
+          title   = "Instruments silent (tick-gap — 0 = all streaming)"
+          region  = local.dash_region
+          view    = "timeSeries"
           metrics = [[local.dash_namespace, "tv_tick_gap_instruments_silent"]]
-          period = 60
-          stat   = "Maximum"
+          period  = 60
+          stat    = "Maximum"
         }
       },
       {
@@ -146,11 +146,11 @@ resource "aws_cloudwatch_dashboard" "operator" {
         width  = 8
         height = 6
         properties = {
-          title  = "Tick spill dropped (0 = no loss)"
-          region = local.dash_region
-          view   = "timeSeries"
+          title   = "Tick spill dropped (0 = no loss)"
+          region  = local.dash_region
+          view    = "timeSeries"
           metrics = [[local.dash_namespace, "tv_spill_dropped_total", { stat = "Sum" }]]
-          period = 300
+          period  = 300
         }
       },
       {
@@ -160,11 +160,11 @@ resource "aws_cloudwatch_dashboard" "operator" {
         width  = 8
         height = 6
         properties = {
-          title  = "DLQ ticks (recoverable overflow — 0 = none)"
-          region = local.dash_region
-          view   = "timeSeries"
+          title   = "DLQ ticks (recoverable overflow — 0 = none)"
+          region  = local.dash_region
+          view    = "timeSeries"
           metrics = [[local.dash_namespace, "tv_dlq_ticks_total", { stat = "Sum" }]]
-          period = 300
+          period  = 300
         }
       },
       {
@@ -174,12 +174,12 @@ resource "aws_cloudwatch_dashboard" "operator" {
         width  = 8
         height = 6
         properties = {
-          title  = "Clock skew (seconds vs trusted source)"
-          region = local.dash_region
-          view   = "timeSeries"
+          title   = "Clock skew (seconds vs trusted source)"
+          region  = local.dash_region
+          view    = "timeSeries"
           metrics = [[local.dash_namespace, "tv_clock_skew_seconds"]]
-          period = 60
-          stat   = "Maximum"
+          period  = 60
+          stat    = "Maximum"
         }
       },
 
@@ -191,12 +191,12 @@ resource "aws_cloudwatch_dashboard" "operator" {
         width  = 12
         height = 6
         properties = {
-          title  = "EC2 CPU utilization (%)"
-          region = local.dash_region
-          view   = "timeSeries"
+          title   = "EC2 CPU utilization (%)"
+          region  = local.dash_region
+          view    = "timeSeries"
           metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.tv_app.id]]
-          period = 60
-          stat   = "Average"
+          period  = 60
+          stat    = "Average"
         }
       },
       {
@@ -206,11 +206,11 @@ resource "aws_cloudwatch_dashboard" "operator" {
         width  = 12
         height = 6
         properties = {
-          title  = "Root disk used (%)"
-          region = local.dash_region
-          view   = "timeSeries"
+          title   = "Root disk used (%)"
+          region  = local.dash_region
+          view    = "timeSeries"
           metrics = [[{ expression = "SELECT MAX(disk_used_percent) FROM \"CWAgent\" WHERE InstanceId = '${aws_instance.tv_app.id}' AND path = '/'", label = "disk used %", id = "diskpct" }]]
-          period = 300
+          period  = 300
         }
       },
 

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -223,6 +223,22 @@ resource "aws_iam_instance_profile" "tv_instance" {
   role = aws_iam_role.tv_instance.name
 }
 
+# SSM Managed-Instance Core — REQUIRED for the deploy-aws.yml workflow to run
+# `aws ssm send-command` against this box (download binary -> smoke test ->
+# atomic swap -> restart). The inline policy above grants ssm:GetParameter etc.
+# for the APP to read its secrets, but the SSM *agent* needs a separate set of
+# permissions (ssm:UpdateInstanceInformation, ssmmessages:*, ec2messages:*) to
+# register the instance as a "managed instance". Without this attachment,
+# send-command fails with `InvalidInstanceId: Instances not in a valid state
+# for account` (observed in deploy-aws run #98, 2026-05-30). This AWS-managed
+# policy is the standard, least-privilege way to enable SSM management +
+# Session Manager (the operator's tunnel access in
+# docs/runbooks/aws-access-from-anywhere.md also depends on it).
+resource "aws_iam_role_policy_attachment" "tv_instance_ssm_core" {
+  role       = aws_iam_role.tv_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 # ---------------------------------------------------------------------------
 # EC2 instance + EIP
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Deploy run **#98** got all the way to the box and failed at the **SSM step** (and the Telegram-notify step). Two root causes, two code fixes — **no manual setup**.

```
Run SSM command: (InvalidInstanceId) ... Instances not in a valid state for account
Notify Telegram on failure: (InvalidParameter) ... Invalid parameter: AccountId
```

### Fix 1 — attach `AmazonSSMManagedInstanceCore` to the instance role (Terraform)

The instance role had inline `ssm:GetParameter`/`PutParameter` (so the **app** reads its secrets) but **not** the policy that lets the **SSM agent** register the box as a managed instance (`ssm:UpdateInstanceInformation`, `ssmmessages:*`, `ec2messages:*`). Without it, `aws ssm send-command` → `InvalidInstanceId`.

Network path was verified already-correct (public subnet, `map_public_ip_on_launch=true`, IGW route, egress `0.0.0.0/0`) — the **only** missing piece was this IAM attachment. It also powers the operator's Session Manager tunnels (`docs/runbooks/aws-access-from-anywhere.md`).

### Fix 2 — derive AWS account id at runtime (workflow)

`${{ secrets.AWS_ACCOUNT_ID }}` was empty → SNS topic ARN malformed → `Invalid parameter: AccountId`. New step resolves it via `aws sts get-caller-identity --query Account` and builds the ARN from `steps.acct.outputs.id`. Removes the manual-secret dependency; `AWS_ACCOUNT_ID` is no longer required.

## Items completed
- [x] `main.tf`: `aws_iam_role_policy_attachment.tv_instance_ssm_core` → `AmazonSSMManagedInstanceCore`
- [x] `deploy-aws.yml`: runtime account-id resolution; both SNS ARNs use it; header comment updated
- [x] 2 guard tests (`test_terraform_instance_role_has_ssm_managed_core`, `test_deploy_aws_resolves_account_id_at_runtime`)

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` — **27/27 pass** (+2)
- [x] `python3 yaml.safe_load` deploy-aws.yml — valid
- [x] `secrets.AWS_ACCOUNT_ID` fully removed; `steps.acct.outputs.id` used in both ARNs

## ⚠️ Operator action after this merges
1. Merging auto-fires `terraform-apply` (touches `deploy/aws/terraform/**`) — applies the IAM policy.
2. **Reboot the instance** from AWS Console (EC2 → `tv-prod-app` → Instance state → **Reboot**) so the SSM agent re-registers immediately with the new permission.
3. Re-run / let auto-deploy fire — the SSM step now succeeds.

## Honest envelope
Removes the SSM-registration + account-id blockers. If a later step (smoke-test boot, systemd restart, 60s health monitor) fails, the run logs name it — that's the next (and likely final) layer: the app actually booting on the box with its staging secrets.

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_