### PR TITLE
fix(alarms): stop 2 CloudWatch alarms false-firing during off-window

### DIFF
--- a/deploy/aws/terraform/app-alarms.tf
+++ b/deploy/aws/terraform/app-alarms.tf
@@ -54,7 +54,15 @@ resource "aws_cloudwatch_metric_alarm" "ws_pool_all_dead" {
   period              = 60
   statistic           = "Maximum"
   threshold           = 0
-  treat_missing_data  = "breaching"
+  # notBreaching (was "breaching", 2026-06-02): the metric is emitted ONLY
+  # while the app runs. On the scheduled weekday 16:30 IST stop, weekends, or
+  # any deploy / CloudWatch-agent gap, the metric goes missing — and
+  # "breaching" held this alarm STUCK FIRING across the gap (operator saw it
+  # firing on the portal while the box was up + ticks flowing). App-death
+  # WHILE the box is up is still caught by systemd Restart=always + the in-app
+  # tick-gap Telegram + the EC2 instance-status alarm. Matches the sibling
+  # ws_failed_connections alarm below.
+  treat_missing_data  = "notBreaching"
   dimensions          = local.app_dimensions
   alarm_actions       = local.app_alarm_actions
   ok_actions          = local.app_alarm_ok
@@ -92,7 +100,11 @@ resource "aws_cloudwatch_metric_alarm" "order_update_ws_inactive" {
   period              = 60
   statistic           = "Minimum"
   threshold           = 1
-  treat_missing_data  = "breaching"
+  # notBreaching (was "breaching", 2026-06-02): same stale-FIRING fix as
+  # ws_pool_all_dead above — the metric is missing whenever the box is
+  # intentionally stopped (16:30 IST / weekends) or during a deploy gap, and
+  # "breaching" held this alarm stuck FIRING across that gap.
+  treat_missing_data  = "notBreaching"
   dimensions          = local.app_dimensions
   alarm_actions       = local.app_alarm_actions
   ok_actions          = local.app_alarm_ok

--- a/deploy/aws/terraform/app-alarms.tf
+++ b/deploy/aws/terraform/app-alarms.tf
@@ -43,6 +43,12 @@ locals {
 
 # ---------------------------------------------------------------------------
 # 1. Main-feed WebSocket pool dead — every conn dropped, no live ticks
+# treat_missing_data = notBreaching (was "breaching", 2026-06-02): the metric
+# is emitted ONLY while the app runs, so on the scheduled weekday 16:30 IST
+# stop / weekends / any deploy gap the metric goes missing and "breaching"
+# held this alarm STUCK FIRING across the gap (operator saw it firing while the
+# box was up + ticks flowing). App-death while the box is up is still caught by
+# systemd Restart=always + the in-app tick-gap Telegram + the EC2 status alarm.
 # ---------------------------------------------------------------------------
 resource "aws_cloudwatch_metric_alarm" "ws_pool_all_dead" {
   alarm_name          = "tv-${var.environment}-ws-pool-all-dead"
@@ -54,14 +60,6 @@ resource "aws_cloudwatch_metric_alarm" "ws_pool_all_dead" {
   period              = 60
   statistic           = "Maximum"
   threshold           = 0
-  # notBreaching (was "breaching", 2026-06-02): the metric is emitted ONLY
-  # while the app runs. On the scheduled weekday 16:30 IST stop, weekends, or
-  # any deploy / CloudWatch-agent gap, the metric goes missing — and
-  # "breaching" held this alarm STUCK FIRING across the gap (operator saw it
-  # firing on the portal while the box was up + ticks flowing). App-death
-  # WHILE the box is up is still caught by systemd Restart=always + the in-app
-  # tick-gap Telegram + the EC2 instance-status alarm. Matches the sibling
-  # ws_failed_connections alarm below.
   treat_missing_data  = "notBreaching"
   dimensions          = local.app_dimensions
   alarm_actions       = local.app_alarm_actions
@@ -89,6 +87,10 @@ resource "aws_cloudwatch_metric_alarm" "ws_failed_connections" {
 
 # ---------------------------------------------------------------------------
 # 3. Order-update WebSocket down — orders fly blind
+# treat_missing_data = notBreaching (was "breaching", 2026-06-02): same
+# stale-FIRING fix as ws_pool_all_dead — the metric is missing whenever the box
+# is intentionally stopped (16:30 IST / weekends) or during a deploy gap, and
+# "breaching" held this alarm stuck FIRING across that gap.
 # ---------------------------------------------------------------------------
 resource "aws_cloudwatch_metric_alarm" "order_update_ws_inactive" {
   alarm_name          = "tv-${var.environment}-order-update-ws-inactive"
@@ -100,10 +102,6 @@ resource "aws_cloudwatch_metric_alarm" "order_update_ws_inactive" {
   period              = 60
   statistic           = "Minimum"
   threshold           = 1
-  # notBreaching (was "breaching", 2026-06-02): same stale-FIRING fix as
-  # ws_pool_all_dead above — the metric is missing whenever the box is
-  # intentionally stopped (16:30 IST / weekends) or during a deploy gap, and
-  # "breaching" held this alarm stuck FIRING across that gap.
   treat_missing_data  = "notBreaching"
   dimensions          = local.app_dimensions
   alarm_actions       = local.app_alarm_actions


### PR DESCRIPTION
## Summary

First fix from the deep false-OK hardening sweep you asked for. The 2 alarms you saw **firing on the portal while the box was up + ticks flowing** (`tv-prod-ws-pool-all-dead`, `tv-prod-order-update-ws-inactive`) were **false-FIRING**: both used `treat_missing_data = "breaching"`, and their metrics are emitted **only while the app runs**. On the scheduled **16:30 IST stop**, weekends, or any deploy / CloudWatch-agent gap, the metric goes missing → CloudWatch held them **stuck in ALARM** across the gap.

## Fix
- [x] `app-alarms.tf`: `ws_pool_all_dead` + `order_update_ws_inactive` → `treat_missing_data = "notBreaching"` (matches the sibling `ws_failed_connections` alarm).

## Honest envelope
App-death *while the box is up* is still caught by 3 other layers — systemd `Restart=always`, the in-app tick-gap Telegram, and the EC2 instance-status alarm — so this only removes the **false** firing during the intentional off-window, not real detection.

## Deploy
Terraform-only → lands via `terraform-apply` (infra workflow), independent of the market-hours app deploy.

🤖 https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_