### PR TITLE
feat(aws): start-watchdog Lambda — AWS-native monitor for the 08:00 auto-start

### DIFF
--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -834,3 +834,46 @@ fn test_systemd_unit_restart_policy() {
         "systemd unit must send SIGTERM (graceful shutdown handler)"
     );
 }
+
+#[test]
+fn test_start_watchdog_lambda_monitors_the_morning_start() {
+    // 2026-06-02: AWS-native watchdog that answers "who monitors the 08:00
+    // start?". A ping Lambda at 08:00 IST + a check Lambda at 08:15 IST that
+    // pages if the box did not come up. Runs IN AWS (not on a GitHub runner),
+    // so it alerts even if GitHub Actions is down — the gap that hid the
+    // 2026-06-02 silent start failure.
+    require_file_exists(
+        "deploy/aws/lambda/start-watchdog/handler.py",
+        "start-watchdog Lambda handler (ping + check)",
+    );
+    require_file_exists(
+        "deploy/aws/terraform/start-watchdog-lambda.tf",
+        "start-watchdog Lambda terraform (IAM + 2 EventBridge schedules)",
+    );
+    let tf = std::fs::read_to_string(
+        workspace_root().join("deploy/aws/terraform/start-watchdog-lambda.tf"),
+    )
+    .expect("start-watchdog-lambda.tf must be readable"); // APPROVED: test
+    // Ping at 08:00 IST (02:30 UTC) + check at 08:15 IST (02:45 UTC), weekdays.
+    assert!(
+        tf.contains("cron(30 2 ? * MON-FRI *)"),
+        "ping schedule must be 02:30 UTC Mon-Fri (08:00 IST)"
+    );
+    assert!(
+        tf.contains("cron(45 2 ? * MON-FRI *)"),
+        "check schedule must be 02:45 UTC Mon-Fri (08:15 IST)"
+    );
+    // Least-privilege: describe EC2 + publish to the alerts topic.
+    assert!(
+        tf.contains("ec2:DescribeInstances") && tf.contains("aws_sns_topic.tv_alerts.arn"),
+        "watchdog Lambda must describe EC2 + publish to tv_alerts"
+    );
+    let py = std::fs::read_to_string(
+        workspace_root().join("deploy/aws/lambda/start-watchdog/handler.py"),
+    )
+    .expect("handler.py must be readable"); // APPROVED: test
+    assert!(
+        py.contains("describe_instances") && py.contains("\"running\""),
+        "handler must check the instance is running"
+    );
+}

