### PR TITLE
fix(deploy): clear plain-English Telegram when the deploy lands (was cryptic)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -679,13 +679,15 @@ jobs:
       - name: Notify Telegram on success
         if: success()
         run: |
-          # The SNS topic has a Telegram webhook subscription; publish
-          # an INFO-level message so the operator sees the deploy land.
+          # The SNS topic has a Telegram webhook subscription; publish a
+          # plain-English message so the operator sees the deploy land clearly.
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          IST_TIME="$(TZ='Asia/Kolkata' date +'%I:%M %p IST')"
           aws sns publish \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ steps.acct.outputs.id }}:tv-prod-alerts \
-            --subject "DLT deploy OK" \
-            --message "commit=${{ github.sha }} ref=${{ github.ref }} actor=${{ github.actor }}"
+            --subject "✅ tickvault deployed — new code is LIVE" \
+            --message "✅ New code is LIVE on AWS, deployed at ${IST_TIME} (version ${SHORT_SHA}). The app restarted on the latest code. Nothing for you to do."
 
       - name: Auto-stop tickvault service on deploy failure (kills Telegram spam)
         # Not on an intentional off-hours skip: the box is already stopped, so
@@ -719,8 +721,10 @@ jobs:
         # Genuine deploy failures (box up, smoke test failed, etc.) still page.
         if: failure() && env.DEPLOY_SKIP_REASON == ''
         run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          IST_TIME="$(TZ='Asia/Kolkata' date +'%I:%M %p IST')"
           aws sns publish \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ steps.acct.outputs.id }}:tv-prod-alerts \
-            --subject "DLT deploy FAILED" \
-            --message "commit=${{ github.sha }} ref=${{ github.ref }} actor=${{ github.actor }} run=${{ github.run_id }}"
+            --subject "🆘 tickvault deploy FAILED" \
+            --message "🆘 Deploy FAILED at ${IST_TIME} (version ${SHORT_SHA}). The app was auto-stopped to avoid repeated alerts; the next deploy re-enables it. Check the run: ${{ github.run_id }}"


### PR DESCRIPTION
## Summary

You said "once it deploys itself it should let me know." It **already** sent an SNS→Telegram on every deploy — but the message was cryptic and off your Telegram style:

```
BEFORE  subject: "DLT deploy OK"
        message: "commit=<40-char-sha> ref=refs/heads/main actor=..."
        → no IST time, no plain words, "DLT" means nothing to you
```

Rewrote both the **success** and **failure** deploy notifications to plain English + emoji + IST time + short version + "what to do":

```
AFTER (success)
  ✅ tickvault deployed — new code is LIVE
  "✅ New code is LIVE on AWS, deployed at 8:02 AM IST (version a1b2c3d).
   The app restarted on the latest code. Nothing for you to do."

AFTER (failure)
  🆘 tickvault deploy FAILED
  "🆘 Deploy FAILED at HH:MM AM IST (version a1b2c3d). The app was
   auto-stopped to avoid repeated alerts; the next deploy re-enables it.
   Check the run: <id>."
```

So tomorrow, the moment the 08:00 instant-deploy lands, you get a clear **"✅ New code is LIVE … 8:02 AM IST"** on Telegram — not a cryptic blob, and not a fixed-time poll.

## Notes
- Short version = `${GITHUB_SHA:0:7}`; IST via `TZ='Asia/Kolkata' date`.
- SNS topic ARN still uses the runtime account id (`steps.acct.outputs.id`) — the account-id-at-runtime guard is unaffected.

## Test plan
- [x] `aws_infra_wiring` 34/34, `github_workflow_guard` 21/21 (no guard pinned the old subject)
- [x] YAML-only — no code/test changes

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_