### PR TITLE
fix(aws): poll SSM manually — 100s waiter ceiling was failing long deploys

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -442,12 +442,39 @@ jobs:
         # below, even when the on-box script fails (smoke test, git refresh,
         # systemctl, etc.). Without this the failure reason was hidden — the
         # "Fetch output" step was skipped on wait-failure (deploy #103).
+        #
+        # DO NOT use `aws ssm wait command-executed` here: that built-in waiter
+        # has a HARD-CODED budget of 20 polls × 5s = 100 seconds. The on-box
+        # script now does Docker Compose plugin download, `docker compose up`
+        # + 30s QuestDB readiness loop, CloudWatch agent install/config, and a
+        # 40s smoke test — easily > 100s of wall-clock. The waiter gave up
+        # while the command was still InProgress, the Fetch step then saw
+        # Status=InProgress (with EMPTY stdout/stderr, because SSM only fills
+        # those at a terminal state) and hard-failed a deploy that was actually
+        # still progressing (deploy run 26732460896, 2026-06-01). We poll
+        # manually with a 10-minute budget for a genuine TERMINAL state instead.
         continue-on-error: true
         run: |
-          aws ssm wait command-executed \
-            --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
-            --command-id ${{ steps.ssm.outputs.command_id }} \
-            --instance-id ${{ secrets.EC2_INSTANCE_ID }}
+          set -uo pipefail
+          REGION="${{ vars.AWS_REGION || 'ap-south-1' }}"
+          CMD_ID="${{ steps.ssm.outputs.command_id }}"
+          IID="${{ secrets.EC2_INSTANCE_ID }}"
+          # 120 polls × 5s = 600s (10 min). SSM send-command default execution
+          # timeout is 3600s, so the command itself is never killed under us.
+          for i in $(seq 1 120); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "$REGION" --command-id "$CMD_ID" --instance-id "$IID" \
+              --query 'Status' --output text 2>/dev/null || echo "Pending")
+            echo "poll $i/120: status=$STATUS"
+            case "$STATUS" in
+              Success|Failed|Cancelled|TimedOut)
+                echo "reached terminal state: $STATUS"
+                exit 0
+                ;;
+            esac
+            sleep 5
+          done
+          echo "::warning::SSM command still non-terminal after 10 min — the Fetch step below will report the real status."
 
       - name: Fetch SSM command output + fail loudly on box-side error
         # if: always() — print the box-side STDOUT/STDERR no matter what, so a


### PR DESCRIPTION
## Summary

The EC2 deploy (`deploy-aws.yml`) failed on run **26732460896** (commit `356db02`) at the **"Fetch SSM command output + fail loudly on box-side error"** step with `Status=InProgress` and **empty STDOUT/STDERR**.

### Root cause (diagnosed, not assumed)

`aws ssm wait command-executed` has a **hard-coded budget of 20 polls × 5s = 100 seconds**. Commit `356db02` ("CWAgent configs as repo files") added a large amount of new on-box work to the SSM command:

- Docker Compose v2 plugin curl-download from GitHub
- `docker compose up -d` + a 30s QuestDB readiness loop
- CloudWatch Agent install + config + restart
- the existing 40s smoke test

Total on-box wall-clock now exceeds 100s. The waiter exhausted its 20 attempts (the failing run's "Wait for SSM command completion" step took **1m42s ≈ 102s** — exactly the ceiling) and returned while the command was still `InProgress`. The next step read `Status=InProgress` — and because **SSM only populates `StandardOutputContent`/`StandardErrorContent` once the command reaches a terminal state**, both were empty — then hard-failed a deploy that was, in fact, still progressing. The empty-output + `InProgress` combination is the unmistakable signature of a waiter timeout, not a genuine on-box error.

### Fix

Replace the fixed-budget `aws ssm wait command-executed` with a bounded **10-minute manual poll** (120 × 5s) that loops until a genuine terminal state (`Success`/`Failed`/`Cancelled`/`TimedOut`). SSM's `send-command` default execution timeout is 3600s, so the command is never killed under us. The existing Fetch step then always sees the **real** status with **real** box-side output.

This is a CI/workflow-only change — one file, no Rust, no runtime code path touched.

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` — `deploy-aws.yml` parses clean
- [x] The next deploy will exercise the real path; the Fetch step will now report a true terminal status + on-box STDOUT/STDERR instead of an opaque `InProgress`.

## Honest envelope

This fixes the diagnosed proximate cause of run 26732460896 (the waiter ceiling). If a *subsequent* deploy reaches a terminal `Failed` state, the on-box reason (smoke test, systemctl, QuestDB) will now be visible in the Fetch step's STDERR — which is the point of the change. No "100% guarantee" beyond that is claimed: this surfaces truth instead of masking it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DYvCVAUxr8qyrbueDpYevw)_