### PR TITLE
fix(deploy): no-deploy window starts at 09:00 IST (pre-open), not 09:15

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -14,7 +14,7 @@
 # Safety nets that prevent the auto-trigger from causing harm:
 #   1. preflight job — skips entire workflow if AWS_ROLE_ARN / AWS_ACCESS_KEY_ID
 #      bootstrap secrets are absent (charter §C "100% no false-OK PR checks").
-#   2. guard_market_hours job — blocks deploy during 09:15-15:30 IST Mon-Fri
+#   2. guard_market_hours job — blocks deploy during 09:00-15:30 IST Mon-Fri
 #      unless workflow_dispatch with confirm_market_hours=yes.
 #   3. concurrency.group serializes deploys; never two at once.
 #   4. Existing rollback path triggers on failed smoke test.
@@ -209,7 +209,7 @@ jobs:
     steps:
       - name: Check current IST time against market window
         run: |
-          # 09:15-15:30 IST = 03:45-10:00 UTC.
+          # 09:00-15:30 IST = 03:30-10:00 UTC.
           # Monday-Friday only (NSE trading days, ignoring holidays for now).
           UTC_HOUR=$(date -u +%H)
           UTC_MINUTE=$(date -u +%M)
@@ -218,12 +218,12 @@ jobs:
 
           echo "UTC time: $UTC_HOUR:$UTC_MINUTE (day $UTC_DOW), numeric $UTC_TIME_NUM"
 
-          # Market open window in UTC: 0345 to 1000
-          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 345 ] && [ "$UTC_TIME_NUM" -lt 1000 ]; then
+          # No-deploy window in UTC: 0330 (09:00 IST) to 1000 (15:30 IST)
+          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 330 ] && [ "$UTC_TIME_NUM" -lt 1000 ]; then
             if [ "${{ github.event.inputs.confirm_market_hours }}" = "yes" ]; then
               echo "WARNING: deploying during market hours with explicit override"
             else
-              echo "BLOCK: deploying during 09:15-15:30 IST is forbidden without override."
+              echo "BLOCK: deploying during 09:00-15:30 IST is forbidden without override."
               echo "Re-run with confirm_market_hours=yes if this is an emergency fix."
               exit 1
             fi
@@ -441,7 +441,7 @@ jobs:
         # cannot see a build that crosses the open boundary.
         #
         # This step re-checks IST market hours IMMEDIATELY before the swap. If
-        # we are now inside 09:15-15:30 IST Mon-Fri, ABORT before touching the
+        # we are now inside 09:00-15:30 IST Mon-Fri, ABORT before touching the
         # box: the binary is already built + in S3, so the 15:31 IST
         # post-market cron (deploy-aws-after-close) will redeploy it safely.
         # DEPLOY_SKIP_REASON suppresses the failure Telegram (this is an
@@ -456,9 +456,9 @@ jobs:
           fi
           DOW=$(TZ='Asia/Kolkata' date +%u)
           HHMM=$(TZ='Asia/Kolkata' date +%H%M); HHMM=$((10#$HHMM))
-          if [ "$DOW" -le 5 ] && [ "$HHMM" -ge 915 ] && [ "$HHMM" -lt 1530 ]; then
+          if [ "$DOW" -le 5 ] && [ "$HHMM" -ge 900 ] && [ "$HHMM" -lt 1530 ]; then
             echo "DEPLOY_SKIP_REASON=market_hours_swap_abort" >> "$GITHUB_ENV"
-            echo "::warning::Market is OPEN ($HHMM IST) at swap time — the build crossed the 09:15 boundary. ABORTING the binary swap to avoid a mid-session restart. The 15:31 IST post-market cron will redeploy this commit. (Override: re-run with confirm_market_hours=yes.)"
+            echo "::warning::Market is OPEN ($HHMM IST) at swap time — the build crossed the 09:00 boundary (pre-open session starts 09:00 IST). ABORTING the binary swap to avoid a mid-session restart. The 15:31 IST post-market cron will redeploy this commit. (Override: re-run with confirm_market_hours=yes.)"
             exit 1
           fi
           echo "outside market hours ($HHMM IST, dow=$DOW) — safe to swap"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -186,7 +186,7 @@ jobs:
           # to avoid pulling in an extra action. Plan output is in the job log.
 
   # ─────────────────────────────────────────────────────────────────
-  # Job 2: market-hours guard — blocks apply during 09:15-15:30 IST Mon-Fri
+  # Job 2: market-hours guard — blocks apply during 09:00-15:30 IST Mon-Fri
   # ─────────────────────────────────────────────────────────────────
   guard-market-hours:
     name: Market-hours guard
@@ -196,7 +196,7 @@ jobs:
     steps:
       - name: Check current IST time against market window
         run: |
-          # 09:15-15:30 IST = 03:45-10:00 UTC.
+          # 09:00-15:30 IST = 03:30-10:00 UTC.
           UTC_HOUR=$(date -u +%H)
           UTC_MINUTE=$(date -u +%M)
           UTC_DOW=$(date -u +%u)  # 1=Mon, 7=Sun
@@ -204,11 +204,11 @@ jobs:
 
           echo "UTC time: $UTC_HOUR:$UTC_MINUTE (day $UTC_DOW), numeric $UTC_TIME_NUM"
 
-          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 345 ] && [ "$UTC_TIME_NUM" -lt 1000 ]; then
+          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 330 ] && [ "$UTC_TIME_NUM" -lt 1000 ]; then
             if [ "${{ github.event.inputs.confirm_market_hours }}" = "yes" ]; then
               echo "WARNING: applying infra changes during market hours with explicit override"
             else
