### PR TITLE
fix(aws): dump app stdout/stderr separately from systemd noise on failure

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -335,9 +335,11 @@ jobs:
               "systemctl daemon-reload",
               "systemctl enable tickvault || true",
               "# On systemctl failure, dump status + journal so the deploy log shows WHY (Z+ L1 DETECT).",
-              "systemctl restart tickvault || (echo ===== systemctl status ===== && systemctl status tickvault.service --no-pager -l || true; echo ===== journalctl tickvault.service last 100 ===== && journalctl -xeu tickvault.service -n 100 --no-pager || true; exit 1)",
+              "# Two journal dumps: (1) -xeu (rich systemd metadata, useful for context),",
+              "# (2) --output=cat -n 200 (raw app stdout/stderr ONLY, no systemd noise — the actual error).",
+              "systemctl restart tickvault || (echo ===== systemctl status ===== && systemctl status tickvault.service --no-pager -l || true; echo ===== app stdout/stderr ONLY last 200 ===== && journalctl -u tickvault.service -n 200 --no-pager --output=cat || true; echo ===== journalctl -xeu last 100 ===== && journalctl -xeu tickvault.service -n 100 --no-pager || true; exit 1)",
               "sleep 5",
-              "systemctl is-active --quiet tickvault || (echo ===== service inactive after 5s ===== && systemctl status tickvault.service --no-pager -l || true; echo ===== journalctl tickvault.service last 100 ===== && journalctl -xeu tickvault.service -n 100 --no-pager || true; exit 1)",
+              "systemctl is-active --quiet tickvault || (echo ===== service inactive after 5s ===== && systemctl status tickvault.service --no-pager -l || true; echo ===== app stdout/stderr ONLY last 200 ===== && journalctl -u tickvault.service -n 200 --no-pager --output=cat || true; echo ===== journalctl -xeu last 100 ===== && journalctl -xeu tickvault.service -n 100 --no-pager || true; exit 1)",
               "echo DEPLOY OK"
             ]' \
             --query 'Command.CommandId' --output text)


### PR DESCRIPTION
## Why — deploy log truncates before showing the actual app error

deploy-aws #113 (after #921 + #922 + #923 + #924 all merged):

```
S7-Step4: tv-smoke-test PASSED in 1ms — binary is safe to start
Created symlink ... (systemctl enable worked)
Job for tickvault.service failed because the control process exited with error code.
```

The journal dump was 100% systemd metadata (`Subject: A start job...`, `Defined-By: systemd`, `Support: ...`) and got truncated by GitHub Actions BEFORE reaching the actual app error line. **We know systemctl failed but cannot see WHY.**

`-xeu` (explain + show explanations + show unit) is great for forensics but it makes the output 5× bigger per restart attempt, drowning out the actual app error.

## Fix — dump app stdout/stderr in a SEPARATE format, raw

```diff
- systemctl restart tickvault || (
-   echo ===== systemctl status ===== && systemctl status ...
-   echo ===== journalctl tickvault.service last 100 ===== && journalctl -xeu ... -n 100
-   exit 1
- )
+ systemctl restart tickvault || (
+   echo ===== systemctl status ===== && systemctl status ...
+   echo ===== app stdout/stderr ONLY last 200 ===== &&
+   journalctl -u tickvault.service -n 200 --no-pager --output=cat || true
+   echo ===== journalctl -xeu last 100 ===== && journalctl -xeu ... -n 100
+   exit 1
+ )
```

`--output=cat` strips all systemd metadata and prints ONLY the raw lines the app wrote to stdout/stderr. The actual `Error: failed to load configuration ...` etc. shows up immediately, not buried under 50 lines of `░░ Subject: ...` ceremony per restart attempt.

## Honest envelope

This PR doesn't fix the app crash itself. It makes the next deploy's failure log show us the actual reason in plain text. After this merges + re-deploy:

- **Most likely (90%):** the real app error is now visible — almost certainly still the staging.toml duplicate (#923's diff check apparently passed silently because the file was overwritten, OR the cp is fine and something else is loading the OLD file from somewhere)
- **Less likely (10%):** a completely different surface (QuestDB connect / SSM secret / something we haven't seen yet)

Either way we get the actual reason in one more deploy run.

## Test plan

- [x] YAML valid (1 file, +4/-2)
- [x] App-only dump uses `--output=cat` (no systemd metadata)
- [x] Keeps existing `-xeu` dump for context (just runs after the cleaner one)

🤖 Generated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJx7LtSiFvXpSu6GkPDcM)_