### PR TITLE
fix(aws): enable Elastic IP — box had no internet path (blocks SSM + Dhan)

### DIFF
--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -58,9 +58,9 @@ variable "ami_id" {
 }
 
 variable "enable_eip" {
-  description = "Provision a 24/7 Elastic IP (static public IP). DEFAULT false per operator lock 2026-05-29 §7 Quote 5: the 3-month data-pull places NO orders, so the Dhan static-IP whitelist is not needed — saving ~₹430/mo. The instance gets a fresh public IP on each stop/start (fine for data-only). Set TRUE before going LIVE with orders (then register the EIP with Dhan; 7-day modify cooldown applies)."
+  description = "Provision a 24/7 Elastic IP (static public IP). FLIPPED TO TRUE 2026-05-31 (operator approved 'Yes — enable it now'). The 2026-05-29 §7 Quote 5 assumption that 'the instance gets a fresh public IP on each stop/start' proved FALSE: after the manual t4g→m8g.large upgrade (stop/modify/start), the instance's ENI has auto-assign-public-IP OFF (console: 'Auto-assigned IP address: –'), so it had NO public IP and NO internet path at all — it could not reach AWS Systems Manager (Fleet Manager showed 0 managed nodes → deploy `InvalidInstanceId`) NOR Dhan. AWS cannot add an ephemeral public IP to an already-running instance; only an EIP can. So the EIP is now mandatory for the box to function, not optional. Cost ~₹300/mo; needed for live orders anyway (then register this EIP with Dhan; 7-day modify cooldown applies)."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "ebs_gp3_size_gb" {


### PR DESCRIPTION
## Summary

**THE root cause of the stuck deploy.** The EC2 box has **no public IP and no internet path at all** — console confirms `Public IPv4: –`, `Auto-assigned IP address: –`, `Managed: false`. So it can't reach **AWS Systems Manager** (Fleet Manager = 0 nodes → deploy `InvalidInstanceId`) **or Dhan**.

### Why
The 2026-05-29 cost-lock assumed "the instance gets a fresh public IP on each stop/start" and set `enable_eip=false`. **False:** after the manual `t4g.medium → m8g.large` upgrade (stop/modify/start), the instance's ENI has **auto-assign-public-IP OFF**, so start gave it no IP. With no public IP + no NAT + no VPC endpoints, the box is fully offline. AWS **cannot** add an ephemeral public IP to a running instance — **only an Elastic IP** can fix this running box without destroying + recreating it.

### Operator approval
Approved **2026-05-31** ("Yes — enable it now") after the console diagnosis (`Public IPv4 = –` confirmed). Cost **~₹300/mo**; needed for live orders anyway (Dhan static-IP whitelist).

### Change
Flip `enable_eip` default `false → true`. `aws_eip.tv_app` already has `instance = aws_instance.tv_app.id`, so terraform creates **and** associates the EIP in one apply.

## Effect once merged
terraform-apply auto-fires → EIP allocated + associated → box gets a **permanent public IP** → SSM agent registers (becomes a managed node) → **deploy SSM step succeeds → app boots**. The app can also finally reach Dhan.

## Test plan
- [x] `terraform fmt -check -recursive` clean (terraform 1.9.8)
- [x] `enable_eip` default = `true`; EIP resource auto-associates via `instance =`

## Honest envelope
This gives the box internet. **After it merges + applies, you do NOT need to reboot** — associating an EIP attaches a public IP to the running instance immediately; the SSM agent registers within a few minutes. Then re-run deploy. Follow-up: update the cost-lock rule file with the +₹300/mo EIP decision (flagged in commit body).

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_