### PR TITLE
fix(aws): telegram-webhook Lambda reads staging SSM path (fixes ParameterNotFound)

### DIFF
--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -92,15 +92,15 @@ variable "operator_cidr" {
 }
 
 variable "telegram_bot_token_ssm_param" {
-  description = "SSM parameter name where the Telegram bot token is stored."
+  description = "SSM parameter name where the Telegram bot token is stored. Defaults to the STAGING path because the app runs TV_ENVIRONMENT=staging during the 3-month no-orders data-pull, and the seed populates /tickvault/staging/* (the /tickvault/prod/* path does not exist yet -> ParameterNotFound in the webhook Lambda, 2026-05-30). Flip to /tickvault/prod/telegram/bot-token when going live (TV_ENVIRONMENT=prod)."
   type        = string
-  default     = "/tickvault/prod/telegram/bot-token"
+  default     = "/tickvault/staging/telegram/bot-token"
 }
 
 variable "telegram_chat_id_ssm_param" {
-  description = "SSM parameter name where the Telegram chat ID (numeric) is stored."
+  description = "SSM parameter name where the Telegram chat ID (numeric) is stored. Defaults to the STAGING path (see telegram_bot_token_ssm_param). Flip to /tickvault/prod/telegram/chat-id when going live."
   type        = string
-  default     = "/tickvault/prod/telegram/chat-id"
+  default     = "/tickvault/staging/telegram/chat-id"
 }
 
 variable "dhan_access_token_ssm_param" {


### PR DESCRIPTION
## Summary

The `tv-prod-telegram-webhook` Lambda errors on **every** invocation (operator's CloudWatch log):

```
[ERROR] ParameterNotFound: GetParameter ... /tickvault/prod/telegram/bot-token
Failed to fetch Telegram credentials from SSM
```

### Root cause
The Lambda's SSM-path variables defaulted to `/tickvault/prod/telegram/*`, but the app runs **`TV_ENVIRONMENT=staging`** during the 3-month no-orders data-pull, and the seed workflow only populates `/tickvault/staging/*` (+ `/tickvault/dev/*`). The `prod` path doesn't exist → `ParameterNotFound` → **all Telegram alerts silently dropped**, including the deploy-aws "DLT deploy OK/FAILED" notifications.

### Fix
Default `telegram_bot_token_ssm_param` + `telegram_chat_id_ssm_param` to the `/tickvault/staging/telegram/*` paths that actually exist. The Lambda's IAM read policy references these vars, so permission follows automatically. Both documented to flip to `/tickvault/prod/*` at go-live (mirrors the systemd `TV_ENVIRONMENT` note).

## Test plan
- [x] `terraform fmt -check -recursive` clean (terraform 1.9.8)
- [x] no `/tickvault/prod/telegram/*` default remains

## Honest envelope
Fixes the Telegram-webhook ParameterNotFound only. **Separate from the SSM managed-node issue** currently blocking the app deploy (that's an instance-registration problem in the AWS console, not a code bug). terraform-apply auto-fires on merge and updates the Lambda env vars.

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_