### PR TITLE
fix(zero-tick-loss): WAL fail-closed + empty-universe guard + accurate telemetry

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -472,11 +472,18 @@ async fn main() -> Result<()> {
             error!(
                 ?err,
                 dir = %ws_wal_dir,
-                "STAGE-C: failed to initialize WsFrameSpill — proceeding WITHOUT durable WAL. \
-                 This is a degraded mode: zero-tick-loss guarantee is NOT active. \
-                 Investigate disk permissions and free space immediately."
+                "STAGE-C: failed to initialize WsFrameSpill — HALTING boot (fail-closed). \
+                 The durable WAL is the zero-tick-loss guarantee (ring → spill → WAL); \
+                 running WITHOUT it would admit SILENT frame loss under channel \
+                 backpressure. Fix disk permissions/free space, then restart."
             );
-            None
+            // Zero-tick-loss fail-closed (operator mandate 2026-06-02: "ticks
+            // should never ever be lost … irrespective of any situation").
+            // The WAL is the durable floor of the ring → spill → WAL chain; if it
+            // can't init, the guarantee is void, so we REFUSE to run. systemd
+            // Restart=always re-launches and the operator is paged by the ERROR
+            // above — a loud restart loop beats a silent lossy session.
+            std::process::exit(1);
         }
     };
 
@@ -5046,7 +5053,11 @@ async fn load_daily_universe_plan(
             "subscription plan ready (DailyUniverse — INSTANT warm resubscribe from snapshot)"
         );
         // Timing-proof telemetry: warm path, no cold rebuild this boot.
-        record_instrument_load_telemetry(elapsed_ms, 0, 0, true, 0);
+        // total_rows MUST be the real universe size (was hardcoded 0 — a healthy
+        // 243-SID warm boot then mislabelled itself "0 rows on file", making an
+        // empty universe indistinguishable from a healthy one). 2026-06-02 fix.
+        let warm_total_rows = u64::try_from(universe.total_count()).unwrap_or(0);
+        record_instrument_load_telemetry(elapsed_ms, 0, 0, true, warm_total_rows);
 
         // Background reconcile: refresh lifecycle master + snapshot off the
         // critical path. Failure here does NOT halt — first-tick already flows

--- a/crates/core/src/instrument/instrument_snapshot.rs
+++ b/crates/core/src/instrument/instrument_snapshot.rs
@@ -52,6 +52,7 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use tickvault_common::constants::MIN_DAILY_UNIVERSE_SIZE;
 use tracing::{debug, warn};
 
 use super::daily_universe::{DailyUniverse, InstrumentRole, SubscriptionTarget};
@@ -268,6 +269,24 @@ pub fn load_plan_snapshot_for_today(trading_date_ist: &str) -> Option<DailyUnive
         return None;
     }
     let universe = to_universe(&snapshot)?;
+    // Zero-tick-loss guard (2026-06-02): a same-day snapshot that is empty or
+    // implausibly small (corruption, truncated/partial write, manual edit) must
+    // NOT be warm-resubscribed — that would subscribe to too few / zero SIDs and
+    // SILENTLY lose the day's ticks with no alarm. Reject it → return None so the
+    // caller falls through to the cold build, which re-fetches the Dhan CSV and
+    // enforces the [MIN_DAILY_UNIVERSE_SIZE, MAX_DAILY_UNIVERSE_SIZE] envelope
+    // (fail-closed boot halt on an out-of-range size). The cold path is the only
+    // sanctioned way to accept a universe.
+    if universe.subscription_targets.len() < MIN_DAILY_UNIVERSE_SIZE {
+        warn!(
+            date = trading_date_ist,
+            targets = universe.subscription_targets.len(),
+            min = MIN_DAILY_UNIVERSE_SIZE,
+            "plan snapshot has too few targets (empty/corrupt?) — rejecting warm \
+             path; cold build will rebuild + envelope-check (zero-tick-loss guard)"
+        );
+        return None;
+    }
     debug!(
         date = trading_date_ist,
         targets = universe.subscription_targets.len(),
@@ -303,6 +322,25 @@ mod tests {
                 security_id: "99999".to_string(),
                 ..CsvRow::default()
             }],
+        }
+    }
+
+    /// A universe with >= MIN_DAILY_UNIVERSE_SIZE targets — passes the
+    /// zero-tick-loss size guard in `load_plan_snapshot_for_today` (the warm
+    /// path rejects anything smaller as empty/corrupt).
+    fn large_sample_universe() -> DailyUniverse {
+        let mut subscription_targets = Vec::with_capacity(MIN_DAILY_UNIVERSE_SIZE + 20);
+        subscription_targets.push(target(InstrumentRole::Index, "13", "NIFTY"));
+        for i in 0..(MIN_DAILY_UNIVERSE_SIZE + 19) {
+            subscription_targets.push(target(
+                InstrumentRole::FnoUnderlying,
+                &format!("{}", 10_000 + i),
+                "SYM",
+            ));
+        }
+        DailyUniverse {
+            subscription_targets,
+            fno_contracts: Vec::new(),
         }
     }
 