--- a/deploy/aws/lambda/start-watchdog/handler.py
+++ b/deploy/aws/lambda/start-watchdog/handler.py
@@ -1,0 +1,105 @@
+"""Instance start watchdog Lambda — answers "who monitors the 08:00 start?".
+
+Two EventBridge schedules invoke this Lambda with a `mode` input:
+
+  * mode="ping"  @ 08:00 IST (02:30 UTC Mon-Fri) — fires WITH the daily_start
+    EventBridge rule. Publishes a positive "start triggered" Telegram so the
+    operator sees the morning kick-off even before the app boots (~3 min later).
+
+  * mode="check" @ 08:15 IST (02:45 UTC Mon-Fri) — 15 min after the start was
+    triggered. Calls ec2:DescribeInstances; if the box is NOT "running" it
+    publishes a Severity::Critical Telegram ("08:00 auto-start FAILED"). This is
+    the AWS-native answer to the 2026-06-02 incident, where the EventBridge ->
+    SSM-Automation start silently failed and NOTHING alerted the operator until
+    he noticed by hand. Because this Lambda runs IN AWS (not on a GitHub Actions
+    runner like aws-autopilot), it alerts even if the box — or GitHub — is dead.
+
+On a healthy "check" (box running) it stays SILENT — no spam.
+
+Publishes to the operator's `tv_alerts` SNS topic with Subject + Message, the
+same shape the telegram-webhook Lambda (PR #781) already renders.
+
+Environment variables (set by Terraform):
+  EC2_INSTANCE_ID    — the tv-app instance to watch
+  ALERTS_TOPIC_ARN   — operator's tv_alerts SNS topic for Telegram
+  LOG_LEVEL          — INFO (default) / DEBUG / WARNING
+
+No pip deps — boto3 is pre-installed in the AWS Lambda Python 3.12 runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import boto3
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+logger = logging.getLogger()
+logger.setLevel(LOG_LEVEL)
+
+EC2_INSTANCE_ID = os.environ.get("EC2_INSTANCE_ID", "")
+ALERTS_TOPIC_ARN = os.environ.get("ALERTS_TOPIC_ARN", "")
+
+
+def _instance_state(ec2_client: Any, instance_id: str) -> str:
+    """Return the EC2 instance lifecycle state, or 'unknown' on any error.
+
+    Never raises — a watchdog that crashes is worse than one that reports
+    'unknown' (which itself is not 'running' and therefore alerts).
+    """
+    try:
+        resp = ec2_client.describe_instances(InstanceIds=[instance_id])
+        reservations = resp.get("Reservations", [])
+        if not reservations:
+            return "not-found"
+        instances = reservations[0].get("Instances", [])
+        if not instances:
+            return "not-found"
+        return instances[0].get("State", {}).get("Name", "unknown")
+    except Exception as exc:  # noqa: BLE001 — watchdog must never crash
+        logger.error("describe_instances failed: %s", exc)
+        return "unknown"
+
+
+def _publish(sns_client: Any, subject: str, message: str) -> None:
+    if not ALERTS_TOPIC_ARN:
+        logger.warning("ALERTS_TOPIC_ARN unset — cannot publish: %s", subject)
+        return
+    sns_client.publish(TopicArn=ALERTS_TOPIC_ARN, Subject=subject, Message=message)
+
+
+def lambda_handler(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
+    """Entry point. `event["mode"]` selects ping vs check behaviour."""
+    mode = (event or {}).get("mode", "check")
+    logger.info("start-watchdog invoked mode=%s instance=%s", mode, EC2_INSTANCE_ID)
+
+    sns_client = boto3.client("sns")
+
+    if mode == "ping":
+        _publish(
+            sns_client,
+            "Instance start triggered",
+            "🟢 08:00 IST instance start triggered (Mon-Fri). "
+            "The app should report live in ~3 min. "
+            "If you do NOT also get a 'tickvault started' message by 08:10, check the box.",
+        )
+        return {"mode": "ping", "published": True}
+
+    # mode == "check" (default): verify the box actually started.
+    ec2_client = boto3.client("ec2")
+    state = _instance_state(ec2_client, EC2_INSTANCE_ID)
+    if state == "running":
+        logger.info("check OK — instance is running; staying silent")
+        return {"mode": "check", "state": state, "alerted": False}
+
+    _publish(
+        sns_client,
+        "08:00 auto-start FAILED",
+        f"🆘 The 08:00 IST auto-start did NOT bring the box up — it is '{state}' at "
+        f"08:15 IST. Market opens 09:15. Start it NOW: portal 'Start instance' or "
+        f"`aws ec2 start-instances --instance-ids {EC2_INSTANCE_ID} --region ap-south-1`.",
+    )
+    logger.error("check FAILED — instance state=%s — operator paged", state)
+    return {"mode": "check", "state": state, "alerted": True}

--- a/deploy/aws/lambda/start-watchdog/test_handler.py
+++ b/deploy/aws/lambda/start-watchdog/test_handler.py
@@ -1,0 +1,80 @@
+"""Unit tests for the instance start-watchdog Lambda.
+
+No AWS calls — fake SNS/EC2 clients capture publishes + describe results.
+Run: python -m pytest deploy/aws/lambda/start-watchdog/test_handler.py
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any
+
+os.environ.setdefault("EC2_INSTANCE_ID", "i-0test")
+os.environ.setdefault("ALERTS_TOPIC_ARN", "arn:aws:sns:ap-south-1:1:tv-prod-alerts")
+
+handler = importlib.import_module("handler")
+
+
+class _FakeSns:
+    def __init__(self) -> None:
+        self.published: list[dict[str, str]] = []
+
+    def publish(self, *, TopicArn: str, Subject: str, Message: str) -> None:  # noqa: N803
+        self.published.append({"topic": TopicArn, "subject": Subject, "message": Message})
+
+
+class _FakeEc2:
+    def __init__(self, state: str | None) -> None:
+        self._state = state
+
+    def describe_instances(self, *, InstanceIds: list[str]) -> dict[str, Any]:  # noqa: N803
+        if self._state is None:
+            raise RuntimeError("boom")
+        return {"Reservations": [{"Instances": [{"State": {"Name": self._state}}]}]}
+
+
+def test_ping_publishes_positive_signal(monkeypatch) -> None:
+    sns = _FakeSns()
+    monkeypatch.setattr(handler.boto3, "client", lambda svc: sns)
+    out = handler.lambda_handler({"mode": "ping"})
+    assert out["published"] is True
+    assert len(sns.published) == 1
+    assert "start triggered" in sns.published[0]["subject"].lower()
+
+
+def test_check_running_stays_silent(monkeypatch) -> None:
+    sns = _FakeSns()
+    ec2 = _FakeEc2("running")
+    monkeypatch.setattr(handler.boto3, "client", lambda svc: ec2 if svc == "ec2" else sns)
+    out = handler.lambda_handler({"mode": "check"})
+    assert out["alerted"] is False
+    assert sns.published == []  # no spam on a healthy box
+
+
+def test_check_stopped_alerts_critical(monkeypatch) -> None:
+    sns = _FakeSns()
+    ec2 = _FakeEc2("stopped")
+    monkeypatch.setattr(handler.boto3, "client", lambda svc: ec2 if svc == "ec2" else sns)
+    out = handler.lambda_handler({"mode": "check"})
+    assert out["alerted"] is True
+    assert out["state"] == "stopped"
+    assert "FAILED" in sns.published[0]["subject"]
+
+
+def test_check_describe_error_treated_as_not_running(monkeypatch) -> None:
+    sns = _FakeSns()
+    ec2 = _FakeEc2(None)  # describe_instances raises
+    monkeypatch.setattr(handler.boto3, "client", lambda svc: ec2 if svc == "ec2" else sns)
+    out = handler.lambda_handler({"mode": "check"})
+    # An error means we can't confirm 'running' → must alert, not stay silent.
+    assert out["alerted"] is True
+    assert out["state"] == "unknown"
+
+
+def test_default_mode_is_check(monkeypatch) -> None:
+    sns = _FakeSns()
+    ec2 = _FakeEc2("running")
+    monkeypatch.setattr(handler.boto3, "client", lambda svc: ec2 if svc == "ec2" else sns)
+    out = handler.lambda_handler({})
+    assert out["mode"] == "check"

