### PR TITLE
feat(aws): widen instance window to 08:00–17:00 IST (pre/post-market + deploy room)

### DIFF
--- a/.claude/rules/project/daily-universe-scope-expansion-2026-05-27.md
+++ b/.claude/rules/project/daily-universe-scope-expansion-2026-05-27.md
@@ -38,6 +38,7 @@
 - 2026-05-27: Approved options X–Z (EventBridge cron at 08:30 IST, `lifecycle_state_locked` column for operator overrides, `--dry-run-universe` CLI flag for first prod validation)
 - 2026-05-29: Approved instance m8g.large (Graviton4, 8 GiB) + weekday-only 08:30–16:30 IST auto schedule (manual start otherwise) per Quote 5
 - 2026-05-29: Approved EBS 100 GB + EIP excluded (no orders) + 270-hr basis → ~₹2,698/mo incl GST per Quote 6
+- 2026-06-02: Operator WIDENED the schedule from 08:30–16:30 IST to **08:00–17:00 IST** (verbatim: "instead of 8.30 am make it as 8 am till 5 pm dude so that pre-market and post-market and deployment and all other activities can run without any worries"). Crons: start `cron(30 2 ? * MON-FRI *)` (02:30 UTC = 08:00 IST), stop `cron(30 11 ? * MON-FRI *)` (11:30 UTC = 17:00 IST). Cost: +1 hr/day (~+₹120/mo), still inside the ~₹2,058/mo envelope. This dated quote satisfies §7 Mechanical Rule 1 for the schedule change.
 
 ---
 
@@ -178,7 +179,7 @@ the `m8gd` local-SSD variant — that NVMe is wiped on every daily auto-stop).
 | Region | ap-south-1 (Mumbai) |
 | Tenancy | Default (Shared) |
 | Pricing | On-demand **$0.06416/hr** (live ap-south-1, 2026-05-29) — no Reserved / Savings Plan / Spot |