-              echo "::error::BLOCK: applying infra changes during 09:15-15:30 IST is forbidden."
+              echo "::error::BLOCK: applying infra changes during 09:00-15:30 IST is forbidden."
               echo "Re-run via workflow_dispatch with confirm_market_hours=yes if this is a critical fix."
               exit 1
             fi

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -477,10 +477,10 @@ fn test_deploy_aws_workflow_has_market_hours_guard() {
         content.contains("guard_market_hours"),
         "deploy-aws.yml must have guard_market_hours job"
     );
-    // The 09:15-15:30 IST window in UTC is 03:45-10:00.
+    // The 09:00-15:30 IST window in UTC is 03:30-10:00.
     assert!(
-        content.contains("345") && content.contains("1000"),
-        "deploy-aws.yml must encode the 09:15-15:30 IST window in UTC (345-1000)"
+        content.contains("330") && content.contains("1000"),
+        "deploy-aws.yml must encode the 09:00-15:30 IST window in UTC (330-1000)"
     );
 }
 
@@ -635,18 +635,18 @@ fn test_deploy_aws_regates_market_hours_at_swap_time() {
     assert!(
         content.contains("Re-gate market hours at SWAP time"),
         "deploy-aws.yml must re-check market hours immediately before the SSM \
-         binary swap (a build that started pre-open can cross the 09:15 boundary)"
+         binary swap (a build that started pre-open can cross the 09:00 boundary)"
     );
     assert!(
         content.contains("market_hours_swap_abort"),
         "the swap-time re-gate must set DEPLOY_SKIP_REASON=market_hours_swap_abort \
          so the deferred run does not page the operator + the 15:31 cron redeploys"
     );
-    // The swap-time gate must encode the 09:15-15:30 IST window (915/1530) and
+    // The swap-time gate must encode the 09:00-15:30 IST window (900/1530) and
     // honour the same operator override as the start-time guard.
     assert!(
-        content.contains("915") && content.contains("1530"),
-        "swap-time re-gate must encode the 09:15-15:30 IST market window (915/1530)"
+        content.contains("900") && content.contains("1530"),
+        "swap-time re-gate must encode the 09:00-15:30 IST market window (900/1530)"
     );
     assert!(
         content.contains("confirm_market_hours"),
@@ -658,7 +658,7 @@ fn test_deploy_aws_regates_market_hours_at_swap_time() {
 fn test_deploy_aws_after_close_workflow_fires_in_premarket_and_postmarket_only() {
     // Operator lock 2026-05-30: "only pre-market AND post-market alone only
     // our new codes merged ones should be deployed". Code-merge-driven
-    // deploys NEVER auto-fire during 09:15-15:30 IST trading hours.
+    // deploys NEVER auto-fire during 09:00-15:30 IST trading hours.
     //   - pre-market cron  = 03:15 UTC = 08:45 IST (after 08:30 instance boot)
     //   - post-market cron = 10:01 UTC = 15:31 IST (after 15:30 NSE close)
     let path = ".github/workflows/deploy-aws-after-close.yml";

--- a/crates/common/tests/github_workflow_guard.rs
+++ b/crates/common/tests/github_workflow_guard.rs
@@ -139,7 +139,7 @@ fn r5_uses_pinned_configure_aws_credentials_action() {
 fn r6_has_market_hours_guard_job() {
     let body = read(WORKFLOW);
     must_contain(&body, "guard-market-hours:", "guard-market-hours job");
-    must_contain(&body, "03:45-10:00 UTC", "IST market-hours window comment");
+    must_contain(&body, "03:30-10:00 UTC", "IST market-hours window comment");
     must_contain(&body, "confirm_market_hours", "override input present");
 }
 


### PR DESCRIPTION
## Summary
Operator directive 2026-06-02: **deploys/merges may only auto-deploy before 09:00 IST** — the pre-open session (09:00–09:15) is now inside the no-deploy window, not just the live market (09:15–15:30).

**Before:** no-deploy window = 09:15–15:30 IST (`UTC 0345–1000`).
**After:** no-deploy window = **09:00–15:30 IST** (`UTC 0330–1000`). A merge/push after 09:00 IST is blocked (deferred to the post-market re-deploy); before 09:00 it auto-deploys.

## Changes
- `deploy-aws.yml`: both guards moved to 09:00 — the start-time `guard-market-hours` job (`-ge 345 → -ge 330`) and the swap-time re-gate (`HHMM -ge 915 → -ge 900`). Window comments updated; the "market opens 09:15" references (still factually correct) left intact.
- `terraform-apply.yml`: same guard moved to 09:00 (no infra changes from pre-open either).
- Ratchets updated to pin the new window: `aws_infra_wiring.rs` (UTC 330-1000 + swap 900/1530), `github_workflow_guard.rs` (`03:30-10:00 UTC`).

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring --test github_workflow_guard` → 52 pass
- [x] grep confirms no workflow still uses the old `-ge 345` / `-ge 915` deploy guard
- [ ] CI

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_