--- a/deploy/aws/terraform/start-watchdog-lambda.tf
+++ b/deploy/aws/terraform/start-watchdog-lambda.tf
@@ -1,0 +1,158 @@
+# Instance start-watchdog Lambda — answers "who monitors the 08:00 start?".
+#
+# 2026-06-02 incident: the EventBridge -> SSM-Automation 08:30 start silently
+# failed and NOTHING alerted the operator until he noticed by hand. aws-autopilot
+# (GitHub Actions, every 15 min) now covers it, but it depends on the GH runner
+# firing. This Lambda is the AWS-native belt-and-suspenders: it runs IN AWS, so
+# it alerts even if GitHub Actions is down.
+#
+# Two EventBridge schedules invoke the same Lambda with a `mode` input:
+#   * ping  @ 02:30 UTC = 08:00 IST (fires with daily_start) -> positive
+#     "start triggered" Telegram.
+#   * check @ 02:45 UTC = 08:15 IST -> ec2:DescribeInstances; if NOT running,
+#     Severity::Critical "08:00 auto-start FAILED" Telegram. Silent if healthy.
+#
+# Cost: 2 invokes/weekday (~44/mo) — free tier (1M req/mo). Effectively ₹0.
+
+# ---------------------------------------------------------------------------
+# IAM — assume + least-privilege (describe EC2 + publish to tv_alerts + logs)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "start_watchdog" {
+  name = "tv-${var.environment}-start-watchdog-lambda"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "start_watchdog" {
+  name = "tv-${var.environment}-start-watchdog-policy"
+  role = aws_iam_role.start_watchdog.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # DescribeInstances has no resource-level scoping in IAM (AWS limitation),
+        # so "*" is required. The Lambda only ever reads EC2_INSTANCE_ID.
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeInstances"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["sns:Publish"]
+        Resource = aws_sns_topic.tv_alerts.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:*:*"
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Lambda source — packaged from deploy/aws/lambda/start-watchdog/
+# ---------------------------------------------------------------------------
+
+data "archive_file" "start_watchdog" {
+  type        = "zip"
+  source_dir  = "${path.module}/../lambda/start-watchdog"
+  output_path = "${path.module}/.start-watchdog.zip"
+  excludes    = ["README.md", "test_handler.py", "__pycache__", "*.pyc"]
+}
+
+resource "aws_lambda_function" "start_watchdog" {
+  function_name    = "tv-${var.environment}-start-watchdog"
+  role             = aws_iam_role.start_watchdog.arn
+  handler          = "handler.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 30
+  memory_size      = 128
+  filename         = data.archive_file.start_watchdog.output_path
+  source_code_hash = data.archive_file.start_watchdog.output_base64sha256
+
+  environment {
+    variables = {
+      EC2_INSTANCE_ID  = aws_instance.tv_app.id
+      ALERTS_TOPIC_ARN = aws_sns_topic.tv_alerts.arn
+      LOG_LEVEL        = "INFO"
+    }
+  }
+
+  tags = {
+    Name    = "tv-${var.environment}-start-watchdog"
+    Project = "tickvault"
+    Layer   = "L1-DETECT"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "start_watchdog" {
+  name              = "/aws/lambda/tv-${var.environment}-start-watchdog"
+  retention_in_days = 30
+  tags = {
+    Project = "tickvault"
+    Layer   = "L1-DETECT"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# EventBridge schedules — ping (08:00 IST) + check (08:15 IST), weekdays
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_event_rule" "start_watchdog_ping" {
+  name                = "tv-${var.environment}-start-watchdog-ping"
+  description         = "08:00 IST (Mon-Fri) positive 'instance start triggered' Telegram"
+  schedule_expression = "cron(30 2 ? * MON-FRI *)"
+}
+
+resource "aws_cloudwatch_event_rule" "start_watchdog_check" {
+  name                = "tv-${var.environment}-start-watchdog-check"
+  description         = "08:15 IST (Mon-Fri) verify the box actually started; page if not"
+  schedule_expression = "cron(45 2 ? * MON-FRI *)"
+}
+
+resource "aws_cloudwatch_event_target" "start_watchdog_ping" {
+  rule      = aws_cloudwatch_event_rule.start_watchdog_ping.name
+  target_id = "start-watchdog-ping"
+  arn       = aws_lambda_function.start_watchdog.arn
+  input     = jsonencode({ mode = "ping" })
+}
+
+resource "aws_cloudwatch_event_target" "start_watchdog_check" {
+  rule      = aws_cloudwatch_event_rule.start_watchdog_check.name
+  target_id = "start-watchdog-check"
+  arn       = aws_lambda_function.start_watchdog.arn
+  input     = jsonencode({ mode = "check" })
+}
+
+resource "aws_lambda_permission" "start_watchdog_ping" {
+  statement_id  = "AllowExecutionFromEventBridgePing"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.start_watchdog.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.start_watchdog_ping.arn
+}
+
+resource "aws_lambda_permission" "start_watchdog_check" {
+  statement_id  = "AllowExecutionFromEventBridgeCheck"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.start_watchdog.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.start_watchdog_check.arn
+}
+
+output "start_watchdog_function_name" {
+  description = "Instance start-watchdog Lambda name"
+  value       = aws_lambda_function.start_watchdog.function_name
+}


### PR DESCRIPTION
## Summary

Answers your question — *"who will monitor the 08:00 EventBridge instance start?"* On 2026-06-02 the EventBridge→SSM-Automation start **silently failed and nothing alerted you** until you noticed by hand. `aws-autopilot` now covers it, but it depends on a GitHub Actions runner firing. **This Lambda runs *in* AWS**, so it alerts even if GitHub Actions is down — the true belt-and-suspenders.

## How it works
Two EventBridge schedules invoke one tiny Lambda:
| When | Mode | Action |
|---|---|---|
| **08:00 IST** (02:30 UTC, Mon–Fri) | `ping` | 🟢 "instance start triggered" Telegram (positive signal — fires with `daily_start`) |
| **08:15 IST** (02:45 UTC, Mon–Fri) | `check` | `ec2:DescribeInstances`; if the box is **not running** → 🆘 "08:00 auto-start FAILED — start it before 09:15." **Silent when healthy.** |

A `DescribeInstances` error is treated as **not-running** (alerts) — a watchdog must never fail silent.

## Files
- [x] `lambda/start-watchdog/handler.py` (+ `test_handler.py`, 5 unit tests with fake SNS/EC2).
- [x] `terraform/start-watchdog-lambda.tf`: least-privilege IAM (`DescribeInstances` + `sns:Publish` to `tv_alerts` + logs), python3.12, 2 EventBridge rules + targets + permissions, mirrors the proven `budget-killswitch` pattern.
- [x] Ratchet `test_start_watchdog_lambda_monitors_the_morning_start`.

## Honest envelope
~44 invokes/mo → **free tier (₹0)**. This is detection only — it pages you; the existing 3-layer self-start (EventBridge + autopilot + deploy) does the healing. Together: at 08:00 you get "started", and by 08:15 either silence (healthy) or a page (failed) — **you'll never find a dead morning by hand again.**

## Test plan
- [x] `python3 -m py_compile` handler + test → OK
- [x] `cargo test -p tickvault-common --test aws_infra_wiring test_start_watchdog` → passed
- (Lambda unit tests run under pytest in CI; boto3/pytest aren't installed locally.)

🤖 https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_