### PR TITLE
fix(aws): dump systemctl status + journal on tickvault.service failure

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -303,9 +303,10 @@ jobs:
               "chown ec2-user:ec2-user bin/tickvault bin/smoke_test",
               "# Reload systemd (picks up the refreshed unit) + restart",
               "systemctl daemon-reload",
-              "systemctl restart tickvault",
+              "# On systemctl failure, dump status + journal so the deploy log shows WHY (Z+ L1 DETECT).",
+              "systemctl restart tickvault || (echo ===== systemctl status ===== && systemctl status tickvault.service --no-pager -l || true; echo ===== journalctl tickvault.service last 100 ===== && journalctl -xeu tickvault.service -n 100 --no-pager || true; exit 1)",
               "sleep 5",
-              "systemctl is-active --quiet tickvault || (echo FAIL && exit 1)",
+              "systemctl is-active --quiet tickvault || (echo ===== service inactive after 5s ===== && systemctl status tickvault.service --no-pager -l || true; echo ===== journalctl tickvault.service last 100 ===== && journalctl -xeu tickvault.service -n 100 --no-pager || true; exit 1)",
               "echo DEPLOY OK"
             ]' \
             --query 'Command.CommandId' --output text)


### PR DESCRIPTION
## 🚀 Major progress from #919 — smoke test PASSED, atomic swap PASSED

deploy-aws #108's box-side log:

```
✅ Cloning into '/opt/tickvault/repo' ... done
✅ download s3://.../tickvault → bin/tickvault.new
✅ download s3://.../smoke_test → bin/smoke_test.new
✅ S7-Step4: tv-smoke-test PASSED in 1ms — binary is safe to start
   [1/5] config file exists
   [2/5] config parse + validate: OK
   [3/5] sandbox window check: OK
   [4/5] spill dir writable
   [5/5] Dhan locked facts: OK
❌ Job for tickvault.service failed because the control process exited with error code.
   See "systemctl status tickvault.service" and "journalctl -xeu tickvault.service" for details.
   failed to run commands: exit status 1
```

The smoke test validates config can parse — it doesn't actually try to connect to QuestDB, fetch SSM secrets, or open a WebSocket. The full systemd boot does, and **that** crashes. We can't see WHY because the deploy script doesn't dump the journal on systemctl failure.

## Fix — Z+ L1 DETECT: dump journal + status on systemctl failure

Two lines changed:

```bash
# was:
"systemctl restart tickvault"
"systemctl is-active --quiet tickvault || (echo FAIL && exit 1)"

# now:
"systemctl restart tickvault || (
  echo ===== systemctl status =====
  systemctl status tickvault.service --no-pager -l || true
  echo ===== journalctl tickvault.service last 100 =====
  journalctl -xeu tickvault.service -n 100 --no-pager || true
  exit 1
)"
# same dump on is-active failure
```

- **Idempotent:** the dump runs only on failure (`|| (...)`); success path unchanged
- **No new dependency:** `systemctl` + `journalctl` already on the box
- **`|| true`** inside the dump prevents a journal read failure from masking the original error

## Z+ Defense Checklist

| Layer | Mechanism |
|---|---|
| L1 DETECT | journal/status dump reveals app-boot crash reason (this PR) |
| L2 VERIFY | Smoke test (already passes 5 checks) + atomic swap (already passes) |
| L3 RECONCILE | Next PR will fix whatever the journal reveals |
| L4 PREVENT | `set -euo pipefail` + `|| true` prevent masking the real error |
| L5 AUDIT | SSM CommandId + journal in deploy log; Telegram on failure |
| L6 RECOVER | Existing rollback path (with #917's `/opt/tickvault` guard) |
| L7 COOLDOWN | n/a — no retry loop |

## Honest envelope

This PR does NOT fix the app-boot crash itself. It reveals WHY by surfacing the journal. The next deploy log will show either:
- ✅ **OK boot** — we've won (unlikely; the service was failing before this PR)
- ❌ The actual crash reason from the journal — we diagnose + fix in the next PR (most likely: SSM secret path mismatch since we only see `/tickvault/dev/*` in Parameter Store but the systemd unit may be looking for `/tickvault/staging/*`)

One root cause at a time. No speculative bundling.

## Test plan

- [x] `deploy-aws.yml` YAML valid (1 file changed, +3/-2)
- [x] Dump branches use `|| true` to never mask the original error
- [x] Success path unchanged (no journal dump on green boot)

🤖 Generated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJx7LtSiFvXpSu6GkPDcM)_