### PR TITLE
fix(aws): auto-trigger deploy-aws on workflow / docker / config changes

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -41,10 +41,20 @@ on:
   push:
     branches: [main]
     paths:
+      # Rust sources + deps
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      # systemd unit (apps's runtime contract)
       - 'deploy/systemd/**'
+      # Docker compose (QuestDB infra; arch / image / env)
+      - 'deploy/docker/**'
+      # Config TOML (loaded by app at boot)
+      - 'config/**'
+      # The deploy workflow ITSELF (so a PR that fixes the deploy
+      # auto-redeploys without the operator clicking "Run workflow").
+      # Charter: "everything completely comprehensively fully automated".
+      - '.github/workflows/deploy-aws.yml'
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
## Operator charter — zero clicks

You said: "everything completely comprehensively fully automated".

The deploy-aws.yml `push` trigger currently only fires on Rust/Cargo/systemd changes. **A PR that fixes deploy-aws.yml itself does NOT auto-trigger a deploy** — operator has to manually click "Run workflow". That was the source of the manual-click frustration through PRs #916-#931 (every fix merged but didn't auto-redeploy).

## Fix — extend trigger paths

```diff
  push:
    branches: [main]
    paths:
      - 'crates/**'
      - 'Cargo.toml'
      - 'Cargo.lock'
      - 'deploy/systemd/**'
+     - 'deploy/docker/**'                    # docker-compose, healthchecks
+     - 'config/**'                            # TOML loaded by app
+     - '.github/workflows/deploy-aws.yml'     # self-referencing
    tags:
      - 'v*.*.*'
```

**Self-referencing path** is the key: deploy fixes auto-redeploy themselves after merge.

## Safety nets unchanged

| Guard | Behavior |
|---|---|
| Preflight | Skips if bootstrap secrets missing — no false-OK PR checks |
| Market-hours guard | Blocks 09:15-15:30 IST Mon-Fri (unless `workflow_dispatch confirm_market_hours=yes`) |
| Concurrency group | Serializes deploys — never two at once |
| Auto-stop on fail (#924) | Kills restart loop + Telegram firehose on any failure |

## Full automation cascade after this lands

1. PR #930 (QuestDB arm64) merges → auto-triggers deploy
2. PR #931 (SSM auto-seed) merges → auto-triggers deploy
3. **This PR merges → auto-triggers deploy** (self-referencing!)
4. Deploy runs the FULL self-healing chain end-to-end
5. **DEPLOY OK** (or auto-stop fires + Telegram alert) — **operator: zero clicks**

🤖 Generated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJx7LtSiFvXpSu6GkPDcM)_