### PR TITLE
fix(aws): install git on box before self-heal clone

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -271,6 +271,8 @@ jobs:
               "# SELF-HEAL box state before any cd (Z+ defense — idempotent).",
               "# Reconstructs /opt/tickvault layout if user-data.sh.tftpl never completed",
               "# (rebuilt instance / EBS swap / cold restore). No-op when already correct.",
+              "# Ensure git is installed (AL2023 uses dnf; AL2 uses yum — try both).",
+              "command -v git >/dev/null 2>&1 || sudo dnf install -y git || sudo yum install -y git",
               "mkdir -p /opt/tickvault/config /opt/tickvault/data/spill /opt/tickvault/logs /opt/tickvault/bin",
               "if [ ! -d /opt/tickvault/repo/.git ]; then sudo -u ec2-user git clone --depth 1 https://github.com/SJParthi/tickvault.git /opt/tickvault/repo; fi",
               "chown -R ec2-user:ec2-user /opt/tickvault",


### PR DESCRIPTION
## Root cause (revealed by deploy-aws #106's box-side error)

#917's self-heal reached the git clone step — and the on-box log showed:

```
===== SSM command status: Failed =====
----- STDERR (on-box) -----
sudo: git: command not found
failed to run commands: exit status 1
```

The EC2 box doesn't have `git` installed. `user-data.sh.tftpl` would have installed it on first boot via `dnf`, but this instance is missing it (rebuilt without user-data completing, or first-boot package install failed).

## Fix

Two-line addition before the existing self-heal block:

```bash
# Ensure git is installed (AL2023 uses dnf; AL2 uses yum — try both).
command -v git >/dev/null 2>&1 || sudo dnf install -y git || sudo yum install -y git
```

- **Idempotent:** `command -v git` skips if already installed — no-op on healthy boxes
- **AL2023 + AL2 compatible:** tries `dnf` first, falls back to `yum`
- **Also unblocks** the existing `git -C repo fetch` line later in the script — that would have failed too even on a self-healed dir if git wasn't installed

## Z+ Defense Checklist

| Layer | Mechanism |
|---|---|
| L1 DETECT | #916's STDOUT/STDERR fetch revealed `sudo: git: command not found` |
| L2 VERIFY | `command -v git >/dev/null 2>&1` — actual presence check, not assumption |
| L3 RECONCILE | `dnf install -y git || yum install -y git` — both AL distros covered |
| L4 PREVENT | Runs before clone and before `git -C repo fetch` — both depend on git |
| L5 AUDIT | SSM CommandId + STDOUT in deploy log; Telegram on success/failure |
| L6 RECOVER | n/a — package install either works or surfaces a new error |
| L7 COOLDOWN | n/a — idempotent no-op on healthy boxes |

## Honest envelope

This gets the SSM script past the clone. If the smoke test then fails (= app boot can't reach QuestDB / missing secret / config issue), that error will surface via the next deploy log via #916's STDOUT/STDERR logging. One root cause at a time — no speculative bundling.

## Test plan

- [x] `deploy-aws.yml` YAML valid (1 file changed, +2/-0)
- [x] `command -v git` is idempotent on boxes that already have git
- [x] `dnf || yum` covers both Amazon Linux 2023 and Amazon Linux 2

🤖 Generated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJx7LtSiFvXpSu6GkPDcM)_