### PR TITLE
fix(observability): report real-tick freshness in "live and ready" message (false-OK fix)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5429,12 +5429,24 @@ async fn emit_websocket_connected_alerts(
     let boot_wall_clock_secs = boot_start.elapsed().as_secs_f64();
 
     if connected_count == total {
+        // Real-tick freshness (not frame freshness): the most-recent GENUINE
+        // tick across all instruments, sourced from the global TickGapDetector
+        // (populated only by real tick frames, never Dhan keep-alive pings).
+        // `None` => zero real ticks captured yet. Surfacing this in the
+        // "live and ready" message closes the 2026-06-02 false-OK where the
+        // per-feed "last update Xs ago" counted pings and could read healthy
+        // while no real ticks flowed. Cold path — once per boot summary.
+        let last_real_tick_age_secs =
+            tickvault_core::pipeline::tick_gap_detector::global_tick_gap_detector()
+                .and_then(|d| d.freshest_tick_age_secs(std::time::Instant::now()))
+                .and_then(|secs| u32::try_from(secs).ok());
         notifier.notify(NotificationEvent::WebSocketPoolOnline {
             connected: connected_count,
             total,
             per_connection,
             boot_path,
             boot_wall_clock_secs,
+            last_real_tick_age_secs,
         });
     } else if !tickvault_common::market_hours::is_within_market_hours_ist() {
         // 2026-05-09: off-hours boot — non-connected slots are

--- a/crates/app/tests/ws_pool_online_truthful_emit_guard.rs
+++ b/crates/app/tests/ws_pool_online_truthful_emit_guard.rs
@@ -34,6 +34,7 @@ fn pool_online_message_for_fully_connected_pool_says_live() {
         ],
         boot_path: BootPathLabel::Slow,
         boot_wall_clock_secs: 11.2,
+        last_real_tick_age_secs: Some(3),
     };
     let msg = event.to_message();
     assert!(
@@ -110,6 +111,7 @@ fn pool_online_severity_is_low_partial_is_high() {
         per_connection: vec![(5_000, 5_000, Some(1)); 5],
         boot_path: BootPathLabel::Slow,
         boot_wall_clock_secs: 10.0,
+        last_real_tick_age_secs: Some(1),
     };
     let partial = NotificationEvent::WebSocketPoolPartialAfterDeadline {
         connected: 0,
@@ -170,4 +172,44 @@ fn boot_path_label_human_strings_are_distinct() {
     assert_ne!(BootPathLabel::Slow.human(), BootPathLabel::Fast.human());
     assert!(BootPathLabel::Slow.human().contains("Normal"));
     assert!(BootPathLabel::Fast.human().contains("crash recovery"));
+}
+
+// 2026-06-02 false-OK fix: the "live and ready" pool-online message must report
+// REAL-tick freshness (not raw frame freshness, which counts Dhan keep-alive
+// pings). These ratchets pin both paths so a future edit cannot silently drop
+// the real-tick line and let "live" look green on a ping-only feed.
+#[test]
+fn pool_online_shows_real_tick_age_when_ticks_flowing() {
+    let event = NotificationEvent::WebSocketPoolOnline {
+        connected: 1,
+        total: 1,
+        per_connection: vec![(243, 5_000, Some(0))],
+        boot_path: BootPathLabel::Slow,
+        boot_wall_clock_secs: 0.9,
+        last_real_tick_age_secs: Some(2),
+    };
+    let msg = event.to_message();
+    assert!(
+        msg.contains("Real market ticks: last one 2s ago"),
+        "pool-online must report real-tick freshness when ticks are flowing; got: {msg}"
+    );
+}
+
+#[test]
+fn pool_online_warns_when_no_real_ticks_only_pings() {
+    let event = NotificationEvent::WebSocketPoolOnline {
+        connected: 1,
+        total: 1,
+        // Frame freshness Some(0) ("0s ago") would look healthy, but zero real
+        // ticks => the message MUST warn, not read green.
+        per_connection: vec![(243, 5_000, Some(0))],
+        boot_path: BootPathLabel::Slow,
+        boot_wall_clock_secs: 0.9,
+        last_real_tick_age_secs: None,
+    };
+    let msg = event.to_message();
+    assert!(
+        msg.contains("NONE captured yet") && msg.contains("keep-alive pings"),
+        "pool-online must warn (not look green) when zero real ticks captured; got: {msg}"
+    );
 }

--- a/crates/core/src/notification/events.rs
+++ b/crates/core/src/notification/events.rs
@@ -292,6 +292,13 @@ pub enum NotificationEvent {
         per_connection: Vec<(usize, usize, Option<u32>)>,
         boot_path: BootPathLabel,
         boot_wall_clock_secs: f64,
+        /// Age (secs) of the most-recent REAL tick across all instruments,
+        /// or `None` if zero real ticks captured yet. Sourced from
+        /// `TickGapDetector::freshest_tick_age_secs` (real ticks only —
+        /// never pings). Closes the 2026-06-02 false-OK where the per-feed
+        /// "last update Xs ago" counted Dhan keep-alive pings and could
+        /// read healthy while no real ticks were captured.
+        last_real_tick_age_secs: Option<u32>,
     },
 
     /// Aggregate pool-degraded summary — fires when only a subset of
@@ -1275,6 +1282,7 @@ fn format_pool_online_message(
     per_connection: &[(usize, usize, Option<u32>)],
     boot_path: BootPathLabel,
     boot_wall_clock_secs: f64,
+    last_real_tick_age_secs: Option<u32>,
 ) -> String {
     let total_subscribed: usize = per_connection.iter().map(|(s, _, _)| *s).sum();
     let total_capacity: usize = per_connection.iter().map(|(_, c, _)| *c).sum();
@@ -1294,6 +1302,19 @@ fn format_pool_online_message(
         cap = format_with_commas(total_capacity),
         pct = pool_pct,
     ));
+    // Real-tick freshness (NOT frame freshness). The per-feed "last update"
+    // line below counts ANY frame incl. Dhan keep-alive pings, so it can read
+    // "0s ago" while zero real ticks are captured. This line reports the
+    // most-recent GENUINE tick so "live" can never look green on a ping-only
+    // feed (2026-06-02 false-OK fix).
+    match last_real_tick_age_secs {
+        Some(age) => out.push_str(&format!("📈 Real market ticks: last one {age}s ago\n\n")),
+        None => out.push_str(
+            "⚠️ Real market ticks: NONE captured yet — feed may be sending only \
+             keep-alive pings. If this persists after market open, the feed is \
+             connected but not delivering data.\n\n",
+        ),
+    }
     out.push_str("Per feed:\n");
     for (idx, (sub, cap, last)) in per_connection.iter().enumerate() {
         let display = idx.saturating_add(1);
@@ -1490,12 +1511,14 @@ impl NotificationEvent {
                 per_connection,
                 boot_path,
                 boot_wall_clock_secs,
+                last_real_tick_age_secs,
             } => format_pool_online_message(
                 *connected,
                 *total,
                 per_connection,
                 *boot_path,
                 *boot_wall_clock_secs,
+                *last_real_tick_age_secs,
             ),
             Self::WebSocketPoolPartialAfterDeadline {
                 connected,

--- a/crates/core/src/pipeline/tick_gap_detector.rs
+++ b/crates/core/src/pipeline/tick_gap_detector.rs
@@ -89,6 +89,25 @@ impl TickGapDetector {
         pin.insert((security_id, segment), now);
     }
 
+    /// Age (seconds) of the MOST-RECENT real tick across ALL instruments,
+    /// or `None` if no tick has ever been recorded (map empty).
+    ///
+    /// This is the "are real market ticks actually flowing?" signal —
+    /// the map is populated ONLY from genuine parsed tick frames
+    /// (`record_tick`), never from WebSocket keep-alive pings. It exists
+    /// so operator-facing health messages can report real-tick freshness
+    /// instead of raw frame freshness (which counts pings and can read
+    /// "0s ago / healthy" while zero real ticks are captured — the
+    /// 2026-06-02 false-OK). Cold path: called once per heartbeat, NOT on
+    /// the hot loop.
+    #[must_use]
+    pub fn freshest_tick_age_secs(&self, now: Instant) -> Option<u64> {
+        let pin = self.last_seen.pin();
+        pin.iter()
+            .map(|(_, last)| now.saturating_duration_since(*last).as_secs())
+            .min()
+    }
+
     /// Returns the list of `(security_id, segment, gap_secs)` for every
     /// instrument silent ≥ `threshold_secs`. Cold path — called once
     /// per coalesce window from a background task.
@@ -457,6 +476,33 @@ mod tests {
         // The hot-path call site must NOT panic when no detector is
         // installed (test binaries that don't call set_*).
         record_tick_global(13, ExchangeSegment::IdxI, Instant::now());
+    }
+
+    #[test]
+    fn test_freshest_tick_age_secs_none_when_empty() {
+        // No ticks ever recorded => None (the "zero real ticks captured"
+        // signal that drives the live-message ping-only warning).
+        let d = TickGapDetector::new(30);
+        assert_eq!(d.freshest_tick_age_secs(Instant::now()), None);
+    }
+
+    #[test]
+    fn test_freshest_tick_age_secs_returns_most_recent_across_instruments() {
+        // Records two ticks at different ages; freshest = the smallest age.
+        let d = TickGapDetector::new(30);
+        let now = Instant::now();
+        // Older tick (10s ago) + newer tick (2s ago).
+        d.record_tick(
+            13,
+            ExchangeSegment::IdxI,
+            now - std::time::Duration::from_secs(10),
+        );
+        d.record_tick(
+            25,
+            ExchangeSegment::IdxI,
+            now - std::time::Duration::from_secs(2),
+        );
+        assert_eq!(d.freshest_tick_age_secs(now), Some(2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the latent false-OK found during today's incident audit: the **"✅ TickVault is live and ready to trade"** message's per-feed *"last update Xs ago"* counts **any** WebSocket frame **including Dhan keep-alive pings** (every 10s, `connection.rs:1192` bumps the gauge on every `Some(Ok(_))`). So it can read **"0s ago / healthy"** while **zero real ticks** are captured — exactly the "feed connected but 0 ticks" confusion at this morning's open.

**Your alerting was already truthful** (the `recent_tick` self-test reads real-tick freshness and fired SELFTEST-02 correctly) — this fixes the *message* so the green signal can't mislead at a glance.

## Changes
- [x] `tick_gap_detector.rs`: `freshest_tick_age_secs()` — age of the most-recent **real** tick across all instruments (the map is populated only by genuine tick frames, never pings); `None` = zero captured. Cold path. + 2 unit tests.
- [x] `events.rs`: `WebSocketPoolOnline` gains `last_real_tick_age_secs`; the message now prints **"📈 Real market ticks: last one Xs ago"** or a **"⚠️ NONE captured yet — feed may be sending only keep-alive pings"** warning.
- [x] `main.rs`: sources it from the global `TickGapDetector` at emit.
- [x] 2 ratchet tests pin both the flowing and ping-only paths (`ws_pool_online_truthful_emit_guard.rs`).

## Honest envelope
Additive: the existing per-feed frame-freshness line is kept; this adds the **real-tick** truth alongside, so "live" can never look green on a ping-only feed. No existing alert removed. Serves your zero-silent-failure rule.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo test -p tickvault-app --test ws_pool_online_truthful_emit_guard` → 8 passed (incl. 2 new)
- [x] `cargo test -p tickvault-core --lib freshest_tick_age` → 2 passed
- [x] pre-commit + pre-push gates green

🤖 https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_