### PR TITLE
fix(alarms): EC2 status-check alarms notBreaching — stop nightly false-fire on scheduled stop

### DIFF
--- a/deploy/aws/terraform/alarms.tf
+++ b/deploy/aws/terraform/alarms.tf
@@ -25,7 +25,13 @@ resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
   statistic           = "Maximum"
   threshold           = 0
   alarm_description   = "EC2 Status Check failed — instance-level fault. See DR runbook §5 (Instance unreachable)."
-  treat_missing_data  = "breaching"
+  # treat_missing_data = notBreaching (was "breaching", 2026-06-02): the box is
+  # auto-stopped daily at 17:00 IST (08:00–17:00 schedule). A STOPPED instance
+  # emits no StatusCheckFailed datapoints, so "breaching" flipped this alarm to
+  # a false ALARM every evening (pager fatigue). notBreaching keeps it OK while
+  # stopped, yet still fires on a real breaching datapoint (instance RUNNING but
+  # status check failing). Matches the app-alarms.tf fix pattern.
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     InstanceId = aws_instance.tv_app.id
@@ -49,7 +55,11 @@ resource "aws_cloudwatch_metric_alarm" "system_status_check" {
   statistic           = "Maximum"
   threshold           = 0
   alarm_description   = "AWS System Check failed — requires reboot to trigger underlying-host move. See DR runbook §5."
-  treat_missing_data  = "breaching"
+  # treat_missing_data = notBreaching (was "breaching", 2026-06-02): same as the
+  # instance-status alarm above — a STOPPED instance (daily 17:00 IST schedule)
+  # emits no datapoints, so "breaching" false-fired this alarm every evening.
+  # notBreaching stays OK while stopped, still fires on a real failed check.
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     InstanceId = aws_instance.tv_app.id

--- a/deploy/aws/terraform/alarms.tf
+++ b/deploy/aws/terraform/alarms.tf
@@ -15,6 +15,12 @@
 # 1. EC2 Status Check failed — hypervisor-level issue, needs hardware move
 # ---------------------------------------------------------------------------
 
+# treat_missing_data = notBreaching (was "breaching", 2026-06-02): the box is
+# auto-stopped daily at 17:00 IST (08:00–17:00 schedule). A STOPPED instance
+# emits no StatusCheckFailed datapoints, so "breaching" flipped this alarm to a
+# false ALARM every evening (pager fatigue). notBreaching keeps it OK while
+# stopped, yet still fires on a real breaching datapoint (instance RUNNING but
+# status check failing). Matches the app-alarms.tf fix pattern.
 resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
   alarm_name          = "tv-${var.environment}-instance-status-failed"
   comparison_operator = "GreaterThanThreshold"
@@ -25,12 +31,6 @@ resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
   statistic           = "Maximum"
   threshold           = 0
   alarm_description   = "EC2 Status Check failed — instance-level fault. See DR runbook §5 (Instance unreachable)."
-  # treat_missing_data = notBreaching (was "breaching", 2026-06-02): the box is
-  # auto-stopped daily at 17:00 IST (08:00–17:00 schedule). A STOPPED instance
-  # emits no StatusCheckFailed datapoints, so "breaching" flipped this alarm to
-  # a false ALARM every evening (pager fatigue). notBreaching keeps it OK while
-  # stopped, yet still fires on a real breaching datapoint (instance RUNNING but
-  # status check failing). Matches the app-alarms.tf fix pattern.
   treat_missing_data  = "notBreaching"
 
   dimensions = {
@@ -45,6 +45,10 @@ resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
 # 2. EC2 System Status Check failed — AWS hardware/network-level issue
 # ---------------------------------------------------------------------------
 
+# treat_missing_data = notBreaching (was "breaching", 2026-06-02): same as the
+# instance-status alarm above — a STOPPED instance (daily 17:00 IST schedule)
+# emits no datapoints, so "breaching" false-fired this alarm every evening.
+# notBreaching stays OK while stopped, still fires on a real failed check.
 resource "aws_cloudwatch_metric_alarm" "system_status_check" {
   alarm_name          = "tv-${var.environment}-system-status-failed"
   comparison_operator = "GreaterThanThreshold"
@@ -55,10 +59,6 @@ resource "aws_cloudwatch_metric_alarm" "system_status_check" {
   statistic           = "Maximum"
   threshold           = 0
   alarm_description   = "AWS System Check failed — requires reboot to trigger underlying-host move. See DR runbook §5."
-  # treat_missing_data = notBreaching (was "breaching", 2026-06-02): same as the
-  # instance-status alarm above — a STOPPED instance (daily 17:00 IST schedule)
-  # emits no datapoints, so "breaching" false-fired this alarm every evening.
-  # notBreaching stays OK while stopped, still fires on a real failed check.
   treat_missing_data  = "notBreaching"
 
   dimensions = {


### PR DESCRIPTION
## Summary
The two 🆘 alarms that fired at 17:00 IST today (`tv-prod-instance-status-failed`, `tv-prod-system-status-failed`) are **false alarms** caused by the **daily scheduled instance stop** (08:00–17:00 IST window).

**Root cause:** these were the **only two** alarms still using `treat_missing_data = "breaching"`. When the box is stopped on schedule, EC2 emits **no** `StatusCheckFailed_*` datapoints → "breaching" flips them to ALARM **every evening**. Every other alarm in the repo already uses `notBreaching`.

**Fix:** `deploy/aws/terraform/alarms.tf` — both → `treat_missing_data = "notBreaching"`:
- **Stopped instance** (no datapoints) → stays **OK** (no nightly false 🆘).
- **Running instance with a genuinely failed status check** (a real breaching datapoint) → **still fires** (real fault detection preserved).

Matches the existing `app-alarms.tf` / #976 pattern (dated `notBreaching` comments).

## Test plan
- [x] grep: alarms.tf now has 0 `breaching` / 5 `notBreaching`; no ratchet test pinned the old value
- [ ] On merge, `terraform-apply` updates the 2 CloudWatch alarms (no instance restart needed — it's a control-plane config change)

## Effect
No more nightly false `instance-status-failed` / `system-status-failed` pages at 17:00 IST. Genuine instance/system faults during running hours still alert.

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_