-| Schedule | **Trading weekdays only (Mon–Fri), 08:30–16:30 IST auto** (start `cron(0 3 ? * MON-FRI *)`, stop `cron(0 11 ? * MON-FRI *)`). Out-of-window runs = operator manual start. Weekends + holidays = OFF unless manually started. |
+| Schedule | **Trading weekdays only (Mon–Fri), 08:00–17:00 IST auto** (start `cron(30 2 ? * MON-FRI *)`, stop `cron(30 11 ? * MON-FRI *)`) — widened from 08:30–16:30 on 2026-06-02 per operator (pre/post-market + deploy room). Out-of-window runs = operator manual start. Weekends + holidays = OFF unless manually started. |
 | EBS | gp3 10 GB (unchanged) |
 | EIP | 1 (24/7, Dhan static-IP mandate — unchanged) |
 | Network | ENA enabled by default |

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -301,11 +301,12 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -uo pipefail
-          # Up-window = 08:30-16:30 IST Mon-Fri (the EventBridge schedule window).
+          # Up-window = 08:00-17:00 IST Mon-Fri (the EventBridge schedule window;
+          # widened from 08:30-16:30 on 2026-06-02 per operator).
           DOW=$(TZ='Asia/Kolkata' date +%u)            # 1=Mon..7=Sun
           HHMM=$(TZ='Asia/Kolkata' date +%H%M); HHMM=$((10#$HHMM))
           UP_WINDOW=no
-          if [ "$DOW" -le 5 ] && [ "$HHMM" -ge 830 ] && [ "$HHMM" -le 1630 ]; then UP_WINDOW=yes; fi
+          if [ "$DOW" -le 5 ] && [ "$HHMM" -ge 800 ] && [ "$HHMM" -le 1700 ]; then UP_WINDOW=yes; fi
           # A manual run or the after-close cron dispatch (workflow_dispatch)
           # always intends the box up — self-start regardless of clock.
           SHOULD_BE_UP=no

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -226,27 +226,29 @@ fn test_terraform_instance_iam_allows_staging_ssm_prefix() {
 fn test_terraform_eventbridge_schedules_match_budget() {
     let content = std::fs::read_to_string(workspace_root().join("deploy/aws/terraform/main.tf"))
         .expect("main.tf must be readable"); // APPROVED: test
-    // Weekday start: 08:30 IST = 03:00 UTC Mon-Fri (operator-lock 2026-05-29,
-    // daily-universe-scope-expansion-2026-05-27.md §7 Quote 5 — trading
-    // weekdays only, 08:30-16:30 IST; SUPERSEDES the 2026-05-18 7-day cron).
+    // Weekday start: 08:00 IST = 02:30 UTC Mon-Fri (operator widened the
+    // window to 08:00-17:00 on 2026-06-02 — "make it as 8 am till 5 pm … so
+    // pre-market and post-market and deployment … can run without worries";
+    // supersedes the 2026-05-29 08:30-16:30 lock §7).
     assert!(
-        content.contains("cron(0 3 ? * MON-FRI *)"),
-        "main.tf missing weekday start schedule (03:00 UTC Mon-Fri = 08:30 IST)"
+        content.contains("cron(30 2 ? * MON-FRI *)"),
+        "main.tf missing weekday start schedule (02:30 UTC Mon-Fri = 08:00 IST)"
     );
-    // Weekday stop: 16:30 IST = 11:00 UTC Mon-Fri.
+    // Weekday stop: 17:00 IST = 11:30 UTC Mon-Fri.
     assert!(
-        content.contains("cron(0 11 ? * MON-FRI *)"),
-        "main.tf missing weekday stop schedule (11:00 UTC Mon-Fri = 16:30 IST)"
+        content.contains("cron(30 11 ? * MON-FRI *)"),
+        "main.tf missing weekday stop schedule (11:30 UTC Mon-Fri = 17:00 IST)"
     );
-    // Negative asserts — the prior 7-day daily crons (02:30/11:30 UTC every
-    // day) were replaced by the weekday-only pair per operator lock 2026-05-29.
+    // Negative asserts — the prior 7-day daily crons (every day, no MON-FRI
+    // restriction) must NOT return. The weekday-only `? * MON-FRI` form is
+    // distinct from the retired 7-day `* * ?` form.
     assert!(
         !content.contains("cron(30 2 * * ? *)"),
-        "7-day daily start cron retired in operator-lock 2026-05-29 (weekday-only now)"
+        "7-day daily start cron retired (weekday-only now)"
     );
     assert!(
         !content.contains("cron(30 11 * * ? *)"),
-        "7-day daily stop cron retired in operator-lock 2026-05-29 (weekday-only now)"
+        "7-day daily stop cron retired (weekday-only now)"
     );
 }
 
@@ -558,8 +560,8 @@ fn test_aws_autopilot_selfheal_workflow_exists() {
          08:30 EventBridge start is not rescued until 09:00 (2026-06-02 incident)"
     );
     assert!(
-        sh.contains("830") && sh.contains("1630"),
-        "is_box_up_window must encode the 08:30-16:30 IST bounds (830/1630)"
+        sh.contains("800") && sh.contains("1700"),
+        "is_box_up_window must encode the 08:00-17:00 IST bounds (800/1700)"
     );
     // 2026-06-02 diagnostic (the 'A' fix): when the box is stopped during the
     // up-window, autopilot must report WHY the EventBridge auto-start failed

--- a/crates/storage/tests/aws_deploy_safety_guard.rs
+++ b/crates/storage/tests/aws_deploy_safety_guard.rs
@@ -114,17 +114,18 @@ fn deploy_instance_ignores_type_and_user_data_to_prevent_replace() {
 }
 
 /// Weekday-only schedule (trading days). Mon-Fri crons, not Mon-Sun.
-/// IST 08:30 start = 03:00 UTC; IST 16:30 stop = 11:00 UTC.
+/// IST 08:00 start = 02:30 UTC; IST 17:00 stop = 11:30 UTC (operator widened
+/// the window to 08:00-17:00 on 2026-06-02 for pre/post-market + deploy room).
 #[test]
 fn deploy_schedule_is_weekday_only() {
     let body = read(MAIN_TF);
     assert!(
-        body.contains("cron(0 3 ? * MON-FRI *)"),
-        "main.tf daily_start must be `cron(0 3 ? * MON-FRI *)` (08:30 IST, Mon-Fri)."
+        body.contains("cron(30 2 ? * MON-FRI *)"),
+        "main.tf daily_start must be `cron(30 2 ? * MON-FRI *)` (08:00 IST, Mon-Fri)."
     );
     assert!(
-        body.contains("cron(0 11 ? * MON-FRI *)"),
-        "main.tf daily_stop must be `cron(0 11 ? * MON-FRI *)` (16:30 IST, Mon-Fri)."
+        body.contains("cron(30 11 ? * MON-FRI *)"),
+        "main.tf daily_stop must be `cron(30 11 ? * MON-FRI *)` (17:00 IST, Mon-Fri)."
     );
     assert!(
         !body.contains("MON-SUN") && !body.contains("* * ? * * *"),
@@ -134,17 +135,22 @@ fn deploy_schedule_is_weekday_only() {
 
 /// EIP off by default (no orders for 3 months → no Dhan static-IP need).
 #[test]
-fn deploy_eip_is_disabled_by_default() {
+fn deploy_eip_is_enabled_by_default() {
     let vars = squish(&read(VARIABLES_TF));
     assert!(
         vars.contains("variable \"enable_eip\""),
         "variables.tf must declare `enable_eip`."
     );
-    // The default false must appear within the enable_eip block. We assert the
-    // bool default is present and that no `default = true` shadows it.
+    // 2026-05-31: operator flipped enable_eip default false -> true. The manual
+    // t4g -> m8g.large upgrade left the ENI with auto-assign-public-IP OFF, so
+    // the box had NO public IP / no internet path (SSM showed 0 managed nodes,
+    // deploy InvalidInstanceId) until an EIP was attached. EIP is now mandatory.
+    // This guard was previously asserting `default = false` (stale) — updated to
+    // match the operator-approved reality.
     assert!(
-        vars.contains("type = bool default = false"),
-        "enable_eip must default to false (no orders 3mo → no EIP → ~₹430/mo saved)."
+        vars.contains("type = bool default = true"),
+        "enable_eip must default to true (operator 2026-05-31 — EIP mandatory; \
+         without it the box has no public IP / no SSM / no Dhan path)."
     );
     let main = squish(&code_only(&read(MAIN_TF)));
     assert!(

--- a/crates/storage/tests/instance_type_lock_guard.rs
+++ b/crates/storage/tests/instance_type_lock_guard.rs
@@ -144,17 +144,16 @@ fn instance_lock_monthly_bill_pinned_to_rupees_2058() {
     );
 }
 
-/// Section D — the schedule lock must mention `08:30 IST` (operator
-/// option X approval, 2026-05-27). Earlier 08:00 IST schedule would
-/// not give enough cold-boot + retry budget for the 08:45 IST CSV
-/// fetch deadline.
+/// Section D — the schedule lock must mention `08:00 IST` (operator widened
+/// the window to 08:00-17:00 on 2026-06-02: "make it as 8 am till 5 pm … so
+/// pre-market and post-market and deployment … can run without worries").
 #[test]
-fn instance_lock_schedule_pinned_to_0830_ist_start() {
+fn instance_lock_schedule_pinned_to_0800_ist_start() {
     let root = repo_root();
     let body =
         read(&root.join(".claude/rules/project/daily-universe-scope-expansion-2026-05-27.md"));
     assert!(
-        body.contains("08:30–17:00 IST") || body.contains("08:30 IST"),
-        "rule file §7 must pin the 08:30 IST EventBridge cron start"
+        body.contains("08:00–17:00 IST") || body.contains("08:00 IST"),
+        "rule file §7 must pin the 08:00 IST EventBridge cron start"
     );
 }

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -347,26 +347,31 @@ resource "aws_cloudwatch_log_group" "tv_app" {
 }
 
 # ---------------------------------------------------------------------------
-# EventBridge weekday start/stop schedule per daily-universe-scope-
-# expansion-2026-05-27.md §7 Quote 5 (2026-05-29): trading WEEKDAYS only
-# (Mon-Fri), 08:30-16:30 IST. Weekends + NSE holidays = instance OFF unless
-# the operator manually starts it. Rules call SSM Automation to start/stop.
+# EventBridge weekday start/stop schedule. Operator widened the window to
+# 08:00-17:00 IST on 2026-06-02 (verbatim: "instead of 8.30 am make it as 8 am
+# till 5 pm dude so that pre-market and post-market and deployment and all
+# other activities can run without any worries") — supersedes the 2026-05-29
+# 08:30-16:30 lock in daily-universe-scope-expansion-2026-05-27.md §7. Trading
+# WEEKDAYS only (Mon-Fri); weekends + NSE holidays = instance OFF unless the
+# operator manually starts it. Rules call SSM Automation to start/stop.
+#
+# Cost: +1 hr/day (~+₹120/mo); still inside the ~₹2,058/mo budget envelope.
 #
 # IST offset is UTC+5:30, so:
-#   Weekday start 08:30 IST = 03:00 UTC (Mon-Fri)
-#   Weekday stop  16:30 IST = 11:00 UTC (Mon-Fri)
+#   Weekday start 08:00 IST = 02:30 UTC (Mon-Fri)
+#   Weekday stop  17:00 IST = 11:30 UTC (Mon-Fri)
 # ---------------------------------------------------------------------------
 
 resource "aws_cloudwatch_event_rule" "daily_start" {
   name                = "tv-${var.environment}-daily-start"
-  description         = "Start tickvault instance at 08:30 IST on trading weekdays (Mon-Fri)"
-  schedule_expression = "cron(0 3 ? * MON-FRI *)"
+  description         = "Start tickvault instance at 08:00 IST on trading weekdays (Mon-Fri)"
+  schedule_expression = "cron(30 2 ? * MON-FRI *)"
 }
 
 resource "aws_cloudwatch_event_rule" "daily_stop" {
   name                = "tv-${var.environment}-daily-stop"
-  description         = "Stop tickvault instance at 16:30 IST on trading weekdays (Mon-Fri)"
-  schedule_expression = "cron(0 11 ? * MON-FRI *)"
+  description         = "Stop tickvault instance at 17:00 IST on trading weekdays (Mon-Fri)"
+  schedule_expression = "cron(30 11 ? * MON-FRI *)"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/aws-autopilot.sh
+++ b/scripts/aws-autopilot.sh
@@ -66,7 +66,7 @@ is_market_window() {
   [ "$dow" -le 5 ] && [ "$t" -ge 900 ] && [ "$t" -le 1535 ]
 }
 
-# --- up-window (IST) helper: is now within 08:30-16:30 IST Mon-Fri? ----------
+# --- up-window (IST) helper: is now within 08:00-17:00 IST Mon-Fri? ----------
 # This is the EventBridge START/STOP schedule window — the box is SUPPOSED to
 # be running for the WHOLE of it, not just market hours (09:15-15:30). The
 # pre-market gap (08:30-09:00) is when the daily universe is fetched + the WS
@@ -79,7 +79,7 @@ is_box_up_window() {
   h=$(TZ='Asia/Kolkata' date +%H); m=$(TZ='Asia/Kolkata' date +%M)
   dow=$(TZ='Asia/Kolkata' date +%u)   # 1=Mon..7=Sun
   t=$((10#$h * 100 + 10#$m))
-  [ "$dow" -le 5 ] && [ "$t" -ge 830 ] && [ "$t" -le 1630 ]
+  [ "$dow" -le 5 ] && [ "$t" -ge 800 ] && [ "$t" -le 1700 ]
 }
 
 # --- diagnostic: is the EventBridge daily-start rule healthy? ----------------


### PR DESCRIPTION
## Summary

Operator 2026-06-02: *"instead of 8.30 am make it as 8 am till 5 pm dude so that pre-market and post-market and deployment and all other activities can run without any worries."* Widens the instance up-window from **08:30–16:30 → 08:00–17:00 IST** (weekday-only, unchanged). More room before the 09:15 open (universe fetch + pre-market deploy) and after the 15:30 close (digest + post-market deploy).

## Changes
- [x] `main.tf` EventBridge crons: start `cron(0 3 …)` → **`cron(30 2 ? * MON-FRI *)`** (02:30 UTC = 08:00 IST); stop `cron(0 11 …)` → **`cron(30 11 ? * MON-FRI *)`** (11:30 UTC = 17:00 IST).
- [x] `aws-autopilot.sh` `is_box_up_window` + `deploy-aws.yml` ensure-running up-window: 08:30–16:30 → **08:00–17:00**. (The swap-time market-hours re-gate stays **09:15–15:30** — deploys still never restart during *trading*.)
- [x] Ratchets updated: `aws_infra_wiring`, `aws_deploy_safety_guard`, `instance_type_lock_guard`.
- [x] Operator-lock rule file `daily-universe-scope-expansion-2026-05-27.md` §7 updated + **dated operator quote** (per the lock's own §7 Mechanical Rule 1).
- [x] **Drive-by fix:** stale `deploy_eip_is_disabled_by_default` guard — `enable_eip` default was flipped `false→true` on 2026-05-31 (operator; EIP became mandatory after the m8g upgrade left the ENI with no public IP), but the test still asserted `false`. Renamed + corrected to match reality.

## Honest envelope
Cost: +1 hr/day (~+₹120/mo), inside the ~₹2,058/mo budget. Pure schedule/config widening — no app-logic change.

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` → 31 passed
- [x] `cargo test -p tickvault-storage --test aws_deploy_safety_guard --test instance_type_lock_guard` → green

🤖 https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_