### PR TITLE
fix(aws): auto-stop tickvault on deploy failure + manual stop-app action

### DIFF
--- a/.github/workflows/aws-control.yml
+++ b/.github/workflows/aws-control.yml
@@ -18,6 +18,7 @@
 #   stop            - stop the EC2 instance (market-hours guarded)
 #   reboot          - reboot the EC2 instance (market-hours guarded)
 #   restart-app     - systemctl restart tickvault (via SSM; market-hours guarded)
+#   stop-app        - kill-switch: stop + disable tickvault (breaks restart loops + Telegram spam)
 #   restart-questdb - restart the QuestDB docker container (via SSM)
 #   seed-secrets    - copy /tickvault/dev/* -> /tickvault/staging/* (idempotent)
 #   deploy          - dispatch the full deploy-aws build+ship+restart pipeline
@@ -38,6 +39,7 @@ on:
           - stop
           - reboot
           - restart-app
+          - stop-app
           - restart-questdb
           - seed-secrets
           - deploy
@@ -117,7 +119,7 @@ jobs:
           force="${{ github.event.inputs.force }}"
           # Only stop/reboot/restart-app interrupt a live session.
           case "$action" in
-            stop|reboot|restart-app) sensitive=1 ;;
+            stop|reboot|restart-app|stop-app) sensitive=1 ;;
             *) sensitive=0 ;;
           esac
           if [ "$sensitive" = "1" ] && [ "$force" != "yes" ]; then
@@ -274,6 +276,23 @@ jobs:
           CMD=$(aws ssm send-command --region "$AWS_REGION" --instance-ids "$IID" \
             --document-name AWS-RunShellScript \
             --parameters 'commands=["systemctl restart tickvault","sleep 5","systemctl is-active --quiet tickvault && echo RESTARTED-OK || (echo FAIL; exit 1)"]' \
+            --query Command.CommandId --output text)
+          aws ssm wait command-executed --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" || true
+          aws ssm get-command-invocation --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" \
+            --query StandardOutputContent --output text
+
+      - name: stop-app
+        if: github.event.inputs.action == 'stop-app'
+        # Kill-switch — stops the tickvault service AND disables it so
+        # systemd Restart=always cannot relaunch it. Use when a deploy
+        # is restart-looping (e.g. config / runtime crash) and spamming
+        # Telegram. Next successful `deploy` will re-enable + start it.
+        run: |
+          set -euo pipefail
+          IID=${{ steps.iid.outputs.id }}
+          CMD=$(aws ssm send-command --region "$AWS_REGION" --instance-ids "$IID" \
+            --document-name AWS-RunShellScript \
+            --parameters 'commands=["systemctl stop tickvault || true","systemctl disable tickvault || true","systemctl is-active --quiet tickvault && (echo FAIL: service still active; exit 1) || echo STOPPED-AND-DISABLED"]' \
             --query Command.CommandId --output text)
           aws ssm wait command-executed --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" || true
           aws ssm get-command-invocation --region "$AWS_REGION" --command-id "$CMD" --instance-id "$IID" \

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -328,8 +328,12 @@ jobs:
               "mv bin/tickvault.new   bin/tickvault",
               "mv bin/smoke_test.new  bin/smoke_test",
               "chown ec2-user:ec2-user bin/tickvault bin/smoke_test",
-              "# Reload systemd (picks up the refreshed unit) + restart",
+              "# Reload systemd (picks up the refreshed unit) + (re)enable + restart.",
+              "# `enable` is required because a previously-failed deploy may have",
+              "# disabled the service via the auto-stop step (kills Telegram spam).",
+              "# `enable` is idempotent — no-op if already enabled.",
               "systemctl daemon-reload",
+              "systemctl enable tickvault || true",
               "# On systemctl failure, dump status + journal so the deploy log shows WHY (Z+ L1 DETECT).",
               "systemctl restart tickvault || (echo ===== systemctl status ===== && systemctl status tickvault.service --no-pager -l || true; echo ===== journalctl tickvault.service last 100 ===== && journalctl -xeu tickvault.service -n 100 --no-pager || true; exit 1)",
               "sleep 5",
@@ -428,6 +432,29 @@ jobs:
             --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ steps.acct.outputs.id }}:tv-prod-alerts \
             --subject "DLT deploy OK" \
             --message "commit=${{ github.sha }} ref=${{ github.ref }} actor=${{ github.actor }}"
