### PR TITLE
fix(config): remove duplicate [strategy] block from staging.toml

### DIFF
--- a/config/staging.toml
+++ b/config/staging.toml
@@ -42,9 +42,3 @@ format = "json"
 [api]
 # Different port so staging + prod can coexist on the same machine.
 port = 3002
-
-[strategy]
-# Duplicate block allowed by figment — last-write-wins. Explicitly
-# name the sandbox-only_until here again so a quick grep shows the
-# 2099 cutoff near the top of the file.
-sandbox_only_until = "2099-12-31"


### PR DESCRIPTION
## 🚀 Massive progress — musl works! New surface revealed.

deploy-aws #110's journal dump (the dump #920 ships):

```
Error: failed to load configuration from config/base.toml
Caused by:
    TOML parse error at line 46, column 1
       |
    46 | [strategy]
       | ^
    invalid table header
    duplicate key `strategy` in document root
     in config/staging.toml TOML file
```

The musl binary loads + runs (PR #921's GLIBC fix worked perfectly — no more `version GLIBC_2.39 not found`). The new failure is a TOML spec violation in `config/staging.toml`: two `[strategy]` headers at the document root. TOML rejects this unconditionally; the file is unparseable; app refuses to boot.

## The duplicate is also entirely redundant

The block at line 46 carried this comment:

```toml
[strategy]
# Duplicate block allowed by figment — last-write-wins. Explicitly
# name the sandbox-only_until here again so a quick grep shows the
# 2099 cutoff near the top of the file.
sandbox_only_until = "2099-12-31"
```

Two things wrong:
1. **figment merges multiple TOML _files_, not duplicate tables within the same file.** TOML's own parser rejects duplicates before figment ever sees the tables.
2. The block's only key (`sandbox_only_until = "2099-12-31"`) is **already set in the first `[strategy]` block at line 30** — the duplicate is entirely redundant even if it had worked.

## Fix — delete the redundant duplicate

```diff
 [api]
 # Different port so staging + prod can coexist on the same machine.
 port = 3002
-
-[strategy]
-# Duplicate block allowed by figment — last-write-wins. Explicitly
-# name the sandbox-only_until here again so a quick grep shows the
-# 2099 cutoff near the top of the file.
-sandbox_only_until = "2099-12-31"
```

The first `[strategy]` block at line 22-30 already carries `sandbox_only_until = "2099-12-31"` — the **SEBI safety mechanical guarantee** (staging can NEVER flip to Live) is preserved.

Verified with `python3 -c "import tomllib; tomllib.loads(open('config/staging.toml').read())"` → clean parse.

## Why smoke_test passed but the app failed (and what to fix later)

`smoke_test` parses **only `base.toml`**; the runtime app loads `base.toml` AND overlays `staging.toml` (via `TV_ENVIRONMENT=staging`). The duplicate lives in `staging.toml`, so smoke_test never sees it. This is also a smoke-test-coverage gap — smoke_test should parse the full env overlay. Not in scope here; one root cause at a time.

## Z+ Defense Checklist

| Layer | Mechanism |
|---|---|
| L1 DETECT | journal dump (already there, from #920) surfaces TOML parse errors verbatim |
| L2 VERIFY | `python3 -c "import tomllib; tomllib.loads(...)"` passes locally |
| L3 RECONCILE | First `[strategy]` block at line 30 already has `sandbox_only_until = "2099-12-31"` — SEBI mechanical guarantee preserved |
| L4 PREVENT | TOML duplicate-key rule is now enforced (was always enforced; this PR just stops violating it). **Follow-up:** make `smoke_test` parse the env overlay so future duplicates fail at build, not deploy. |
| L5 AUDIT | Commit message explains the misconception + the SEBI invariant preservation |
| L6 RECOVER | n/a — config edit, no runtime retry concern |
| L7 COOLDOWN | n/a |

## Honest envelope

After this PR merges + re-trigger deploy, the next log shows either:
- ✅ **DEPLOY OK** — app live (we win 🎉)
- ❌ The NEXT box-side error from #920's journal dump (most likely now: SSM secret path mismatch since Parameter Store only has `/tickvault/dev/*` but staging env may lookup `/tickvault/staging/*`) → one more small fix

## Test plan

- [x] `python3 tomllib` parses the file clean
- [x] Single `[strategy]` block remains
- [x] `sandbox_only_until = "2099-12-31"` still present (SEBI guarantee preserved)

🤖 Generated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJx7LtSiFvXpSu6GkPDcM)_