### PR TITLE
fix(aws): deploy always prints box-side SSM output (reveals on-box failures)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -304,20 +304,47 @@ jobs:
           echo "command_id=$CMD_ID" >> $GITHUB_OUTPUT
 
       - name: Wait for SSM command completion
+        # continue-on-error so the box-side output is ALWAYS fetched + printed
+        # below, even when the on-box script fails (smoke test, git refresh,
+        # systemctl, etc.). Without this the failure reason was hidden — the
+        # "Fetch output" step was skipped on wait-failure (deploy #103).
+        continue-on-error: true
         run: |
           aws ssm wait command-executed \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --command-id ${{ steps.ssm.outputs.command_id }} \
             --instance-id ${{ secrets.EC2_INSTANCE_ID }}
 
-      - name: Fetch SSM command output
+      - name: Fetch SSM command output + fail loudly on box-side error
+        # if: always() — print the box-side STDOUT/STDERR no matter what, so a
+        # failed on-box step (e.g. smoke test) shows its real reason in the log
+        # instead of an opaque "Waiter ... Failed". Then re-fail the job if the
+        # command status was not Success.
+        if: always()
         run: |
+          STATUS=$(aws ssm get-command-invocation \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
+            --command-id ${{ steps.ssm.outputs.command_id }} \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --query 'Status' --output text)
+          echo "===== SSM command status: ${STATUS} ====="
+          echo "----- STDOUT (on-box) -----"
           aws ssm get-command-invocation \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --command-id ${{ steps.ssm.outputs.command_id }} \
             --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
-            --query '[Status,StandardOutputContent,StandardErrorContent]' \
-            --output text
+            --query 'StandardOutputContent' --output text || true
+          echo "----- STDERR (on-box) -----"
+          aws ssm get-command-invocation \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
+            --command-id ${{ steps.ssm.outputs.command_id }} \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --query 'StandardErrorContent' --output text || true
+          if [ "${STATUS}" != "Success" ]; then
+            echo "::error::SSM command on the box failed with status=${STATUS} — see STDOUT/STDERR above for the on-box reason."
+            exit 1
+          fi
+
 
       - name: Monitor first 60 seconds for crashes
         run: |


### PR DESCRIPTION
## Summary

deploy-aws #103 **reached the box and ran** — the `InvalidInstanceId` blocker is **gone** (the Elastic IP fixed SSM connectivity 🎉). But the on-box script returned "Failed" and the run only showed an opaque `Waiter CommandExecuted failed ... matched expected path: "Failed"`. The **real reason was hidden** because "Fetch SSM command output" is skipped when the wait step fails.

## Fix
- `Wait for SSM command completion` → `continue-on-error: true` (don't kill the job before we read the box output).
- `Fetch SSM command output` → `if: always()`; prints **Status + on-box STDOUT + STDERR**, then re-fails with `::error::` if status ≠ Success.

So every on-box failure (smoke test, git refresh, systemctl, QuestDB) now shows its **real reason** in the deploy log instead of an opaque waiter error. Directly serves the operator's auto-debug requirement (2026-05-31).

## Test plan
- [x] `deploy-aws.yml` YAML valid

## Honest envelope
This reveals *why* the on-box step fails — it doesn't change what runs. Next deploy will print the exact box-side error (most likely the smoke test = app boot). Then we fix that root cause.

https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvuA9wqDcf3HSi35brt2ay)_