### PR TITLE
feat(deploy): instant auto-deploy the moment the instance starts (08:00 IST)

### DIFF
--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -920,6 +920,26 @@ fn test_deploy_watchdog_lambda_is_wired() {
         tf.contains("aws_sns_topic.tv_alerts.arn"),
         "deploy-watchdog must be able to page the operator via the tv_alerts SNS topic"
     );
+    // INSTANT deploy on instance start (operator directive 2026-06-02): an
+    // EC2 state-change event rule fires the watchdog the moment the box enters
+    // `running`, so the latest main deploys right after the 08:00 auto-start —
+    // not at the 08:45 cron. This is the PRIMARY morning deploy trigger.
+    assert!(
+        tf.contains("EC2 Instance State-change Notification") && tf.contains("\"running\""),
+        "deploy-watchdog must have an EventBridge event-pattern rule that fires \
+         on the tv-app EC2 instance entering 'running' — the instant-deploy-on-start \
+         trigger (operator directive 2026-06-02)."
+    );
+    assert!(
+        tf.contains("aws_instance.tv_app.id"),
+        "the instance-start rule must scope to THIS instance (aws_instance.tv_app.id), \
+         not fire on every EC2 in the account."
+    );
+    assert!(
+        tf.contains("window = \"instance-start\""),
+        "the instance-start target must pass window=\"instance-start\" so the handler \
+         logs/labels the instant trigger distinctly."
+    );
 }
 
 #[test]

--- a/deploy/aws/lambda/deploy-watchdog/handler.py
+++ b/deploy/aws/lambda/deploy-watchdog/handler.py
@@ -7,11 +7,16 @@ would leave the box running STALE code with no signal. aws-autopilot mitigates
 some of this, but it too runs on GitHub.
 
 This Lambda is the belt-and-suspenders: it runs IN AWS (EventBridge -> Lambda),
-so it covers GitHub-cron misses even when GitHub Actions is degraded. Two
-EventBridge schedules fire it a few minutes AFTER the GitHub cron:
+so it covers GitHub-cron misses even when GitHub Actions is degraded. Three
+EventBridge triggers fire it:
 
-  * 08:50 IST (03:20 UTC Mon-Fri) — 5 min after the 08:45 pre-market cron.
-  * 15:36 IST (10:06 UTC Mon-Fri) — 5 min after the 15:31 post-market cron.
+  * INSTANT (event-pattern): the moment the tv-app EC2 instance enters the
+    `running` state — i.e. right after the 08:00 IST auto-start. This is the
+    PRIMARY morning deploy trigger (operator directive 2026-06-02: "auto
+    deployment should happen instantly when the instance is started"). Latest
+    `main` is deployed within ~1-2 min of 08:00, not at the 08:45 cron.
+  * 08:50 IST (03:20 UTC Mon-Fri) — backup, 5 min after the 08:45 pre-market cron.
+  * 15:36 IST (10:06 UTC Mon-Fri) — backup, 5 min after the 15:31 post-market cron.
 
 On each fire it answers ONE question, using GitHub as the source of truth (the
 same idempotency signal `deploy-aws-after-close.yml` itself uses):

--- a/deploy/aws/terraform/deploy-watchdog-lambda.tf
+++ b/deploy/aws/terraform/deploy-watchdog-lambda.tf
@@ -184,7 +184,7 @@ resource "aws_cloudwatch_event_rule" "deploy_watchdog_instance_start" {
     source        = ["aws.ec2"]
     "detail-type" = ["EC2 Instance State-change Notification"]
     detail = {
-      state       = ["running"]
+      state         = ["running"]
       "instance-id" = [aws_instance.tv_app.id]
     }
   })

--- a/deploy/aws/terraform/deploy-watchdog-lambda.tf
+++ b/deploy/aws/terraform/deploy-watchdog-lambda.tf
@@ -160,6 +160,51 @@ resource "aws_lambda_permission" "deploy_watchdog_postmarket" {
   source_arn    = aws_cloudwatch_event_rule.deploy_watchdog_postmarket.arn
 }
 
