### PR TITLE
fix(aws): clean timestamp display in portal SQL results (IST, no .000000Z noise)

### DIFF
--- a/deploy/aws/lambda/operator-control/handler.py
+++ b/deploy/aws/lambda/operator-control/handler.py
@@ -840,8 +840,12 @@ async function runSql(){ const q=$('sql').value.trim(); if(!q){ toast('Type a qu
   const j=await call('sql',{query:q}); if(!j){ $('sqlout').innerHTML=''; return; }
   const lines=(j.csv||'').split(/\r?\n/).filter(x=>x.length); if(!lines.length){ $('sqlout').innerHTML='<span class="muted">no rows</span>'; return; }
   const rows=lines.map(l=>l.split(',').map(c=>c.replace(/^"|"$/g,'')));
+  // QuestDB renders our IST-stored timestamps as "...T15:28:00.000000Z" — the
+  // value is already IST (project storage convention); strip the noisy
+  // microseconds + Z and the T so it reads "2026-06-01 15:28:00 IST".
+  const tcell=c=>{ const m=/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.\d+)?Z?$/.exec(c); return m? m[1]+' '+m[2]+' IST' : c; };
   let h='<table><tr>'+rows[0].map(c=>'<th>'+esc(c)+'</th>').join('')+'</tr>';
-  for(let i=1;i<rows.length;i++) h+='<tr>'+rows[i].map(c=>'<td>'+esc(c)+'</td>').join('')+'</tr>';
+  for(let i=1;i<rows.length;i++) h+='<tr>'+rows[i].map(c=>'<td>'+esc(tcell(c))+'</td>').join('')+'</tr>';
   $('sqlout').innerHTML=h+'</table>'; }
 
 function ciBadge(s){ const k=['success','pending','failure'].includes(s)?s:'unknown'; return '<span class="badge '+k+'">'+s+'</span>'; }

--- a/deploy/aws/terraform/operator-control-lambda.tf
+++ b/deploy/aws/terraform/operator-control-lambda.tf
@@ -1,8 +1,6 @@
 # Operator portal Lambda — action backend for the single-page operator portal
 # (Overview / Data / GitHub / Logs / AWS / Latency tabs).
-# Re-trigger marker: this file edit fires terraform-apply on push to main so the
-# portal (enabled via TF_VAR_enable_operator_control_lambda in the workflow) is
-# created and the ready-made link is DM'd to Telegram. (2026-06-01)
+# Re-trigger marker: bump to fire terraform-apply (re-zips handler.py). (2026-06-01b)
 #
 # WHY: the operator wants ONE place (console URL + Telegram) to view AND control
 # the box, without the AWS console or GitHub UI. Grafana = view; this = control.


### PR DESCRIPTION
## Summary

The portal SQL results showed timestamps as `2026-06-01T15:28:00.000000Z`. That value is **already IST** (project storage convention), but the `.000000Z` microseconds + `T` + `Z` are noise. The results table now formats timestamp-like cells as **`2026-06-01 15:28:00 IST`** — readable, no double-conversion.

Also bumps the terraform re-trigger marker so `terraform-apply` re-zips + redeploys the Lambda with this handler change on merge.

## Test plan
- [x] `python3 -m unittest test_handler` → 26 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYvCVAUxr8qyrbueDpYevw)_