### PR TITLE
fix(aws): wipe button uses TRUNCATE (the docker down -v wipe didn't clear data)

### DIFF
--- a/deploy/aws/lambda/operator-control/handler.py
+++ b/deploy/aws/lambda/operator-control/handler.py
@@ -453,23 +453,22 @@ def lambda_handler(event, _context):
             cid = _ssm_shell(["cd /opt/tickvault/repo/deploy/docker && docker compose restart questdb"])
             return _resp(200, {"ok": True, "action": action, "command_id": cid})
         if action == "wipe-questdb":
-            # DESTRUCTIVE: deletes ALL QuestDB data for a fresh start. Always
-            # requires force=true (even off-hours), and is in _DESTRUCTIVE so it
-            # is ALSO market-hours-blocked. Sequence: stop app -> compose down -v
-            # (removes the tv-questdb-data volume) -> up -d (empty QuestDB) ->
-            # start app (boot DDL recreates the schema). Next session = fresh.
+            # DESTRUCTIVE: empties the market-data tables for a fresh start.
+            # Requires force=true (even off-hours) + is in _DESTRUCTIVE
+            # (market-hours-blocked). TRUNCATEs ticks + candles directly in
+            # QuestDB — the docker-volume approach (down -v) proved unreliable on
+            # this box (QuestDB started outside the compose project / volume
+            # in-use), but TRUNCATE clears the rows regardless and keeps the
+            # schema, so no recreation is needed. Audit tables are intentionally
+            # preserved (SEBI retention). Next session = fresh data.
             if not force:
                 return _resp(409, {"error": 'wipe is destructive — re-send with {"force": true}', "action": action})
-            cid = _ssm_shell(
-                [
-                    "set +e",
-                    "systemctl stop tickvault || true",
-                    "cd /opt/tickvault/repo/deploy/docker && docker compose down -v",
-                    "cd /opt/tickvault/repo/deploy/docker && docker compose up -d",
-                    "sleep 8",
-                    "systemctl start tickvault || true",
-                ]
-            )
+            tables = ["ticks", "candles_1m", "candles_5m", "candles_15m", "candles_60m", "candles_1d"]
+            cmds = ["set +e"]
+            cmds += [
+                f"curl -fsS 'http://127.0.0.1:9000/exec?query=TRUNCATE%20TABLE%20{t}' 2>/dev/null; echo" for t in tables
+            ]
+            cid = _ssm_shell(cmds)
             return _resp(200, {"ok": True, "action": action, "command_id": cid})
 
         # ---- overview / data ----

--- a/deploy/aws/terraform/operator-control-lambda.tf
+++ b/deploy/aws/terraform/operator-control-lambda.tf
@@ -1,6 +1,6 @@
 # Operator portal Lambda — action backend for the single-page operator portal
 # (Overview / Data / GitHub / Logs / AWS / Latency tabs).
-# Re-trigger marker: bump to fire terraform-apply (re-zips handler.py). (2026-06-01b)
+# Re-trigger marker: bump to fire terraform-apply (re-zips handler.py). (2026-06-01c)
 #
 # WHY: the operator wants ONE place (console URL + Telegram) to view AND control
 # the box, without the AWS console or GitHub UI. Grafana = view; this = control.


### PR DESCRIPTION
## Summary

**Live proof:** the portal's 🗑️ wipe button ran `docker compose down -v`, but `SELECT count() FROM ticks` stayed at **723,198** — the volume was never removed (QuestDB started outside that compose project / volume in-use). Running **`TRUNCATE TABLE ticks/candles_*`** directly cleared it instantly (count → **0**, confirmed on the box).

So the button now uses **TRUNCATE** of the market-data tables (`ticks` + `candles_1m/5m/15m/60m/1d`) via QuestDB `/exec`:
- Reliable regardless of how QuestDB was started (no docker/volume dependency)
- Keeps the schema (no recreation needed)
- **Preserves audit tables** (SEBI retention) — only market data is wiped
- Still `force`-gated + market-hours-blocked + UI types `WIPE`

Bumps the terraform re-trigger marker so the handler redeploys on merge.

## Test plan
- [x] `python3 -m unittest test_handler` → 26 passed
- [x] verified manually: TRUNCATE via SSM cleared `ticks` (723,198 → 0)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYvCVAUxr8qyrbueDpYevw)_