### PR TITLE
feat(monitoring): alarm on tv_ticks_dropped_total — the last unalarmed zero-tick-loss breach

### DIFF
--- a/.claude/rules/project/aws-budget.md
+++ b/.claude/rules/project/aws-budget.md
@@ -47,7 +47,7 @@ removal is the highest-risk PR and must not be half-shipped.
 | EIP (24/7) | 1 static IP — Dhan static-IP mandate | $0.005/hr × 720h | ₹306 |
 | EBS gp3 | 10 GB (tight — 4-SID dataset is small) | $0.0912/GB-mo | ₹78 |
 | S3 cold | Tiny dataset (4 SIDs) — Intelligent-Tier → Glacier auto | $0.025→$0.002/GB-mo | ₹15 |
-| CloudWatch | 10 metrics + 10 alarms + 5GB logs (free tier) | $0 | ₹0 |
+| CloudWatch | 10 custom metrics + 5GB logs (free tier) + 18 alarms (13 app + 5 infra; first 10 free, 8 over @ $0.10) | ~$0.80 | ₹68 |
 | SNS SMS | ~100 India SMS/mo | $0.00278/msg | ₹24 |
 | SNS Email / HTTPS / Lambda | free tier | $0 | ₹0 |
 | Data transfer | ~10 GB outbound | ~$0.01/GB | ₹85 |

--- a/crates/common/tests/cloudwatch_app_alarms_wiring.rs
+++ b/crates/common/tests/cloudwatch_app_alarms_wiring.rs
@@ -137,15 +137,20 @@ fn test_every_alarm_metric_is_in_emf_filter_list() {
 }
 
 #[test]
-fn test_app_alarms_count_is_twelve() {
+fn test_app_alarms_count_is_thirteen() {
     // Pin the count so future PRs that delete an alarm without updating
     // the rule files / PR body fail this guard. Cost note (aws-budget.md)
     // depends on this number — keeping the budget honest means keeping
     // this number explicit.
+    //
+    // 13 (was 12) since 2026-06-02: added `tv_ticks_dropped_total` — the
+    // final zero-tick-loss breach (rescue ring + spill + DLQ all failed),
+    // the operator's #1 invariant. The upstream spill/dlq tiers were
+    // already alarmed; this is the strictly-more-severe irrecoverable case.
     let count = alarm_metric_names().len();
     assert_eq!(
-        count, 12,
-        "Z+ L2 VERIFY ratchet: expected exactly 12 app-level CloudWatch alarms \
+        count, 13,
+        "Z+ L2 VERIFY ratchet: expected exactly 13 app-level CloudWatch alarms \
          (one per critical app signal). Found {count}. If you intentionally added \
          or removed one, update aws-budget.md custom-metric cost line AND this guard."
     );

--- a/deploy/aws/terraform/app-alarms.tf
+++ b/deploy/aws/terraform/app-alarms.tf
@@ -204,6 +204,32 @@ resource "aws_cloudwatch_metric_alarm" "dlq_ticks" {
 }
 
 # ---------------------------------------------------------------------------
+# 8b. Tick PERMANENTLY dropped — the final zero-tick-loss breach
+#
+# `tv_ticks_dropped_total` increments ONLY when the rescue ring AND the disk
+# spill AND the DLQ NDJSON all failed for a tick (tick_persistence.rs). This
+# is strictly more severe than `tv_spill_dropped_total` / `tv_dlq_ticks_total`
+# (which still recover the payload downstream): a non-zero value here means a
+# tick was IRRECOVERABLY lost. It is the operator's #1 invariant breach, so it
+# gets its own dedicated alarm even though the upstream tiers also alarm.
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_metric_alarm" "ticks_dropped" {
+  alarm_name          = "tv-${var.environment}-ticks-dropped"
+  alarm_description   = "A tick was PERMANENTLY dropped — rescue ring + disk spill + DLQ NDJSON ALL failed. Irrecoverable zero-tick-loss breach (host OOM + disk full + dlq dir unwritable). Investigate immediately. MUST always be 0."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "tv_ticks_dropped_total"
+  namespace           = local.app_namespace
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+  dimensions          = local.app_dimensions
+  alarm_actions       = local.app_alarm_actions
+  ok_actions          = local.app_alarm_ok
+}
+
+# ---------------------------------------------------------------------------
 # 9. Aggregator producing zero seals during market hours
 #
 # Note: this alarm is NOT market-hours-gated at the CloudWatch level (CW

--- a/deploy/aws/terraform/user-data.sh.tftpl
+++ b/deploy/aws/terraform/user-data.sh.tftpl
@@ -90,9 +90,9 @@ cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<CWCFG
           "metric_declaration": [
             {
               "source_labels": ["__name__"],
-              "label_matcher": "^(tv_websocket_pool_all_dead|tv_websocket_failed_connections_count|tv_order_update_ws_active|tv_questdb_disconnected_seconds|tv_tick_gap_instruments_silent|tv_token_remaining_seconds|tv_spill_dropped_total|tv_dlq_ticks_total|tv_aggregator_seals_emitted_total|tv_aggregator_close_pct_nonzero_total|tv_orders_rejected_total|tv_realtime_guarantee_score|tv_clock_skew_seconds)$",
+              "label_matcher": "^(tv_websocket_pool_all_dead|tv_websocket_failed_connections_count|tv_order_update_ws_active|tv_questdb_disconnected_seconds|tv_tick_gap_instruments_silent|tv_token_remaining_seconds|tv_spill_dropped_total|tv_dlq_ticks_total|tv_ticks_dropped_total|tv_aggregator_seals_emitted_total|tv_aggregator_close_pct_nonzero_total|tv_orders_rejected_total|tv_realtime_guarantee_score|tv_clock_skew_seconds)$",
               "dimensions": [["host"]],
-              "metric_selectors": ["^(tv_websocket_pool_all_dead|tv_websocket_failed_connections_count|tv_order_update_ws_active|tv_questdb_disconnected_seconds|tv_tick_gap_instruments_silent|tv_token_remaining_seconds|tv_spill_dropped_total|tv_dlq_ticks_total|tv_aggregator_seals_emitted_total|tv_aggregator_close_pct_nonzero_total|tv_orders_rejected_total|tv_realtime_guarantee_score|tv_clock_skew_seconds)$"]
+              "metric_selectors": ["^(tv_websocket_pool_all_dead|tv_websocket_failed_connections_count|tv_order_update_ws_active|tv_questdb_disconnected_seconds|tv_tick_gap_instruments_silent|tv_token_remaining_seconds|tv_spill_dropped_total|tv_dlq_ticks_total|tv_ticks_dropped_total|tv_aggregator_seals_emitted_total|tv_aggregator_close_pct_nonzero_total|tv_orders_rejected_total|tv_realtime_guarantee_score|tv_clock_skew_seconds)$"]
             }
           ]
         }


