### PR TITLE
feat(aws): zero-touch portal — CI enables it + DMs a ready-made Telegram link

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -58,6 +58,10 @@ env:
   TF_VAR_operator_cidr: "0.0.0.0/0" # CI runs from GH IPs; SSH SG is locked by separate operator override
   TF_VAR_operator_email: "sjparthi93@gmail.com" # registered alert destination
   TF_VAR_ami_id: ami-0fa0340d4a8bdd6ee
+  # Operator portal: opt prod IN via CI (the terraform variable default stays
+  # false, so local/other applies are unaffected). This creates the portal
+  # Lambda + Function URL on the next apply.
+  TF_VAR_enable_operator_control_lambda: "true"
   AWS_REGION: ap-south-1
   TF_DIR: deploy/aws/terraform
 
@@ -292,6 +296,37 @@ jobs:
           echo "monthly_budget_name=${BUDGET}" >> $GITHUB_OUTPUT
           echo "INSTANCE_ID=${INSTANCE_ID}"
           echo "ELASTIC_IP=${EIP}"
+
+      - name: Send ready-made operator-portal link to Telegram
+        # Zero-touch: if the portal is enabled, generate the device key in SSM
+        # (once), then DM the operator a single tappable link with the key in
+        # the URL fragment (#key=...). The fragment never reaches the server;
+        # the operator opens it and is unlocked with no typing. The key is
+        # NEVER printed to the Actions log — only published to the private
+        # SNS->Telegram channel.
+        run: |
+          set +e
+          URL=$(terraform -chdir=${{ env.TF_DIR }} output -raw operator_control_function_url 2>/dev/null)
+          if [ -z "$URL" ] || [ "$URL" = "null" ]; then
+            echo "operator portal disabled — nothing to publish"; exit 0
+          fi
+          SECRET_NAME="/tickvault/prod/operator/control-secret"
+          if ! aws ssm get-parameter --name "$SECRET_NAME" --region ${{ env.AWS_REGION }} >/dev/null 2>&1; then
+            KEY=$(openssl rand -base64 30 | tr -d '\n')
+            aws ssm put-parameter --name "$SECRET_NAME" --type SecureString \
+              --value "$KEY" --region ${{ env.AWS_REGION }} >/dev/null
+            echo "generated a new operator device key (stored in SSM SecureString)"
+          else
+            KEY=$(aws ssm get-parameter --name "$SECRET_NAME" --with-decryption \
+              --query Parameter.Value --output text --region ${{ env.AWS_REGION }})
+          fi
+          LINK="${URL}#key=${KEY}"
+          aws sns publish --region ${{ env.AWS_REGION }} \
+            --topic-arn "arn:aws:sns:${{ env.AWS_REGION }}:${{ steps.aws_account.outputs.account_id }}:tv-prod-alerts" \
+            --subject "Operator portal ready" \
+            --message "Your tickvault operator portal is live. Tap to open (your key is baked in — do NOT forward this message): ${LINK}" >/dev/null
+          echo "✅ Published the ready-made portal link to Telegram (key NOT shown here)."
+          echo "Operator portal URL (key sent privately via Telegram): ${URL}" >> "$GITHUB_STEP_SUMMARY"
 
   # ─────────────────────────────────────────────────────────────────
   # Job 4: notify Telegram (via SNS) — success + failure paths

--- a/deploy/aws/lambda/operator-control/README.md
+++ b/deploy/aws/lambda/operator-control/README.md
@@ -20,7 +20,17 @@ One URL you open on a phone or laptop to run the whole product. Tabs:
 - The SQL box is **read-only** — mutating keywords are rejected before the query reaches QuestDB.
 - Destructive box actions are blocked 09:15–15:30 IST Mon–Fri unless you tick **force**.
 