+
+      - name: Auto-stop tickvault service on deploy failure (kills Telegram spam)
+        if: failure()
+        # When the deploy fails AFTER the binary is in place, systemd's
+        # Restart=always keeps relaunching it every few seconds. If each
+        # boot reaches the auth step (it does after PR #921/#922), each
+        # boot fires a "Auth OK" Telegram — operator gets one Telegram
+        # per minute forever. Auto-stop + disable here breaks the loop
+        # the moment the deploy fails. Next successful deploy will
+        # re-enable + start the service via the existing systemctl
+        # daemon-reload + restart sequence above.
+        # Honest envelope: this can only execute if AWS creds were
+        # configured (i.e. failure happened AFTER the configure-creds
+        # step). For earlier failures it silently no-ops via `|| true`.
+        run: |
+          set +e
+          aws ssm send-command \
+            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
+            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+            --document-name "AWS-RunShellScript" \
+            --comment "tickvault auto-stop on deploy failure sha=${{ github.sha }}" \
+            --parameters 'commands=["systemctl stop tickvault || true","systemctl disable tickvault || true","echo AUTO-STOPPED-AND-DISABLED: next successful deploy will re-enable + start the service"]' \
+            --query Command.CommandId --output text || echo "(could not dispatch auto-stop — AWS creds likely not configured at this stage)"
 
       - name: Notify Telegram on failure
         if: failure()


### PR DESCRIPTION
## Why this PR — operator's "fully extreme automation" charter

When deploy-aws #112 failed, the binary was already in place. systemd's `Restart=always` relaunched it every few seconds. Each boot reached the auth step (PR #921/#922 unblocked it) and fired one `[LOW] Auth OK — Dhan JWT acquired` Telegram → operator received **one Telegram per minute, ~20+ messages**, until manually intervened.

The previous design required the operator to open the AWS console, find the instance, run an SSM command manually — violates the "fully comprehensive extreme automation" charter. **Failure should auto-contain, not auto-amplify.**

## Three changes, one PR

| Change | File | What it does |
|---|---|---|
| **Auto-stop on deploy failure** | `deploy-aws.yml` | New step with `if: failure()` dispatches `systemctl stop + systemctl disable tickvault` via SSM. Kills the restart loop the moment deploy fails. |
| **Auto-enable on deploy success** | `deploy-aws.yml` | `systemctl enable tickvault \|\| true` before restart, so a successful deploy auto-recovers a previously-stopped service. Idempotent. |
| **Manual kill-switch** | `aws-control.yml` | New `stop-app` workflow_dispatch action — operator can stop + disable from GitHub Actions UI without touching AWS console. Market-hours guarded. |

## Z+ Defense Checklist

| Layer | Mechanism |
|---|---|
| L1 DETECT | Existing deploy-aws failure detection unchanged |
| L2 VERIFY | `systemctl is-active --quiet tickvault && (exit 1) \|\| echo STOPPED-AND-DISABLED` confirms the service is genuinely down |
| L3 RECONCILE | Successful deploy re-enables; failure auto-stops. Cycle is self-healing. |
| L4 PREVENT | **Failures contain themselves** — restart loop cannot amplify into Telegram firehose |
| L5 AUDIT | SSM CommandId + AUTO-STOPPED log line in the deploy run |
| L6 RECOVER | Manual `stop-app` action available for any out-of-band emergencies |
| L7 COOLDOWN | n/a — single-shot stop, no retry loop |

## Honest envelope

- Auto-stop fires only AFTER AWS creds are configured (i.e. failure happened during or after the SSM send step). For earlier failures (preflight, build, market-hours guard), the service is untouched — but those failures don't deploy a broken binary either, so there's no restart loop to stop.
- `enable` is idempotent. `disable` is idempotent. `stop` is idempotent. The whole flow is replay-safe.
- The `stop-app` manual action is market-hours guarded (will refuse during 09:15-15:30 IST Mon-Fri unless `force=yes`).

## Test plan

- [x] YAML valid (2 files, +48/-2)
- [x] Auto-stop uses `|| true` to never mask original error
- [x] Manual `stop-app` action sensitive list includes itself (market-hours guard fires)
- [x] Successful deploy now `enable`s before restart (auto-recovery)

## Cross-references

- PR #921 (musl) unblocked the auth step
- PR #922 (toml fix) made the duplicate visible in the repo
- PR #923 (cp diagnostic) — diagnoses why the box still has the stale config
- **This PR (#924?)** — makes failures stop being a Telegram firehose

🤖 Generated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJx7LtSiFvXpSu6GkPDcM)_