### PR TITLE
fix(aws): terraform-apply re-plans so Lambda archive_file zips exist (fixes apply on main)

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -268,8 +268,18 @@ jobs:
             -backend-config="dynamodb_table=tv-terraform-locks" \
             -backend-config="encrypt=true"
 
-      - name: terraform apply tfplan
-        run: terraform -chdir=${{ env.TF_DIR }} apply -auto-approve -no-color tfplan
+      - name: terraform apply
+        # Re-plan + apply on THIS runner instead of applying the saved tfplan.
+        # WHY: the Lambda resources use `data "archive_file"` which builds the
+        # .zip on whichever runner evaluates it. The plan job built the zips on
+        # the PLAN runner and uploaded only `tfplan` (not the zips), so
+        # `apply tfplan` on this separate runner failed with
+        # `reading ZIP file (./.budget-killswitch.zip): no such file or
+        # directory` (terraform-apply #40/#43/#46). Re-evaluating here rebuilds
+        # the zips locally. archive_file is deterministic, and apply only runs
+        # after the plan job already passed + the market-hours guard, so a
+        # same-commit re-plan is safe and idempotent.
+        run: terraform -chdir=${{ env.TF_DIR }} apply -auto-approve -no-color
 
       - name: Capture outputs
         id: outputs

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -308,6 +308,30 @@ fn test_aws_control_workflow_covers_all_operations() {
 }
 
 #[test]
+fn test_terraform_apply_replans_so_archive_file_zips_exist() {
+    // Regression 2026-05-30 (terraform-apply #40/#43/#46): apply ran on a
+    // SEPARATE runner from plan and only downloaded `tfplan`, so the Lambda
+    // `data "archive_file"` .zip files built during plan were missing ->
+    // `reading ZIP file (./.budget-killswitch.zip): no such file or directory`.
+    // The fix re-plans on the apply runner (`apply -auto-approve` WITHOUT the
+    // saved tfplan) so archive_file rebuilds the zips locally. Guard pins that
+    // the apply step no longer applies the saved plan file.
+    let content =
+        std::fs::read_to_string(workspace_root().join(".github/workflows/terraform-apply.yml"))
+            .expect("terraform-apply.yml must be readable"); // APPROVED: test
+    assert!(
+        !content.contains("apply -auto-approve -no-color tfplan"),
+        "terraform-apply.yml must NOT apply the saved tfplan — the apply runner \
+         lacks the archive_file .zip outputs built on the plan runner. Re-plan \
+         on the apply runner instead."
+    );
+    assert!(
+        content.contains("apply -auto-approve -no-color"),
+        "terraform-apply.yml must still run terraform apply -auto-approve"
+    );
+}
+
+#[test]
 fn test_terraform_instance_role_has_ssm_managed_core() {
     // Regression 2026-05-30 (deploy-aws run #98): `aws ssm send-command` failed
     // with `InvalidInstanceId: Instances not in a valid state for account`. The


### PR DESCRIPTION
## Summary

`terraform-apply` on `main` has been **red on every push** (#40 / #43 / #46) at the apply step:

```
Error: reading ZIP file (./.budget-killswitch.zip): no such file or directory
Error: reading ZIP file (./.telegram-webhook.zip): no such file or directory
```

### Root cause
The `budget-killswitch` + `telegram-webhook` Lambdas use `data "archive_file"` (`source_dir = ../lambda/<name>`, `output_path = ${path.module}/.<name>.zip`). `archive_file` builds the `.zip` **on whichever runner evaluates it**. The **plan** job built the zips on the *plan* runner and uploaded only `tfplan` (not the zips). The **apply** job runs on a **separate runner**, downloads `tfplan`, and `apply tfplan` can't find the zips → exit 1. Resources without local files (IAM, dashboard, SSM attachment) applied fine — which is why **#910's SSM permission DID land** (apply #46 log line 20: *"Creation complete"*).

### Fix
Apply step now runs `terraform apply -auto-approve` (re-plan on the apply runner) instead of applying the saved `tfplan`, so `archive_file` rebuilds the zips locally before upload. `archive_file` is deterministic, and apply only runs **after** the plan job passed + the market-hours guard → same-commit re-plan is safe + idempotent.

### Effect once merged + applied
- ✅ `budget-killswitch` Lambda deploys → cost-overrun auto-stop works
- ✅ `telegram-webhook` Lambda deploys → SNS→Telegram alerts work
- ✅ terraform-apply on `main` goes **green** → all future infra changes apply

## Items completed
- [x] `terraform-apply.yml`: apply step drops the saved `tfplan` (re-plans locally)
- [x] Guard test `test_terraform_apply_replans_so_archive_file_zips_exist`

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` — **28/28 pass** (+1)
- [x] `python3 yaml.safe_load` terraform-apply.yml — valid; `apply ... tfplan` refs = 0

## Honest envelope
Fixes the apply-runner zip problem. The two Lambdas then deploy on the next apply. **Separate from the app deploy** — #910 already applied the SSM permission, so after an instance reboot the `deploy-aws` SSM step succeeds independent of this PR.

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_