### PR TITLE
fix(deploy): re-gate market hours at SWAP time — prevent mid-session restart

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -429,6 +429,39 @@ jobs:
             s3://tv-prod-cold/deploys/${{ github.sha }}/smoke_test \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }}
 
+      - name: Re-gate market hours at SWAP time (no mid-session restart)
+        # ROOT-CAUSE FIX 2026-06-02 (incident #2): the `guard_market_hours`
+        # job checks the clock at JOB START. PR #971 merged at 09:11:21 IST
+        # (4 min before the 09:15 open), passed that guard, then the ~4-5 min
+        # ARM build pushed the actual SSM binary-swap + `systemctl restart` to
+        # ~09:16 IST — INSIDE market open. That restart blanked the live feed
+        # for ~2 min right at the bell (recent_tick SELFTEST-02 failed 09:15;
+        # ticks resumed only after FAST BOOT 09:17). The start-time guard
+        # cannot see a build that crosses the open boundary.
+        #
+        # This step re-checks IST market hours IMMEDIATELY before the swap. If
+        # we are now inside 09:15-15:30 IST Mon-Fri, ABORT before touching the
+        # box: the binary is already built + in S3, so the 15:31 IST
+        # post-market cron (deploy-aws-after-close) will redeploy it safely.
+        # DEPLOY_SKIP_REASON suppresses the failure Telegram (this is an
+        # intentional defer, not a failure) while keeping the run non-success
+        # so the cron re-fires. The manual override path stays open via
+        # workflow_dispatch confirm_market_hours=yes (same as the start guard).
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event.inputs.confirm_market_hours }}" = "yes" ]; then
+            echo "operator override (confirm_market_hours=yes) — proceeding with swap during market hours"
+            exit 0
+          fi
+          DOW=$(TZ='Asia/Kolkata' date +%u)
+          HHMM=$(TZ='Asia/Kolkata' date +%H%M); HHMM=$((10#$HHMM))
+          if [ "$DOW" -le 5 ] && [ "$HHMM" -ge 915 ] && [ "$HHMM" -lt 1530 ]; then
+            echo "DEPLOY_SKIP_REASON=market_hours_swap_abort" >> "$GITHUB_ENV"
+            echo "::warning::Market is OPEN ($HHMM IST) at swap time — the build crossed the 09:15 boundary. ABORTING the binary swap to avoid a mid-session restart. The 15:31 IST post-market cron will redeploy this commit. (Override: re-run with confirm_market_hours=yes.)"
+            exit 1
+          fi
+          echo "outside market hours ($HHMM IST, dow=$DOW) — safe to swap"
+
       - name: Run SSM command — download binaries + smoke test + atomic swap
         # Target path is /opt/tickvault (matches user-data.sh.tftpl step 4).
         # Smoke test is a SEPARATE binary (crates/app/src/bin/smoke_test.rs),
@@ -580,7 +613,7 @@ jobs:
         # Skipped on an intentional off-hours skip (the box is down on purpose;
         # there is no command_id to query, so this would only emit AWS
         # ParamValidation noise — see the "Ensure instance running" step).
-        if: always() && env.DEPLOY_SKIP_REASON != 'intentional_stopped'
+        if: always() && env.DEPLOY_SKIP_REASON == ''
         run: |
           STATUS=$(aws ssm get-command-invocation \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
@@ -656,7 +689,7 @@ jobs:
       - name: Auto-stop tickvault service on deploy failure (kills Telegram spam)
         # Not on an intentional off-hours skip: the box is already stopped, so
         # this would only emit InvalidInstanceId noise.
-        if: failure() && env.DEPLOY_SKIP_REASON != 'intentional_stopped'
+        if: failure() && env.DEPLOY_SKIP_REASON == ''
         # When the deploy fails AFTER the binary is in place, systemd's
         # Restart=always keeps relaunching it every few seconds. If each
         # boot reaches the auth step (it does after PR #921/#922), each
@@ -683,7 +716,7 @@ jobs:
         # purpose, auto push outside the up-window) is NOT a failure worth
         # paging the operator at 2 AM. The 08:45 IST pre-market cron redeploys.
         # Genuine deploy failures (box up, smoke test failed, etc.) still page.
-        if: failure() && env.DEPLOY_SKIP_REASON != 'intentional_stopped'
+        if: failure() && env.DEPLOY_SKIP_REASON == ''
         run: |
           aws sns publish \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -609,10 +609,46 @@ fn test_deploy_aws_self_starts_stopped_instance_and_skips_offhours_cleanly() {
         "deploy-aws.yml must set DEPLOY_SKIP_REASON for an off-hours skip"
     );
     assert!(
-        content.contains("env.DEPLOY_SKIP_REASON != 'intentional_stopped'"),
-        "deploy-aws.yml failure-notify + auto-stop steps must be gated on \
-         DEPLOY_SKIP_REASON so an intentional off-hours skip does NOT page the \
+        content.contains("env.DEPLOY_SKIP_REASON == ''"),
+        "deploy-aws.yml failure-notify + auto-stop + fetch-output steps must be \
+         gated on DEPLOY_SKIP_REASON being empty so ANY intentional defer \
+         (off-hours stopped box OR market-hours swap abort) does NOT page the \
          operator (anti-spam)"
+    );
+}
+
+#[test]
+fn test_deploy_aws_regates_market_hours_at_swap_time() {
+    // ROOT-CAUSE FIX 2026-06-02 (incident #2): PR #971 merged at 09:11 IST
+    // (4 min before the 09:15 open), passed the START-time guard_market_hours,
+    // then the ~4-5 min ARM build pushed the SSM binary swap + systemctl
+    // restart to ~09:16 IST — INSIDE market open — blanking the live feed for
+    // ~2 min at the bell. The start-time guard cannot see a build that crosses
+    // the open boundary. This pins the SWAP-time re-gate: immediately before
+    // the SSM swap, deploy-aws re-checks IST market hours and ABORTS (defers
+    // to the 15:31 cron) instead of restarting the live app mid-session.
+    let content =
+        std::fs::read_to_string(workspace_root().join(".github/workflows/deploy-aws.yml"))
+            .expect("deploy-aws.yml must be readable"); // APPROVED: test
+    assert!(
+        content.contains("Re-gate market hours at SWAP time"),
+        "deploy-aws.yml must re-check market hours immediately before the SSM \
+         binary swap (a build that started pre-open can cross the 09:15 boundary)"
+    );
+    assert!(
+        content.contains("market_hours_swap_abort"),
+        "the swap-time re-gate must set DEPLOY_SKIP_REASON=market_hours_swap_abort \
+         so the deferred run does not page the operator + the 15:31 cron redeploys"
+    );
+    // The swap-time gate must encode the 09:15-15:30 IST window (915/1530) and
+    // honour the same operator override as the start-time guard.
+    assert!(
+        content.contains("915") && content.contains("1530"),
+        "swap-time re-gate must encode the 09:15-15:30 IST market window (915/1530)"
+    );
+    assert!(
+        content.contains("confirm_market_hours"),
+        "swap-time re-gate must keep the workflow_dispatch confirm_market_hours override"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes the hole that blanked the live feed at today's open. **PR #971 merged at 09:11:21 IST** (4 min before the 09:15 open), passed the *start-time* `guard_market_hours`, then the ~4–5 min ARM build pushed the SSM binary swap + `systemctl restart` to **~09:16 IST — inside market open**. That restart blanked the feed for ~2 min at the bell (`recent_tick` SELFTEST-02 failed 09:15; ticks resumed after FAST BOOT 09:17).

**Root cause:** `guard_market_hours` checks the clock at *job start*; it cannot see a build that crosses the 09:15 boundary before the swap lands.

(Clean re-open of #973, which went `dirty` due to the #971/#972 squash-merge divergence; this branch is rebased onto current main — diff is exactly the 2 swap-regate files.)

## Fix
- [x] New **"Re-gate market hours at SWAP time"** step runs immediately before the SSM swap. If now is inside 09:15–15:30 IST Mon–Fri, it **ABORTS before touching the box** (binary already built + in S3) and lets the 15:31 IST post-market cron redeploy. Honours the same `workflow_dispatch confirm_market_hours=yes` override as the start guard.
- [x] `DEPLOY_SKIP_REASON=market_hours_swap_abort` suppresses the failure Telegram (intentional defer, not failure); run stays non-success so the cron re-fires.
- [x] Generalized the failure-notify / auto-stop / fetch-output gates to suppress on **any** `DEPLOY_SKIP_REASON` (`== ''`).
- [x] Ratchet `test_deploy_aws_regates_market_hours_at_swap_time`.

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` → 31 passed
- [x] `deploy-aws.yml` parses as YAML

🤖 https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_