### PR DESCRIPTION
## Summary

**Monitoring audit + the one genuine gap.** Per audit Rule 10, I verified each candidate "blind spot" against current code before building — and found the observability stack is **already comprehensive**:

```
PROPOSED GAP          VERDICT        ALREADY COVERED BY
────────────────────  ─────────────  ─────────────────────────────────────
ws-pool-all-dead      ✅ covered     tv_websocket_pool_all_dead alarm +
                                     pool_watchdog CRITICAL + halt
token < 4h            ✅ covered     tv_token_remaining_seconds alarm +
                                     AUTH-GAP-03 force-renew
cross-verify-1m       ✅ covered     #980 (error codes + CSV + Telegram)
spill / dlq loss      ✅ covered     tv_spill_dropped_total +
                                     tv_dlq_ticks_total alarms
ticks PERMANENTLY     ❌ GAP         (none) — this PR
  dropped
```

The one real gap: **`tv_ticks_dropped_total`** — the operator's #1 invariant breach — had no alarm. It increments **only** when the rescue ring **and** disk spill **and** DLQ NDJSON all fail (`tick_persistence.rs:706/725`) = a tick was **irrecoverably lost**. Strictly more severe than the already-alarmed `spill_dropped` / `dlq_ticks` tiers (which still recover the payload as NDJSON), so it gets its own dedicated alarm.

## Changes
- **`app-alarms.tf`** — new `tv-${env}-ticks-dropped` alarm (`>0`, `notBreaching`, critical SNS fan-out), mirrors the spill/dlq pattern.
- **`user-data.sh.tftpl`** — added `tv_ticks_dropped_total` to both EMF `label_matcher` + `metric_selectors` so the CW agent publishes it.
- **`cloudwatch_app_alarms_wiring.rs`** — count guard 12 → 13.
- **`aws-budget.md`** — honest CloudWatch line: 18 total alarms (13 app + 5 infra), 8 over the 10-alarm free tier @ $0.10 = **~$0.80/mo (~₹68)**. The doc previously understated this as "$0 within free tier" — corrected (no hallucination).

## Honest claim
This closes the **last unalarmed** zero-tick-loss counter. The 3-way EMF↔alarm↔Rust-emit wiring is ratchet-verified. The alarm fires via the existing SNS 4-channel fan-out (SMS + Telegram + Email + Connect). It does NOT change the tick pipeline — purely adds operator visibility on the irrecoverable-loss path.

## Test plan
- [x] `cloudwatch_app_alarms_wiring` 3/3 (count=13, emit-site present, EMF filter present)
- [x] `aws_deploy_safety_guard` 11/11, `aws_infra_wiring` 32/32, `zero_tick_loss_alert_guard` 4/4
- [x] fmt clean (terraform validated by CI `terraform-apply`)

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_