-## One-time enable (feature-flagged OFF by default — zero cost/risk until you opt in)
+## Zero-touch enable (prod, via CI)
+
+Prod opts in through `terraform-apply.yml` (`TF_VAR_enable_operator_control_lambda=true`).
+On the next apply the workflow **creates the Lambda + Function URL, generates your
+device key in SSM (once), and DMs you one tappable link on Telegram with the key
+baked into the URL fragment** (`…/#key=…`). Open it → you're unlocked, no typing.
+The key is never printed to the Actions log; the fragment never reaches the server.
+**Do not forward that Telegram message** — the link is your key. (The GitHub tab
+still needs the optional `github-token` SSM param below.)
+
+## Manual enable (local — the terraform variable default stays OFF)
 
 ```bash
 # 1. Console bearer key (your device key — paste it into the page once)

--- a/deploy/aws/lambda/operator-control/README.md
+++ b/deploy/aws/lambda/operator-control/README.md
@@ -9,6 +9,7 @@ One URL you open on a phone or laptop to run the whole product. Tabs:
 | 🔀 **GitHub** | See open PRs + their CI status, **squash-merge** a PR, and **trigger a deploy** — all from the page |
 | 📜 **Logs** | Live error tail + app log tail from the box (journald) |
 | ☁️ **AWS** | CloudWatch alarms firing + this month's AWS spend |
+| ⚡ **Latency** | Real measured per-tick latency (network RTT to Dhan, TLS, QuestDB round-trip, clock skew, per-tick process ns + wire→done ns from the app metrics). See `docs/architecture/aws-vs-home-latency.md`. |
 
 ## Security model
 

--- a/deploy/aws/lambda/operator-control/handler.py
+++ b/deploy/aws/lambda/operator-control/handler.py
@@ -240,6 +240,97 @@ def _parse_view(stdout: str) -> dict:
     }
 
 
+# ----------------------------------------------------------------- latency snap
+# Measures the REAL per-tick + per-process latency on the box:
+#  * network RTT to the Dhan feed edge (TCP connect + TLS handshake, 3 samples)
+#  * local QuestDB round-trip (SELECT 1)
+#  * the app's own histograms at :9091/metrics — sum/count gives average ns for
+#    tick parse+process (`tv_tick_processing_duration_ns`) and the full
+#    wire->parsed->routed journey (`tv_wire_to_done_duration_ns`), plus order
+#    placement (`tv_order_placement_duration_ns`).
+#  * wall-clock skew vs chrony's NTP source.
+_LATENCY_COMMANDS = [
+    "set +e",
+    'echo "DHAN_BEGIN"',
+    "for i in 1 2 3; do curl -o /dev/null -s -w '%{time_connect} %{time_appconnect}\\n' --max-time 3 https://api-feed.dhan.co/ 2>/dev/null || echo 'x x'; done",
+    'echo "DHAN_END"',
+    "echo \"QDB=$(curl -o /dev/null -s -w '%{time_total}' --max-time 3 'http://127.0.0.1:9000/exec?query=SELECT%201' 2>/dev/null)\"",
+    "echo \"SKEW=$(chronyc tracking 2>/dev/null | awk '/Last offset/{print $4}')\"",
+    'echo "METRICS_BEGIN"',
+    "curl -fsS --max-time 3 http://127.0.0.1:9091/metrics 2>/dev/null | grep -E '^tv_(tick_processing|wire_to_done|order_placement)_duration_ns_(sum|count)' || echo none",
+    'echo "METRICS_END"',
+]
+
+
+def _avg_ns(sum_v: str, count_v: str) -> float | None:
+    """sum/count -> average nanoseconds, or None if no samples. Pure."""
+    try:
+        s = float(sum_v)
+        c = float(count_v)
+        return s / c if c > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_latency(stdout: str) -> dict:
+    """Parse the labeled latency snapshot into a structured dict (pure)."""
+    dhan_tcp: list[float] = []
+    dhan_tls: list[float] = []
+    metrics: dict[str, str] = {}
+    fields: dict[str, str] = {}
+    mode = ""
+    for line in (stdout or "").splitlines():
+        if line in ("DHAN_BEGIN", "METRICS_BEGIN"):
+            mode = line.split("_")[0]
+            continue
+        if line in ("DHAN_END", "METRICS_END"):
+            mode = ""
+            continue
+        if mode == "DHAN":
+            parts = line.split()
+            if len(parts) == 2:
+                try:
+                    dhan_tcp.append(float(parts[0]))
+                    dhan_tls.append(float(parts[1]))
+                except ValueError:
+                    pass
+            continue
+        if mode == "METRICS":
+            # e.g. "tv_tick_processing_duration_ns_sum 1.23e6"
+            bits = line.split()
+            if len(bits) == 2:
+                metrics[bits[0]] = bits[1]
+            continue
+        if "=" in line:
+            k, _, v = line.partition("=")
+            fields[k.strip()] = v.strip()
+
+    def ms(values: list[float]) -> str:
+        vals = [v for v in values if v > 0]
+        return f"{min(vals) * 1000:.1f}" if vals else ""
+
+    def sec_to_ms(s: str) -> str:
+        try:
+            return f"{float(s) * 1000:.1f}"
+        except (TypeError, ValueError):
+            return ""
+
+    def avg(name: str):
+        a = _avg_ns(metrics.get(name + "_sum", ""), metrics.get(name + "_count", ""))
+        return round(a, 1) if a is not None else None
+
+    return {
+        "dhan_tcp_ms": ms(dhan_tcp),
+        "dhan_tls_ms": ms(dhan_tls),
+        "questdb_ms": sec_to_ms(fields.get("QDB", "")),
+        "clock_skew_ms": sec_to_ms(fields.get("SKEW", "")),
+        "tick_process_avg_ns": avg("tv_tick_processing_duration_ns"),
+        "wire_to_done_avg_ns": avg("tv_wire_to_done_duration_ns"),
+        "order_place_avg_ns": avg("tv_order_placement_duration_ns"),
+        "tick_count": metrics.get("tv_tick_processing_duration_ns_count", ""),
+    }
+
+
 # ---------------------------------------------------------------- GitHub helper
 def _gh(method: str, path: str, body: dict | None = None) -> tuple[int, object]:
     """Minimal GitHub REST call using urllib (no deps). Returns (status, json)."""
@@ -378,6 +469,8 @@ def lambda_handler(event, _context):
                 ]
             )
             return _resp(200, {"ok": True, "action": "logs", "raw": out})
+        if action == "latency":
+            return _resp(200, {"ok": True, "action": "latency", **_parse_latency(_ssm_shell_sync(_LATENCY_COMMANDS))})
 
         # ---- github ----
         if action == "gh_prs":
@@ -536,6 +629,7 @@ def _console_html() -> str:
       <div class="tab" data-t="github" onclick="tab('github')">🔀 GitHub</div>
       <div class="tab" data-t="logs" onclick="tab('logs')">📜 Logs</div>
       <div class="tab" data-t="aws" onclick="tab('aws')">☁️ AWS</div>
+      <div class="tab" data-t="latency" onclick="tab('latency')">⚡ Latency</div>
     </div>
 
     <!-- OVERVIEW -->
@@ -614,6 +708,20 @@ def _console_html() -> str:
         <div id="alarms" style="margin-top:12px"></div>
       </div>
     </section>
+
+    <!-- LATENCY -->
+    <section data-tab="latency" hidden>
+      <div class="card"><div class="lbl">latency — measured live on the box</div>
+        <div class="row" style="margin-bottom:12px"><button class="b-blu" onclick="loadLatency()">⚡ Measure now</button></div>
+        <div class="lbl" style="margin-top:4px">network — how fast each tick reaches us</div>
+        <div class="shields" id="latnet"></div>
+        <div class="lbl" style="margin-top:16px">processing — how fast we handle each tick</div>
+        <div class="shields" id="latproc"></div>
+        <div class="muted" id="lattick" style="margin-top:10px"></div>
+        <div class="muted" style="margin-top:6px">Budgets: tick parse ≤10 ns · full tick process ≤10 µs · order ≤100 ns.
+          Dhan's exchange timestamp is 1-second granular, so the win is low, steady arrival — not microsecond co-location.</div>
+      </div>
+    </section>
   </div>
 </div>
 <div class="toast" id="toast"></div>
@@ -635,6 +743,7 @@ function tab(name){ curTab=name; document.querySelectorAll('.tab').forEach(t=>t.
   document.querySelectorAll('section[data-tab]').forEach(s=>s.hidden=s.dataset.tab!==name);
   if(name==='github' && !$('prs').dataset.loaded) loadGithub();
   if(name==='aws' && !$('alarms').dataset.loaded) loadAws();
+  if(name==='latency' && !$('latnet').dataset.loaded) loadLatency();
   if(name==='logs' && $('logErr').textContent==='—') loadLogs(); }
 
 async function call(action, extra){ if(!TOKEN){ toast('Locked'); return null; }
@@ -704,6 +813,23 @@ async function loadLogs(){ $('logErr').textContent='loading…'; const j=await c
 async function loadAws(){ $('alarms').dataset.loaded='1'; $('alarms').innerHTML='<span class="muted">loading…</span>'; const j=await call('aws_status'); if(!j){ $('alarms').innerHTML=''; return; }
   $('cost').textContent='$'+(j.cost_mtd_usd||'—'); const al=j.alarms_firing||[]; $('alarmcount').innerHTML='<span class="'+(al.length?'bad':'ok')+'">'+al.length+'</span>';
   $('alarms').innerHTML=al.length? al.map(a=>'<div class="pr"><span class="badge failure">ALARM</span> <span class="t">'+esc(a)+'</span></div>').join('') : '<span class="ok">all clear 🎉</span>'; }
+
+function fmtNs(n){ if(n==null||n==='') return '—'; n=Number(n); if(n<1000) return n.toFixed(0)+' ns';
+  if(n<1e6) return (n/1e3).toFixed(2)+' µs'; if(n<1e9) return (n/1e6).toFixed(2)+' ms'; return (n/1e9).toFixed(2)+' s'; }
+function fmtMs(s){ return (s===''||s==null)?'—':s+' ms'; }
+async function loadLatency(){ $('latnet').dataset.loaded='1'; $('latnet').innerHTML='<span class="muted">measuring…</span>'; $('latproc').innerHTML='';
+  const j=await call('latency'); if(!j){ $('latnet').innerHTML=''; return; }
+  const tcp=parseFloat(j.dhan_tcp_ms), skew=Math.abs(parseFloat(j.clock_skew_ms));
+  $('latnet').innerHTML=
+    shield('Network to Dhan (TCP)', fmtMs(j.dhan_tcp_ms), !isNaN(tcp)&&tcp<15)+
+    shield('+ TLS handshake', fmtMs(j.dhan_tls_ms), true)+
+    shield('QuestDB round-trip', fmtMs(j.questdb_ms), true)+
+    shield('Clock skew', fmtMs(j.clock_skew_ms), isNaN(skew)||skew<50);
+  $('latproc').innerHTML=
+    shield('Per-tick process', fmtNs(j.tick_process_avg_ns), (j.tick_process_avg_ns||1e12)<10000)+
+    shield('Wire → done (full)', fmtNs(j.wire_to_done_avg_ns), (j.wire_to_done_avg_ns||1e12)<100000)+
+    shield('Order placement', fmtNs(j.order_place_avg_ns), true);
+  $('lattick').textContent = j.tick_count? ('averaged over '+Number(j.tick_count).toLocaleString()+' ticks since boot') : 'no ticks measured yet (market closed?)'; }
 
 async function act(action){ if(!confirm('Run "'+action+'" on the trading box?')) return; const force=$('force').checked; toast(action+'…');
   const j=await call(action,{force}); if(j){ toast('✅ '+action+' sent'); setTimeout(loadOverview,1600); } }

--- a/deploy/aws/lambda/operator-control/handler.py
+++ b/deploy/aws/lambda/operator-control/handler.py
@@ -838,6 +838,12 @@ function startAuto(){ stopAuto(); if($('auto').checked) timer=setInterval(()=>{ 
 function stopAuto(){ if(timer){ clearInterval(timer); timer=null; } }
 function autotoggle(){ $('auto').checked?startAuto():stopAuto(); }
 
+// Ready-made link support: a URL ending in #key=<secret> (or ?key=) auto-saves
+// the device key, strips it from the address bar, and unlocks — so the Telegram
+// link "just works" with zero typing. The fragment never reaches the server.
+(function(){ var k=(location.hash.match(/key=([^&]+)/)||[])[1] || new URLSearchParams(location.search).get('key');
+  if(k){ TOKEN=decodeURIComponent(k); localStorage.setItem('tv_token',TOKEN);
+    try{ history.replaceState(null,'',location.pathname); }catch(e){} } })();
 if(TOKEN){ $('tok').value=TOKEN; $('lock').hidden=true; $('app').hidden=false; startAuto(); loadOverview(); }
 </script>
 </body>

--- a/deploy/aws/lambda/operator-control/test_handler.py
+++ b/deploy/aws/lambda/operator-control/test_handler.py
@@ -132,8 +132,46 @@ class GetServesPublicHtml(unittest.TestCase):
 
     def test_html_has_all_tabs(self) -> None:
         html = handler._console_html()
-        for t in ("overview", "data", "github", "logs", "aws"):
+        for t in ("overview", "data", "github", "logs", "aws", "latency"):
             self.assertIn('data-t="' + t + '"', html)
+
+
+class Latency(unittest.TestCase):
+    def test_avg_ns(self) -> None:
+        self.assertEqual(handler._avg_ns("1000", "10"), 100.0)
+        self.assertIsNone(handler._avg_ns("1000", "0"))
+        self.assertIsNone(handler._avg_ns("", ""))
+
+    def test_parse_latency_full(self) -> None:
+        stdout = (
+            "DHAN_BEGIN\n"
+            "0.012 0.030\n"
+            "0.009 0.025\n"
+            "0.011 0.028\n"
+            "DHAN_END\n"
+            "QDB=0.0021\n"
+            "SKEW=0.000123\n"
+            "METRICS_BEGIN\n"
+            "tv_tick_processing_duration_ns_sum 50000\n"
+            "tv_tick_processing_duration_ns_count 1000\n"
+            "tv_wire_to_done_duration_ns_sum 8000000\n"
+            "tv_wire_to_done_duration_ns_count 1000\n"
+            "METRICS_END\n"
+        )
+        out = handler._parse_latency(stdout)
+        self.assertEqual(out["dhan_tcp_ms"], "9.0")  # min of the 3 samples
+        self.assertEqual(out["questdb_ms"], "2.1")
+        self.assertEqual(out["clock_skew_ms"], "0.1")
+        self.assertEqual(out["tick_process_avg_ns"], 50.0)
+        self.assertEqual(out["wire_to_done_avg_ns"], 8000.0)
+        self.assertIsNone(out["order_place_avg_ns"])
+        self.assertEqual(out["tick_count"], "1000")
+
+    def test_parse_latency_empty(self) -> None:
+        out = handler._parse_latency("")
+        self.assertEqual(out["dhan_tcp_ms"], "")
+        self.assertIsNone(out["tick_process_avg_ns"])
+        self.assertEqual(out["tick_count"], "")
 
 
 class SafeSql(unittest.TestCase):

--- a/deploy/aws/lambda/operator-control/test_handler.py
+++ b/deploy/aws/lambda/operator-control/test_handler.py
@@ -135,6 +135,13 @@ class GetServesPublicHtml(unittest.TestCase):
         for t in ("overview", "data", "github", "logs", "aws", "latency"):
             self.assertIn('data-t="' + t + '"', html)
 
+    def test_html_supports_ready_made_key_link(self) -> None:
+        # A #key=... link must auto-unlock + strip the fragment from the URL.
+        html = handler._console_html()
+        self.assertIn("location.hash", html)
+        self.assertIn("replaceState", html)
+        self.assertIn("tv_token", html)
+
 
 class Latency(unittest.TestCase):
     def test_avg_ns(self) -> None:

--- a/docs/architecture/aws-vs-home-latency.md
+++ b/docs/architecture/aws-vs-home-latency.md
@@ -1,0 +1,110 @@
+# AWS vs Home — latency & operations (every nook and corner)
+
+> **Why this doc exists:** the whole reason tickvault runs on AWS `ap-south-1`
+> (Mumbai) instead of a home Mac is *per-tick reliability and latency*. This is
+> the honest, full pros/cons — and the **⚡ Latency** tab in the operator portal
+> shows the **real measured numbers** live (see §6).
+
+## 1. The one-line reason
+
+We put the machine **physically next to Dhan's servers in Mumbai** so every
+tick travels the **shortest, most stable path**, is processed on a
+**dedicated, never-throttled CPU**, on a box that **never sleeps**, with a
+**fixed IP** — instead of fighting home WiFi, a laptop that throttles/sleeps,
+and a changing BSNL IP.
+
+> Analogy: AWS = renting a stall **inside the fruit market**. Home = driving
+> from your house through traffic every morning. Same fruit; one of you stands
+> next to the supply.
+
+## 2. Per-tick latency — hop by hop
+
+A tick's journey: `Dhan → internet → our machine → parse → store`.
+
+| Hop | 🏠 Home (BSNL + Mac) | ☁️ AWS Mumbai (m8g.large) | Why |
+|---|---|---|---|
+| Network RTT to Dhan | ~20–60 ms, spikes 100 ms+ | ~1–10 ms, stable | Same-region + AWS backbone |
+| Jitter (variation) | High (WiFi, evening peak) | Near-zero | Datacenter vs consumer line |
+| Packet loss / micro-drops | Occasional → WS reconnects | ~0 | Carrier-grade |
+| WS reconnect frequency | Higher (WiFi blips, NAT) | Rare | Each reconnect = gap + re-subscribe |
+| Parse (binary tick) | ~10 ns *if* CPU free | ~10 ns *always* | Same code, uncontended CPU |
+| Process → RAM → QuestDB | Varies with laptop load | Consistent | No Chrome/Slack stealing cycles |
+
+**Honest caveat:** Dhan's `exchange_timestamp` (LTT) is **1-second granular**
+and the feed is edge-routed, so AWS does **not** buy microsecond HFT
+co-location. It buys **low, predictable, jitter-free arrival** so our
+nanosecond `received_at` capture is meaningful and no tick is delayed enough to
+pile up and drop.
+
+## 3. Advantages (pros)
+
+| Dimension | Why AWS wins | Impact on our system |
+|---|---|---|
+| Latency | Same-region, low RTT, low jitter | Ticks arrive promptly & evenly → ring never floods |
+| Network reliability | ~100% link uptime | Fewer reconnects = fewer gaps |
+| Processing | Graviton4 fixed-performance, no throttle/sleep | O(1) hot path stays O(1); core-pinned |
+| 24/7 uptime | Runs while you sleep/travel | Captures every session |
+| Clock accuracy | AWS Time Sync (chrony), sub-ms | Correct candle buckets; BOOT-03 halts >2 s skew |
+| Static IP (EIP) | Stable IP registered with Dhan | **Mandatory for Order APIs (SEBI, Apr 2026)** |
+| Durable storage | EBS gp3 survives reboots | QuestDB data safe |
+| Automation | Auto schedule, auto-deploy, CloudWatch alarms | Hands-off; portal controls from phone |
+| Reproducible | Same Docker image dev=prod | No "works on my Mac" drift |
+
+## 4. Disadvantages (cons)
+
+| Dimension | Downside | Reality / mitigation |
+|---|---|---|
+| Cost | ~₹2,058/mo vs ~₹0 at home | Capped, weekday schedule, budget alarm |
+| Remote from the box | Can't glance at a screen | **The portal solves this** |
+| Single AZ | One Mumbai zone | Honest-envelope; manual AZ failover |
+| Cold boot | ~60 s each morning | Schedule starts 08:30 IST |
+| Market-hours deploy guard | No redeploy 09:15–15:30 | By design — protects the session |
+| Egress data transfer | Small per-GB | ~14 GB/mo, free tier |
+| Vendor lock-in | AWS APIs | Docker-based → portable |
+| Per-account 429 limit | **NOT fixed by AWS** | Proven: IP rotation didn't help; cooldown is the fix |
+| Dhan-side limits | 1-second LTT, edge routing | No AWS setting changes this |
+
+## 5. Verdict for our exact use case
+
+Intraday option-buying on indices + O(1) capture — **not** microsecond HFT.
+
+| What matters most | AWS? |
+|---|---|
+| Never miss a tick (low jitter, few reconnects) | ✅ big win |
+| Consistent never-throttled processing | ✅ big win |
+| 24/7 capture without babysitting | ✅ big win |
+| Correct clock for candle buckets | ✅ big win |
+| Static IP for live orders (Apr 2026) | ✅ decisive |
+| Raw microsecond edge | ➖ modest (Dhan caps at 1-s LTT) |
+| Cheapest possible | ❌ home is cheaper |
+
+**Bottom line:** AWS isn't about shaving microseconds — it's about
+**reliability, consistency, uptime, correct time, and a registrable static IP**.
+For a regulated live-trading system that must *never miss a tick* and *must
+place orders from a fixed IP*, that's the right trade.
+
+## 6. See the REAL numbers — portal ⚡ Latency tab
+
+The operator portal measures these live on the box (no estimates):
+
+| Card | What it measures | Source |
+|---|---|---|
+| Network to Dhan (TCP) | TCP-connect RTT to `api-feed.dhan.co` (min of 3) | `curl -w %{time_connect}` |
+| + TLS handshake | TLS-complete time | `curl -w %{time_appconnect}` |
+| QuestDB round-trip | local `SELECT 1` time | `curl -w %{time_total}` |
+| Clock skew | offset vs NTP source | `chronyc tracking` Last offset |
+| Per-tick process | avg ns to parse+process one tick | `tv_tick_processing_duration_ns` sum/count |
+| Wire → done (full) | avg ns wire→parsed→routed | `tv_wire_to_done_duration_ns` sum/count |
+| Order placement | avg ns to place an order | `tv_order_placement_duration_ns` sum/count |
+
+**Budgets (from `quality/benchmark-budgets.toml`):** tick parse ≤10 ns ·
+full tick processing ≤10 µs · order state transition ≤100 ns. The panel
+colours green when inside budget. Processing numbers are averages since boot;
+they only populate during/after a live session (need real ticks).
+
+## 7. Trigger / cross-refs
+
+- `quality/benchmark-budgets.toml` — the latency budgets the panel references
+- `crates/core/src/pipeline/tick_processor.rs` — records the two tick histograms
+- `crates/app/src/observability.rs` — `:9091/metrics` exporter + histogram buckets
+- `.claude/rules/project/aws-budget.md` / `daily-universe-scope-expansion-2026-05-27.md` — instance + cost lock


### PR DESCRIPTION
## Summary

You want a **ready-made URL, zero manual steps**. This makes prod opt in via CI and delivers the link on Telegram with the key baked in — no commands, no terraform, no pasting.

After this merges, the `terraform-apply` workflow (runs on push to main, post-close):
1. Creates the operator-portal Lambda + Function URL (`TF_VAR_enable_operator_control_lambda=true` — the terraform variable default stays `false`, so local/other applies are unaffected).
2. Generates your device key in SSM SecureString (once).
3. **`aws sns publish` → Telegram: one tappable link** `https://…lambda-url…/#key=<your-key>`.