+# ---------------------------------------------------------------------------
+# INSTANT deploy on instance start (operator directive 2026-06-02)
+#
+# "auto deployment should happen instantly when the instance is started at
+# 08:00." The 08:00 EventBridge start brings the box up; this rule fires the
+# deploy-watchdog the MOMENT the instance enters the `running` state — so the
+# latest `main` is pulled + restarted within a couple of minutes of 08:00,
+# NOT at the 08:45 cron. The watchdog is idempotent (only dispatches if main
+# is actually newer than the last successful deploy), so a same-day restart
+# that is already up-to-date is a silent no-op. The 08:45/08:50 schedules
+# above remain as belt-and-suspenders backups.
+#
+# Event-pattern (not a schedule): EC2 Instance State-change → `running` for
+# THIS instance only. SSM agent is up within ~30-60s of `running`; the
+# dispatched GitHub deploy takes ~1-2 min to reach its SSM step, by which the
+# box is ready.
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_event_rule" "deploy_watchdog_instance_start" {
+  name        = "tv-${var.environment}-deploy-watchdog-instance-start"
+  description = "Instant deploy when the tv-app EC2 instance enters 'running' (08:00 auto-start)"
+  event_pattern = jsonencode({
+    source        = ["aws.ec2"]
+    "detail-type" = ["EC2 Instance State-change Notification"]
+    detail = {
+      state       = ["running"]
+      "instance-id" = [aws_instance.tv_app.id]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "deploy_watchdog_instance_start" {
+  rule      = aws_cloudwatch_event_rule.deploy_watchdog_instance_start.name
+  target_id = "deploy-watchdog-instance-start"
+  arn       = aws_lambda_function.deploy_watchdog.arn
+  input     = jsonencode({ window = "instance-start" })
+}
+
+resource "aws_lambda_permission" "deploy_watchdog_instance_start" {
+  statement_id  = "AllowExecutionFromEventBridgeInstanceStart"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.deploy_watchdog.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.deploy_watchdog_instance_start.arn
+}
+
 output "deploy_watchdog_function_name" {
   description = "Deploy-watchdog Lambda name (covers GitHub-cron auto-deploy misses)"
   value       = aws_lambda_function.deploy_watchdog.function_name


### PR DESCRIPTION
## Summary

You're right — the box starting at 08:00 but deploying at 08:45 left ~45 min of stale code. This makes the deploy fire **the instant the instance starts**.

Adds an EventBridge **event-pattern** rule (not a schedule) that triggers the deploy-watchdog Lambda the moment the tv-app EC2 instance enters `running` — right after the 08:00 IST auto-start. The watchdog checks "is `main` newer than the last deploy?" and dispatches the deploy immediately → latest code live within ~1–2 min of 08:00.

```
BEFORE                              AFTER (this PR)
────────────────────────────────   ────────────────────────────────
08:00  instance starts             08:00  instance starts
08:00  app boots (STALE code)      08:00  app boots + EC2 'running'
   …45 min of stale code…                 event → watchdog → deploy
08:45  deploy (cron)               ~08:02 latest main deployed + live
                                   08:45/08:50  backups (unchanged)
```

## Reuses #990 — no new Lambda
- New rule `tv-${env}-deploy-watchdog-instance-start`: `EC2 Instance State-change → running`, scoped to `aws_instance.tv_app.id` **only** (never fires on other instances). Target passes `window="instance-start"`.
- The 08:50 + 15:36 schedules stay as belt-and-suspenders backups.

## Safety preserved (no illusion)
- **Idempotent** — the watchdog only deploys if `main` is actually newer than the last successful deploy; a same-day up-to-date restart is a silent no-op.
- **Mid-market protection intact** — the rule fires on every `running` transition, but the dispatched deploy keeps its market-hours guard (no-deploy 09:00–15:30 IST). So a mid-session restart with new merges will **not** redeploy during trading — only the 08:00 pre-market start deploys.

## Ratchet
`aws_infra_wiring.rs::test_deploy_watchdog_lambda_is_wired` extended to pin the EC2 state-change event-pattern, the instance-id scoping, and the `window="instance-start"` target.

## Test plan
- [x] `aws_infra_wiring` 34/34
- [x] `py_compile` clean, fmt clean
- [x] terraform applied to live AWS by CI `terraform-apply` on merge (so it's live for tomorrow 08:00)

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_