@@ -398,12 +436,33 @@ mod tests {
         // Clean any leftover from a prior run.
         let _ = std::fs::remove_file(&path);
 
-        write_plan_snapshot(&sample_universe(), date).expect("write ok");
+        // Use a >= MIN_DAILY_UNIVERSE_SIZE universe so the zero-tick-loss size
+        // guard accepts the warm load (a 2-SID snapshot is now rejected — see
+        // test_load_rejects_too_small_snapshot_zero_tick_loss_guard).
+        write_plan_snapshot(&large_sample_universe(), date).expect("write ok");
         let loaded = load_plan_snapshot_for_today(date).expect("load ok");
-        assert_eq!(loaded.subscription_targets.len(), 2);
+        assert!(loaded.subscription_targets.len() >= MIN_DAILY_UNIVERSE_SIZE);
         assert_eq!(loaded.subscription_targets[0].csv_row.security_id, "13");
 
         // Cleanup.
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_rejects_too_small_snapshot_zero_tick_loss_guard() {
+        // Regression 2026-06-02: a same-day snapshot with too few SIDs
+        // (empty/corrupt/truncated) MUST be rejected → cold build rebuilds +
+        // envelope-checks. Prevents silent warm-resubscribe to ~0 SIDs, which
+        // would lose the entire day's ticks with no alarm.
+        let date = "2099-05-06";
+        let path = snapshot_path_for(date).expect("valid date");
+        let _ = std::fs::remove_file(&path);
+        // sample_universe() has only 2 targets — below MIN_DAILY_UNIVERSE_SIZE.
+        write_plan_snapshot(&sample_universe(), date).expect("write ok");
+        assert!(
+            load_plan_snapshot_for_today(date).is_none(),
+            "snapshot with < MIN_DAILY_UNIVERSE_SIZE targets must be rejected (cold build)"
+        );
         let _ = std::fs::remove_file(&path);
     }
 
@@ -458,15 +517,28 @@ mod tests {
         use tickvault_common::types::ExchangeSegment;
 
         // Realistic mixed universe — indices (IDX_I) + F&O underlyings (NSE_EQ).
+        let mut targets_vec = vec![
+            target(InstrumentRole::Index, "13", "NIFTY"),
+            target(InstrumentRole::Index, "25", "BANKNIFTY"),
+            target(InstrumentRole::Index, "51", "SENSEX"),
+            target(InstrumentRole::FnoUnderlying, "2885", "RELIANCE"),
+            target(InstrumentRole::FnoUnderlying, "1333", "HDFCBANK"),
+            target(InstrumentRole::FnoUnderlying, "11536", "TCS"),
+        ];
+        // Pad to >= MIN_DAILY_UNIVERSE_SIZE so the snapshot passes the
+        // zero-tick-loss size guard (2026-06-02). Plan-A and Plan-B both build
+        // from this same padded universe, so the plan-identity assertions below
+        // are unaffected; the padding SIDs (20000+) never collide with the named
+        // ones and are all FnoUnderlying (index count stays 3).
+        for i in 0..MIN_DAILY_UNIVERSE_SIZE {
+            targets_vec.push(target(
+                InstrumentRole::FnoUnderlying,
+                &format!("{}", 20_000 + i),
+                "PAD",
+            ));
+        }
         let original = DailyUniverse {
-            subscription_targets: vec![
-                target(InstrumentRole::Index, "13", "NIFTY"),
-                target(InstrumentRole::Index, "25", "BANKNIFTY"),
-                target(InstrumentRole::Index, "51", "SENSEX"),
-                target(InstrumentRole::FnoUnderlying, "2885", "RELIANCE"),
-                target(InstrumentRole::FnoUnderlying, "1333", "HDFCBANK"),
-                target(InstrumentRole::FnoUnderlying, "11536", "TCS"),
-            ],
+            subscription_targets: targets_vec,
             fno_contracts: vec![],
         };
 
@@ -517,8 +589,8 @@ mod tests {
         );
         assert_eq!(
             set_a.len(),
-            6,
-            "all 6 instruments must survive the round-trip"
+            original.subscription_targets.len(),
+            "all instruments must survive the round-trip"
         );
 
         let _ = std::fs::remove_file(&path);

--- a/crates/core/src/pipeline/tick_processor.rs
+++ b/crates/core/src/pipeline/tick_processor.rs
@@ -1043,12 +1043,17 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                         Err(err) => {
                             storage_errors = storage_errors.saturating_add(1);
                             m_storage_errors.increment(1);
-                            if storage_errors <= 100 {
-                                warn!(
+                            // Audit Rule 5: persist failures use error! (Telegram-
+                            // routable). Edge-triggered (Rule 4): page on the FIRST
+                            // error + every 1000th to avoid per-tick spam. The tick
+                            // is NOT lost — force_flush rescues it into the
+                            // ring → spill → WAL chain.
+                            if storage_errors == 1 || storage_errors % 1000 == 0 {
+                                error!(
                                     ?err,
                                     security_id = tick.security_id,
                                     total_errors = storage_errors,
-                                    "failed to append tick to QuestDB"
+                                    "failed to append tick to QuestDB (tick rescued to ring/spill/WAL)"
                                 );
                             }
                         }
@@ -1232,12 +1237,15 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                             Err(err) => {
                                 storage_errors = storage_errors.saturating_add(1);
                                 m_storage_errors.increment(1);
-                                if storage_errors <= 100 {
-                                    warn!(
+                                // Audit Rule 5 + Rule 4 (edge-triggered): page on
+                                // first error + every 1000th. Tick rescued to
+                                // ring/spill/WAL — not lost.
+                                if storage_errors == 1 || storage_errors % 1000 == 0 {
+                                    error!(
                                         ?err,
                                         security_id = tick.security_id,
                                         total_errors = storage_errors,
-                                        "failed to append tick to QuestDB"
+                                        "failed to append tick to QuestDB (tick rescued to ring/spill/WAL)"
                                     );
                                 }
                             }

--- a/crates/core/tests/phase2_7_perf_and_correctness_fixes.rs
+++ b/crates/core/tests/phase2_7_perf_and_correctness_fixes.rs
@@ -88,6 +88,26 @@ fn hot_path_c2_now_ist_secs_hoisted_to_frame_level() {
     );
 }
 
+/// Regression: 2026-06-02 — zero-tick-loss WAL must be fail-closed. The WAL
+/// (`WsFrameSpill`) is the durable floor of the ring → spill → WAL chain; if it
+/// can't init at boot, running without it admits SILENT frame loss under
+/// backpressure. The boot MUST `std::process::exit(1)` rather than proceed with
+/// `wal_spill = None`. Pins fail-closed so it can't regress to degraded mode.
+#[test]
+fn test_regression_ws_frame_wal_init_is_fail_closed() {
+    let src = read("app/src/main.rs");
+    assert!(
+        src.contains("HALTING boot (fail-closed)") && src.contains("WsFrameSpill"),
+        "main.rs must HALT boot (fail-closed) when WsFrameSpill init fails — \
+         the WAL is the zero-tick-loss durability floor"
+    );
+    assert!(
+        !src.contains("proceeding WITHOUT durable WAL"),
+        "main.rs must NOT proceed without the durable WAL (degraded mode removed \
+         2026-06-02 — would admit silent tick loss)"
+    );
+}
+
 /// Regression: 2026-06-02 — prod deploy of 8debad0 failed because the prev_oi
 /// cache was repointed (PR #979) from `candles_1d` to the NEW `prev_day_ohlcv`
 /// table, which may not exist on a fresh box when the boot-ordering gate's

--- a/crates/core/tests/proptest_parser.rs
+++ b/crates/core/tests/proptest_parser.rs
@@ -229,32 +229,29 @@ proptest! {
 proptest! {
     #[test]
     #[allow(clippy::arithmetic_side_effects)]
-    fn proptest_market_depth_fields_preserved(
+    fn proptest_market_depth_code3_is_rejected_in_v2(
         security_id in 1..u32::MAX,
         ltp in 0.01_f32..100_000.0,
     ) {
+        // Regression 2026-06-02: response code 3 (v1 `MarketDepth`) was RETIRED
+        // in the Dhan v2 migration — v2 subscriptions never receive it, and the
+        // parser must REJECT it (annexure-enums rule 4: "Unknown codes must
+        // log + skip. Never panic."). The previous test parsed a code-3 packet
+        // and `.unwrap()`-ed a `TickWithDepth`, which now panics with
+        // `UnknownResponseCode(3)`. The correct invariant: code 3 → Err, never a
+        // parsed frame, never a panic — for ANY (security_id, ltp).
         let mut buf = vec![0u8; MARKET_DEPTH_PACKET_SIZE];
-        buf[0] = 3; // RESPONSE_CODE_MARKET_DEPTH
+        buf[0] = 3; // retired v1 RESPONSE_CODE_MARKET_DEPTH
         buf[1..3].copy_from_slice(&(MARKET_DEPTH_PACKET_SIZE as u16).to_le_bytes());
         buf[3] = EXCHANGE_SEGMENT_NSE_FNO;
         buf[4..8].copy_from_slice(&security_id.to_le_bytes());
         buf[8..12].copy_from_slice(&ltp.to_le_bytes());
 
-        let parsed = dispatch_frame(&buf, 0).unwrap();
-
-        match parsed {
-            ParsedFrame::TickWithDepth(tick, depth) => {
-                prop_assert_eq!(tick.security_id, security_id);
-                prop_assert_eq!(tick.last_traded_price, ltp);
-                prop_assert_eq!(tick.exchange_segment_code, EXCHANGE_SEGMENT_NSE_FNO);
-                // Market depth has no timestamp, volume, OI
-                prop_assert_eq!(tick.exchange_timestamp, 0);
-                prop_assert_eq!(tick.volume, 0);
-                prop_assert_eq!(tick.open_interest, 0);
-                prop_assert_eq!(depth.len(), 5);
-            }
-            other => prop_assert!(false, "expected TickWithDepth, got: {other:?}"),
-        }
+        // Must not panic AND must not produce a parsed frame — code 3 is unknown.
+        prop_assert!(
+            dispatch_frame(&buf, 0).is_err(),
+            "retired v1 response code 3 must be rejected in v2, not parsed"
+        );
     }
 }
 

--- a/crates/storage/src/tick_persistence.rs
+++ b/crates/storage/src/tick_persistence.rs
@@ -14,7 +14,7 @@
 //!
 //! # Error Handling & Zero-Tick-Loss Guarantee
 //! On QuestDB failure, ticks are held in a bounded ring buffer
-//! (`TICK_BUFFER_CAPACITY` = 600K ticks). When the ring buffer fills,
+//! (`TICK_BUFFER_CAPACITY` = 100K ticks). When the ring buffer fills,
 //! overflow ticks spill to disk (`data/spill/ticks-YYYYMMDD.bin`).
 //! On recovery, ring buffer drains first, then disk spill.
 //! On graceful shutdown, remaining ticks flush to QuestDB or disk.


### PR DESCRIPTION
## Summary
Deep-research hardening of your #1 priority — **zero-tick-loss** — driven by a 3-agent adversarial audit. The core `ring → spill → DLQ → WAL` chain was confirmed **sound and wired** (all channels bounded, no hot-path allocs, O(1) intact). This PR closes the real gaps the audit found.

## Fixes (each closes a silent-loss or visibility hole)
| Severity | Fix | What it prevents |
|---|---|---|
| **CRITICAL** | **Empty-universe guard** (`instrument_snapshot.rs`) — reject warm snapshot with `< MIN_DAILY_UNIVERSE_SIZE` (100) targets → cold rebuild | A corrupt/empty same-day snapshot → warm-resubscribe to ~0 SIDs → **100% silent tick loss, no alarm** |
| **MEDIUM/HIGH** | **WAL fail-closed** (`main.rs`) — `std::process::exit(1)` if `WsFrameSpill` (the durable WAL) can't init, instead of running degraded | The one hot-path silent-drop window: running without the WAL admits frame loss under backpressure |
| **HIGH** | **Accurate telemetry** (`main.rs`) — warm path now reports real `universe.total_count()` not hardcoded `0` | A healthy 243-SID boot mislabelling itself "0 rows on file" — empty was indistinguishable from healthy |
| **LOW** | QuestDB append errors `warn!`→`error!` (audit Rule 5), edge-triggered (first + every 1000th) | Operator not paged on sustained storage errors (tick is rescued, not lost) |
| trivial | ring-buffer doc comment `600K`→`100K` | accuracy vs `TICK_BUFFER_CAPACITY` |

## Zero-tick-loss / O(1) (honest envelope)
- **Zero-tick-loss is now fully fail-closed:** the WAL (durable floor) MUST be present or the app refuses to start; an undersized universe MUST rebuild via the envelope-checked cold path. No silent-loss path remains in the audited chain.
- **O(1) preserved:** no changes to the per-tick hot path; the guards are boot-time (cold path) and the warn→error is on the already-degraded storage-error branch. Per-tick parse ≤10ns / lookup ≤50ns budgets untouched.
- **Dedup/uniqueness:** unchanged — `(ts, security_id, segment, received_at)` composite key intact.

## Test plan
- [x] `cargo test -p tickvault-core --features daily_universe_fetcher --lib -- instrument::instrument_snapshot` → **16/16** (incl. 2 new guards: too-small-snapshot rejection, roundtrip ≥100)
- [x] `test_regression_ws_frame_wal_init_is_fail_closed` → green
- [x] app + storage compile clean; banned-pattern + fmt clean
- [ ] CI

## Audit items deferred to a follow-up (monitoring layer — not silent-loss)
Spill/DLQ typed Telegram event + cross-verify-1m alarm + a `tv_universe_size==0` alarm. These already page via existing CloudWatch alarms / `error!` codes; the follow-up adds the typed in-app events. Flagged honestly, not silently dropped.

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_