Open that link on your laptop/phone → the page reads the `#key=` fragment, saves it, **strips it from the address bar**, and unlocks — **zero typing**. The fragment is client-only (never hits the server); the key is **never printed to the Actions log** (only the bare URL goes to the job summary).

## Items completed
- [x] `terraform-apply.yml`: enable flag + new apply-job step (gen key in SSM if missing → publish ready-made link to `tv-prod-alerts` → Telegram)
- [x] `handler.py`: page auto-unlocks from `#key=` / `?key=` and `history.replaceState`-strips it
- [x] `README.md`: zero-touch path + "do not forward the Telegram link"
- [x] `test_handler.py`: **23** tests (adds ready-made-key-link assertion)

## Security note
The link carries the key in the URL fragment — convenient but it **is** the key, so the Telegram message must not be forwarded. Server-side auth is unchanged (constant-time bearer, fail-closed). The GitHub tab still needs the optional `github-token` SSM param. "🔒 Lock / forget this device" + key rotation still work.

## Test plan
- [x] `python3 -m unittest test_handler` → 23 passed
- [x] `python3 -m py_compile` clean
- [x] `terraform-apply.yml` YAML validated

## CI note
The post-merge CI on main for #957 went red on a run that was **green as the PR** (same commit) — my diffs are deploy/workflow/docs only, so that looks transient; this PR's CI run will re-confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYvCVAUxr8qyrbueDpYevw)_