### PR TITLE
fix(aws): budget-guards.tf - zip path + terraform fmt

### DIFF
--- a/deploy/aws/terraform/budget-guards.tf
+++ b/deploy/aws/terraform/budget-guards.tf
@@ -23,7 +23,7 @@
 
 data "archive_file" "tv_daily_budget_digest_zip" {
   type        = "zip"
-  output_path = "${path.module}/lambda-zips/tv_daily_budget_digest.zip"
+  output_path = "${path.module}/.tv-daily-budget-digest.zip"
   source {
     content  = <<-PYEOF
 import os, json, boto3
@@ -164,7 +164,7 @@ resource "aws_lambda_permission" "tv_daily_budget_digest_eventbridge" {
 
 data "archive_file" "tv_hard_stop_guard_zip" {
   type        = "zip"
-  output_path = "${path.module}/lambda-zips/tv_hard_stop_guard.zip"
+  output_path = "${path.module}/.tv-hard-stop-guard.zip"
   source {
     content  = <<-PYEOF
 import os, json, boto3

--- a/deploy/aws/terraform/budget-guards.tf
+++ b/deploy/aws/terraform/budget-guards.tf
@@ -101,18 +101,18 @@ resource "aws_iam_role_policy" "tv_daily_budget_digest" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = ["ce:GetCostAndUsage", "ce:GetCostForecast"]
+        Effect   = "Allow"
+        Action   = ["ce:GetCostAndUsage", "ce:GetCostForecast"]
         Resource = "*"
       },
       {
-        Effect = "Allow"
-        Action = "sns:Publish"
+        Effect   = "Allow"
+        Action   = "sns:Publish"
         Resource = aws_sns_topic.tv_alerts.arn
       },
       {
-        Effect = "Allow"
-        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Effect   = "Allow"
+        Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
         Resource = "*"
       },
     ]
@@ -218,18 +218,18 @@ resource "aws_iam_role_policy" "tv_hard_stop_guard" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = ["ec2:DescribeInstances", "ec2:StopInstances"]
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeInstances", "ec2:StopInstances"]
         Resource = "*"
       },
       {
-        Effect = "Allow"
-        Action = "sns:Publish"
+        Effect   = "Allow"
+        Action   = "sns:Publish"
         Resource = aws_sns_topic.tv_alerts.arn
       },
       {
-        Effect = "Allow"
-        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Effect   = "Allow"
+        Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
         Resource = "*"
       },
     ]


### PR DESCRIPTION
## Fixes terraform-apply #53 failure on PR #934 (budget Lambdas)

Two root causes in `budget-guards.tf` from PR #934 — both fixed + validated locally before push:

### 1. zip output_path used non-existent subdirectory

```diff
- output_path = "${path.module}/lambda-zips/tv_daily_budget_digest.zip"
+ output_path = "${path.module}/.tv-daily-budget-digest.zip"
- output_path = "${path.module}/lambda-zips/tv_hard_stop_guard.zip"
+ output_path = "${path.module}/.tv-hard-stop-guard.zip"
```

Matches the canonical pattern from `telegram-webhook-lambda.tf` + `budget-killswitch-lambda.tf` (single file with leading dot, no subdir).

### 2. `terraform fmt -check` failed (exit code 3)

Ran `terraform fmt deploy/aws/terraform/budget-guards.tf` with Terraform v1.9.8 locally — applied 12 lines of formatting fixes (alignment of `=` signs in IAM policy statement blocks).

### Validation BEFORE push

```
✅ terraform fmt -check -recursive deploy/aws/terraform/ → exit 0
✅ All zip paths use canonical ${path.module}/.NAME.zip pattern
```

### Cascade after merge

1. terraform-apply.yml auto-fires (path filter on `deploy/aws/terraform/**`)
2. `terraform fmt -check` passes (✅)
3. `terraform plan` resolves the 2 Lambdas + IAM + cron + log groups
4. `terraform apply` creates them
5. First budget digest fires next weekday 17:30 IST
6. First stop-guard runs same evening 17:00 IST

🤖 Generated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJx7LtSiFvXpSu6GkPDcM)_