### PR TITLE
fix(boot): ensure prev_day_ohlcv table exists before prev_oi load — fixes deploy-killing exit(1)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -3009,6 +3009,22 @@ async fn main() -> Result<()> {
         );
         let tick_enricher =
             std::sync::Arc::new(tickvault_core::pipeline::tick_enricher::TickEnricher::new());
+        // 1d-historical-only regression fix (2026-06-02): the prev_oi cache
+        // now loads from `prev_day_ohlcv` (repointed from `candles_1d` in
+        // PR #979). Unlike `candles_1d` — which is always CREATEd early in boot
+        // by `ensure_shadow_candle_tables` — `prev_day_ohlcv` is a NEW table
+        // whose `ensure_*` runs inside the concurrently-spawned boot fetch
+        // task, so on a fresh box's first boot with the new binary it may not
+        // exist yet when the gate-blocking load below runs. A missing table
+        // makes `load_from_questdb` return Err → the boot-ordering gate stays
+        // `AwaitingOiCache` → `try_authorize_subscribe()` fails →
+        // `std::process::exit(1)` → systemd marks tickvault.service failed →
+        // the deploy aborts. Ensure the table exists HERE (idempotent
+        // CREATE TABLE IF NOT EXISTS) so the load hits an existing — possibly
+        // empty (Ok count=0, graceful) — table. A genuine QuestDB-unreachable
+        // still Errs and fail-closes as designed (L14 invariant preserved).
+        tickvault_storage::prev_day_ohlcv_persistence::ensure_prev_day_ohlcv_table(&config.questdb)
+            .await;
         // Phase 2.8 H4 fix: only mark the gate ready on Ok. On Err the
         // gate stays in `AwaitingOiCache` and `try_authorize_subscribe`
         // refuses authorization — the operator gets a typed ERROR

--- a/crates/core/tests/phase2_7_perf_and_correctness_fixes.rs
+++ b/crates/core/tests/phase2_7_perf_and_correctness_fixes.rs
@@ -88,6 +88,31 @@ fn hot_path_c2_now_ist_secs_hoisted_to_frame_level() {
     );
 }
 
+/// Regression: 2026-06-02 — prod deploy of 8debad0 failed because the prev_oi
+/// cache was repointed (PR #979) from `candles_1d` to the NEW `prev_day_ohlcv`
+/// table, which may not exist on a fresh box when the boot-ordering gate's
+/// blocking load runs. A missing table → load Err → gate AwaitingOiCache →
+/// try_authorize_subscribe() false → std::process::exit(1) → systemd marks
+/// tickvault.service failed → deploy aborts. The fix ensures the table exists
+/// BEFORE the load. This guard pins that ordering so it can't regress.
+#[test]
+fn test_regression_prev_day_ohlcv_table_ensured_before_prev_oi_load() {
+    let src = read("app/src/main.rs");
+    let ensure_idx = src
+        .find("ensure_prev_day_ohlcv_table(")
+        .expect("main.rs must ensure prev_day_ohlcv table before the prev_oi load");
+    let load_idx = src
+        .find(".load_from_questdb(&config.questdb)")
+        .expect("main.rs must load prev_oi_cache from QuestDB at boot");
+    assert!(
+        ensure_idx < load_idx,
+        "ensure_prev_day_ohlcv_table() MUST be called BEFORE \
+         prev_oi_cache.load_from_questdb() — otherwise a missing prev_day_ohlcv \
+         table on a fresh box makes the boot-ordering gate exit(1) and the \
+         deploy fails (regression 2026-06-02, commit 8debad0)"
+    );
+}
+
 /// Hostile C1 ratchet: midnight rollover task is spawned in slow boot.
 /// Without this, ~24,300 ticks at 09:15 IST on Day N+1 trigger false
 /// VOLUME-MONO-01 alerts (per L13).


### PR DESCRIPTION
## Summary — prod deploy hotfix
The post-market deploy of `8debad0` **failed at "Deploy to EC2"** and auto-stopped the service. Root cause is a **boot regression introduced by PR #979 (1d-historical-only)**, NOT the CloudWatch agent (its `DescribeTags` 403 is non-fatal `|| true` noise).

### Root cause
PR #979 repointed the prev-OI cache load from `candles_1d` → the **new** `prev_day_ohlcv` table.
- `candles_1d` is always `CREATE`d early in boot (`ensure_shadow_candle_tables`).
- `prev_day_ohlcv` is new; its `ensure_*` runs in a **concurrently-spawned** boot task, so on a fresh box's first boot with the new binary the table may not exist yet when the **gate-blocking** load runs.
- Missing table → `load_from_questdb` returns `Err` → boot-ordering gate stays `AwaitingOiCache` → `try_authorize_subscribe()` false → **`std::process::exit(1)`** (`main.rs:3092`, L14 fail-closed) → `systemd` (`Type=notify`) marks `tickvault.service` failed → deploy aborts.

This exactly matches the deploy log + Telegram (boot reached "Auth OK" but never "live and ready").

### Fix
`crates/app/src/main.rs`: call `ensure_prev_day_ohlcv_table(&config.questdb)` **before** the gate-blocking `prev_oi_cache.load_from_questdb()`. Idempotent `CREATE TABLE IF NOT EXISTS`, so the load now hits an existing (possibly empty → `Ok(0)`, graceful) table. **A genuine QuestDB-unreachable still `Err`s and fail-closes — the L14 invariant is preserved.**

### Regression guard
`test_regression_prev_day_ohlcv_table_ensured_before_prev_oi_load` (source-scan on `main.rs`) pins `ensure_*` < `load_from_questdb` ordering so this can't silently regress.

## Test plan
- [x] `cargo build -p tickvault-app` clean
- [x] regression test green
- [ ] CI
- [ ] **operator re-runs `deploy-aws-after-close` after merge** → deploy should now go green

## Separate, lower-priority (not in this PR)
The CloudWatch agent lacks `ec2:DescribeTags` (adds ~66s + scary 403s to every deploy, but `|| true` keeps it non-fatal). Worth fixing next (add the IAM perm via terraform, or drop `append_dimensions` from `cloudwatch-agent.json`).

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_