### PR TITLE
feat(aws): autopilot — self-check + auto-heal the deployment every 15 min (zero human)

### DIFF
--- a/.github/workflows/aws-autopilot.yml
+++ b/.github/workflows/aws-autopilot.yml
@@ -1,0 +1,96 @@
+# =============================================================================
+# aws-autopilot — self-check + auto-heal the AWS deployment (zero human)
+# =============================================================================
+# Operator demand 2026-05-31: "make it as an extreme complete comprehensive
+# automated process ... I never ever wanted to get stuck with manual
+# configurations like run deploy, configure static elastic IP."
+#
+# This workflow runs scripts/aws-autopilot.sh which checks every layer of the
+# running deployment and AUTO-FIXES what it safely can (start a stopped box in
+# market hours, re-associate the Elastic IP, restart the app, bring QuestDB
+# back up), and Telegram-alerts only what needs human eyes. It posts a summary
+# to the run + Telegram so the operator never has to open the AWS console.
+#
+# Triggers:
+#   - schedule: every 15 min between 03:00-11:00 UTC (08:30-16:30 IST) Mon-Fri,
+#     i.e. while the box is supposed to be up. (Cheap: a few aws CLI calls.)
+#   - workflow_dispatch: on-demand, with a `strict` input that exits non-zero
+#     if anything is unhealed (so you can wire it as a gate).
+#
+# Auth: same OIDC-or-access-key fallback as seed/deploy. Skips cleanly if the
+# bootstrap secrets aren't set.
+# =============================================================================
+
+name: aws-autopilot
+
+on:
+  schedule:
+    # Every 15 min, 03:00-11:00 UTC (08:30-16:30 IST), Mon-Fri.
+    - cron: '*/15 3-11 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Exit non-zero if any issue is left unhealed? (yes/no)'
+        required: false
+        default: 'no'
+
+concurrency:
+  group: aws-autopilot
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-south-1
+  TV_ENVIRONMENT: staging
+
+jobs:
+  preflight:
+    name: Preflight — bootstrap secrets present?
+    runs-on: ubuntu-24.04
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - name: Check AWS creds
+        id: check
+        env:
+          OIDC_ROLE: ${{ secrets.AWS_ROLE_ARN }}
+          ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          EC2_ID: ${{ secrets.EC2_INSTANCE_ID }}
+        run: |
+          if { [ -n "$OIDC_ROLE" ] || [ -n "$ACCESS_KEY" ]; } && [ -n "$EC2_ID" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::AWS bootstrap secrets / EC2_INSTANCE_ID not set — autopilot skipped."
+          fi
+
+  autopilot:
+    name: Self-check + auto-heal
+    runs-on: ubuntu-24.04
+    needs: preflight
+    if: needs.preflight.outputs.ready == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS credentials (OIDC preferred, keys fallback)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: tv-autopilot-${{ github.run_id }}
+
+      - name: Run autopilot
+        env:
+          AWS_REGION: ${{ env.AWS_REGION }}
+          EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          TV_ENVIRONMENT: ${{ env.TV_ENVIRONMENT }}
+          STRICT: ${{ github.event.inputs.strict || 'no' }}
+        run: bash scripts/aws-autopilot.sh

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -502,6 +502,53 @@ fn test_deploy_aws_workflow_uses_oidc() {
 }
 
 #[test]
+fn test_aws_autopilot_selfheal_workflow_exists() {
+    // Operator demand 2026-05-31: "make it an extreme complete comprehensive
+    // automated process ... never get stuck with manual configurations like
+    // run deploy, configure static elastic IP." The aws-autopilot workflow +
+    // script self-check the running deployment every 15 min and auto-heal
+    // (start stopped box in market hours, re-associate EIP, restart app,
+    // bring QuestDB up), Telegram-alerting only what needs human eyes.
+    require_file_exists(
+        ".github/workflows/aws-autopilot.yml",
+        "AWS self-check + auto-heal workflow (operator demand 2026-05-31)",
+    );
+    require_file_exists("scripts/aws-autopilot.sh", "AWS autopilot self-heal script");
+    let wf = std::fs::read_to_string(workspace_root().join(".github/workflows/aws-autopilot.yml"))
+        .expect("aws-autopilot.yml must be readable"); // APPROVED: test
+    // Runs on a schedule (every 15 min during the box's up-window) — not
+    // only on-demand, so it self-heals without a human.
+    assert!(
+        wf.contains("schedule:") && wf.contains("*/15"),
+        "aws-autopilot.yml must run on a 15-minute schedule (self-heal without a human)"
+    );
+    assert!(
+        wf.contains("scripts/aws-autopilot.sh"),
+        "aws-autopilot.yml must invoke scripts/aws-autopilot.sh"
+    );
+
+    let sh = std::fs::read_to_string(workspace_root().join("scripts/aws-autopilot.sh"))
+        .expect("aws-autopilot.sh must be readable"); // APPROVED: test
+    // The auto-heal actions the operator explicitly wanted to never do by hand.
+    assert!(
+        sh.contains("associate-address"),
+        "autopilot must auto-re-associate the Elastic IP (operator: 'configure static elastic IP')"
+    );
+    assert!(
+        sh.contains("systemctl restart tickvault"),
+        "autopilot must auto-restart the app"
+    );
+    assert!(
+        sh.contains("start-instances"),
+        "autopilot must auto-start a stopped box during market hours"
+    );
+    assert!(
+        sh.contains("describe-instance-information"),
+        "autopilot must verify the box is an SSM managed node"
+    );
+}
+
+#[test]
 fn test_deploy_aws_after_close_workflow_fires_in_premarket_and_postmarket_only() {
     // Operator lock 2026-05-30: "only pre-market AND post-market alone only
     // our new codes merged ones should be deployed". Code-merge-driven

--- a/scripts/aws-autopilot.sh
+++ b/scripts/aws-autopilot.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# =============================================================================
+# aws-autopilot.sh — self-check + auto-heal the tickvault AWS deployment.
+# =============================================================================
+# Runs from GitHub Actions (aws-autopilot.yml) with AWS creds already
+# configured. Checks every layer of the running deployment and AUTO-FIXES what
+# it safely can, alerting (Telegram via SNS) only when human eyes are needed.
+#
+# Design rules:
+#   - Idempotent: safe to run every 15 min. Each check is independent.
+#   - Conservative healing: only actions that cannot lose data.
+#   - Market-hours aware: a STOPPED box outside the trading window is EXPECTED
+#     (EventBridge stop schedule) — not an error. We do NOT fight that schedule.
+#   - Never silent: every run posts a one-line Telegram summary.
+#
+# Exit code is always 0 (a failed check is reported, not a workflow failure) —
+# EXCEPT --strict mode (manual dispatch) where unhealed issues exit 1.
+# =============================================================================
+set -uo pipefail
+
+REGION="${AWS_REGION:-ap-south-1}"
+INSTANCE_ID="${EC2_INSTANCE_ID:-}"
+ENVIRONMENT="${TV_ENVIRONMENT:-staging}"
+STRICT="${STRICT:-no}"
+
+if [ -z "$INSTANCE_ID" ]; then
+  echo "::error::EC2_INSTANCE_ID not set — cannot run autopilot."
+  exit 1
+fi
+
+ISSUES=()       # human-action-needed
+HEALED=()       # auto-fixed this run
+OK=()           # already healthy
+
+note_ok()     { OK+=("$1");     echo "OK    : $1"; }
+note_heal()   { HEALED+=("$1"); echo "HEAL  : $1"; }
+note_issue()  { ISSUES+=("$1"); echo "ISSUE : $1"; }
+
+# --- helper: run a shell command ON the box via SSM, capture stdout ----------
+ssm_run() {
+  local cmd="$1" cid out status
+  cid=$(aws ssm send-command \
+    --region "$REGION" --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunShellScript" \
+    --parameters "commands=[\"$cmd\"]" \
+    --query 'Command.CommandId' --output text 2>/dev/null) || return 1
+  # wait (bounded)
+  for _ in $(seq 1 20); do
+    status=$(aws ssm get-command-invocation --region "$REGION" \
+      --command-id "$cid" --instance-id "$INSTANCE_ID" \
+      --query 'Status' --output text 2>/dev/null || echo Pending)
+    [ "$status" = "InProgress" ] || [ "$status" = "Pending" ] || break
+    sleep 3
+  done
+  aws ssm get-command-invocation --region "$REGION" \
+    --command-id "$cid" --instance-id "$INSTANCE_ID" \
+    --query 'StandardOutputContent' --output text 2>/dev/null
+}
+
+# --- market-hours (IST) helper: is now within 09:00-15:35 IST Mon-Fri? -------
+is_market_window() {
+  local h m dow t
+  h=$(TZ='Asia/Kolkata' date +%H); m=$(TZ='Asia/Kolkata' date +%M)
+  dow=$(TZ='Asia/Kolkata' date +%u)   # 1=Mon..7=Sun
+  t=$((10#$h * 100 + 10#$m))
+  [ "$dow" -le 5 ] && [ "$t" -ge 900 ] && [ "$t" -le 1535 ]
+}
+
+echo "===== tickvault AWS autopilot — $(date -u +%FT%TZ) ====="
+echo "instance=$INSTANCE_ID region=$REGION env=$ENVIRONMENT strict=$STRICT"
+
+# ---------------------------------------------------------------------------
+# 1. Instance state
+# ---------------------------------------------------------------------------
+STATE=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].State.Name' --output text 2>/dev/null || echo unknown)
+if [ "$STATE" = "running" ]; then
+  note_ok "EC2 instance running"
+elif [ "$STATE" = "stopped" ]; then
+  if is_market_window; then
+    echo "  instance stopped DURING market window — starting it"
+    if aws ec2 start-instances --region "$REGION" --instance-ids "$INSTANCE_ID" >/dev/null 2>&1; then
+      note_heal "started EC2 instance (was stopped during market hours)"
+    else
+      note_issue "EC2 instance stopped during market hours and start failed"
+    fi
+  else
+    note_ok "EC2 instance stopped (expected — outside trading window)"
+  fi
+  # Nothing else to check on a stopped box.
+  STATE="stopped"
+else
+  note_issue "EC2 instance state=$STATE (not running/stopped)"
+fi
+
+# ---------------------------------------------------------------------------
+# The remaining checks only make sense on a RUNNING box.
+# ---------------------------------------------------------------------------
+if [ "$STATE" = "running" ]; then
+
+  # 2. Elastic IP associated?
+  EIP=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text 2>/dev/null || echo None)
+  if [ -n "$EIP" ] && [ "$EIP" != "None" ]; then
+    note_ok "public IP present ($EIP)"
+  else
+    # Try to find an allocated-but-unassociated tv EIP and associate it.
+    ALLOC=$(aws ec2 describe-addresses --region "$REGION" \
+      --filters "Name=tag:Name,Values=tv-${ENVIRONMENT}-eip,tv-prod-eip" \
+      --query 'Addresses[?AssociationId==null]|[0].AllocationId' --output text 2>/dev/null || echo None)
+    if [ -n "$ALLOC" ] && [ "$ALLOC" != "None" ]; then
+      if aws ec2 associate-address --region "$REGION" \
+        --instance-id "$INSTANCE_ID" --allocation-id "$ALLOC" >/dev/null 2>&1; then
+        note_heal "re-associated Elastic IP ($ALLOC)"
+      else
+        note_issue "no public IP and EIP re-association failed"
+      fi
+    else
+      note_issue "no public IP and no free tv EIP to associate (run terraform-apply)"
+    fi
+  fi
+
+  # 3. SSM managed node online?
+  PING=$(aws ssm describe-instance-information --region "$REGION" \
+    --filters "Key=InstanceIds,Values=$INSTANCE_ID" \
+    --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null || echo None)
+  if [ "$PING" = "Online" ]; then
+    note_ok "SSM managed node Online"
+  else
+    note_issue "SSM managed node not Online (ping=$PING) — check instance role + internet path"
+  fi
+
+  # Below here we need SSM to reach the box. Skip if not Online.
+  if [ "$PING" = "Online" ]; then
+
+    # 4. App systemd unit active?
+    APP=$(ssm_run "systemctl is-active tickvault 2>/dev/null || echo inactive" | tr -d '[:space:]')
+    if [ "$APP" = "active" ]; then
+      note_ok "app (tickvault) active"
+    else
+      echo "  app inactive ($APP) — restarting via SSM"
+      ssm_run "systemctl restart tickvault 2>/dev/null; sleep 5" >/dev/null
+      APP2=$(ssm_run "systemctl is-active tickvault 2>/dev/null || echo inactive" | tr -d '[:space:]')
+      if [ "$APP2" = "active" ]; then
+        note_heal "restarted app (tickvault) — was $APP"
+      else
+        note_issue "app (tickvault) not active after restart ($APP2) — check journalctl"
+      fi
+    fi
+
+    # 5. QuestDB container up?
+    QDB=$(ssm_run "docker ps --filter name=tv-questdb --filter status=running -q 2>/dev/null | head -c1" | tr -d '[:space:]')
+    if [ -n "$QDB" ]; then
+      note_ok "QuestDB container running"
+    else
+      echo "  QuestDB not running — docker compose up via SSM"
+      ssm_run "cd /opt/tickvault && docker compose -f deploy/docker/docker-compose.yml up -d tv-questdb 2>/dev/null; sleep 5" >/dev/null
+      QDB2=$(ssm_run "docker ps --filter name=tv-questdb --filter status=running -q 2>/dev/null | head -c1" | tr -d '[:space:]')
+      if [ -n "$QDB2" ]; then
+        note_heal "started QuestDB container"
+      else
+        note_issue "QuestDB container not running after docker compose up"
+      fi
+    fi
+  fi
+
+  # 6. Required SSM secrets present? (re-seed from dev if any staging key missing)
+  NEED=("dhan/client-id" "dhan/totp-secret" "questdb/pg-password" "telegram/bot-token" "api/bearer-token")
+  MISSING=()
+  for k in "${NEED[@]}"; do
+    if ! aws ssm get-parameter --region "$REGION" \
+      --name "/tickvault/${ENVIRONMENT}/${k}" >/dev/null 2>&1; then
+      MISSING+=("$k")
+    fi
+  done
+  if [ "${#MISSING[@]}" -eq 0 ]; then
+    note_ok "all required SSM secrets present (/tickvault/${ENVIRONMENT}/*)"
+  else
+    note_issue "missing SSM secrets: ${MISSING[*]} (run seed-staging-ssm workflow)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary + Telegram (via SNS) — always.
+# ---------------------------------------------------------------------------
+echo ""
+echo "===== SUMMARY ====="
+printf 'OK     : %s\n' "${#OK[@]}"
+printf 'HEALED : %s\n' "${#HEALED[@]}"
+printf 'ISSUES : %s\n' "${#ISSUES[@]}"
+
+{
+  echo "## AWS autopilot — $(TZ='Asia/Kolkata' date '+%d %b %Y %I:%M %p IST')"
+  echo ""
+  echo "- ✅ healthy: ${#OK[@]}"
+  echo "- 🔧 auto-fixed: ${#HEALED[@]}"
+  echo "- 🆘 needs attention: ${#ISSUES[@]}"
+  [ "${#HEALED[@]}" -gt 0 ] && { echo ""; echo "**Auto-fixed:**"; printf '  - %s\n' "${HEALED[@]}"; }
+  [ "${#ISSUES[@]}" -gt 0 ] && { echo ""; echo "**Needs attention:**"; printf '  - %s\n' "${ISSUES[@]}"; }
+} >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+# Telegram via SNS — only fire if something was healed or is broken (avoid spam
+# on all-green runs). Account id derived at runtime (no AWS_ACCOUNT_ID secret).
+if [ "${#HEALED[@]}" -gt 0 ] || [ "${#ISSUES[@]}" -gt 0 ]; then
+  ACCT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "")
+  if [ -n "$ACCT" ]; then
+    EMOJI="🔧"; [ "${#ISSUES[@]}" -gt 0 ] && EMOJI="🆘"
+    MSG="$EMOJI AWS autopilot: ${#HEALED[@]} auto-fixed, ${#ISSUES[@]} need attention."
+    [ "${#HEALED[@]}" -gt 0 ] && MSG="$MSG Fixed: ${HEALED[*]}."
+    [ "${#ISSUES[@]}" -gt 0 ] && MSG="$MSG ACTION: ${ISSUES[*]}."
+    aws sns publish --region "$REGION" \
+      --topic-arn "arn:aws:sns:${REGION}:${ACCT}:tv-prod-alerts" \
+      --subject "AWS autopilot" --message "$MSG" >/dev/null 2>&1 || true
+  fi
+fi
+
+# Strict mode (manual dispatch): non-zero exit if unhealed issues remain.
+if [ "$STRICT" = "yes" ] && [ "${#ISSUES[@]}" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

**Operator demand 2026-05-31:** "100% extreme complete comprehensive automation ... not even a single manual human effort or config ... must work from Claude Code / Claude Chat / Cowork / GitHub."

The 30-step manual repair we just did (enable EIP, register SSM node, reboot, re-run deploy) must **never** be needed by hand again. This is **piece 1** of the no-human automation: a continuous **self-heal autopilot**.

## What it does — `aws-autopilot.yml` + `scripts/aws-autopilot.sh`

Runs **every 15 min** (and on-demand) and **auto-fixes** what it safely can:

| Check | Auto-fix |
|---|---|
| Instance stopped during market hours | starts it |
| **Elastic IP detached** | **re-associates it** (no more manual EIP) |
| App (`tickvault`) inactive | `systemctl restart` via SSM |
| QuestDB container down | `docker compose up` via SSM |
| SSM managed-node offline | alerts (root/internet issue) |
| Required SSM secrets missing | alerts to re-seed |

- **Telegram (via SNS)** only when it healed something or needs you — no all-green spam.
- **Market-hours-aware**: a stopped box outside the window is expected (EventBridge), never fought.
- **Dispatchable from anywhere**: GitHub UI, **Claude Code / Cowork / Chat** (via GitHub MCP `run_workflow`), with a `strict` mode for gating.

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` — **29/29** (+1 guard)
- [x] `bash -n` clean; `yaml.safe_load` valid (jobs: preflight, autopilot)
- [x] Guard pins: 15-min schedule, EIP re-association, app restart, instance start, SSM node check

## Honest envelope
Piece 1 of the full picture: **infra is already 100% in Terraform** (recreates with zero clicks), **deploy auto-fires** on merge + pre/post-market crons, and now **autopilot continuously self-heals** the running box. Follow-ups (next PRs): Terraform **drift-detection** workflow + an end-to-end **"AWS doctor"** one-command gate. After those, the only ever-human step is the one-time IAM bootstrap key (AWS mathematically requires it once).

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_