### PR TITLE
feat(deploy): always auto-deploy at 08:00 start + no-deploy band 09:00–15:45 IST

### DIFF
--- a/.github/workflows/deploy-aws-after-close.yml
+++ b/.github/workflows/deploy-aws-after-close.yml
@@ -1,28 +1,39 @@
 # =============================================================================
-# tickvault — auto-deploy in pre-market + post-market windows ONLY
+# tickvault — auto-deploy outside the 09:00-15:45 IST no-deploy window
 # =============================================================================
-# Operator lock 2026-05-30: "only pre-market AND post-market alone only our
-# new codes merged ones should be deployed". Code-merge-driven deploys NEVER
-# fire during 09:15-15:30 IST trading hours via the auto path. (Instance
-# start/stop/restart remain on-demand via the AWS Console — separate concern.)
+# Operator lock 2026-06-03: "always deploy the app whenever the instance gets
+# auto started at 8 am ... whenever any merge happens to main it should always
+# be auto deployed to ec2 — ONLY between 9 am till 3.45 pm it should not happen.
+# except this time always auto deployment should happen." So the ONLY no-deploy
+# window is 09:00-15:45 IST (the live trading + post-close-settle band); every
+# other time — including the 08:00 IST auto-start — auto-deploys the latest main.
 #
-# Two crons, both Mon–Fri:
-#   • 03:15 UTC = 08:45 IST → PRE-MARKET window. Instance auto-starts at
-#     08:30 IST; this fires 15 minutes later, well before 09:15 market open.
-#   • 10:01 UTC = 15:31 IST → POST-MARKET window. ~1 minute after NSE close.
+# Three crons, all Mon–Fri:
+#   • 02:30 UTC = 08:00 IST → INSTANCE-START deploy. Fires the moment the box is
+#     scheduled to auto-start. deploy-aws SELF-STARTS a stopped box in the
+#     08:00-17:00 up-window (see "Ensure instance running" in deploy-aws.yml),
+#     so even if the 08:00 EventBridge instance-start silently fails, THIS cron
+#     still brings the box up + ships the latest main before 09:00 open. This is
+#     the belt-and-suspenders fix for the 2026-06-03 "box never auto-started"
+#     incident — it does not depend on the EC2 'running' event firing at all.
+#   • 03:15 UTC = 08:45 IST → PRE-MARKET backup, well before the 09:15 open.
+#   • 10:16 UTC = 15:46 IST → POST-MARKET window, just AFTER the 15:45 IST end of
+#     the no-deploy band (moved from 15:31 so it is no longer blocked by the
+#     guard). ~16 min after NSE close — redeploys anything merged during hours.
 #
 # Idempotent: before dispatching, we compare main's current HEAD against the
 # `head_sha` of the most recent SUCCESSFUL deploy-aws run on main. If equal,
 # nothing to deploy — exit clean (no spurious restart on quiet days).
 #
 # Triggers:
-#   - schedule: 03:15 + 10:01 UTC Mon–Fri
+#   - schedule: 02:30 + 03:15 + 10:16 UTC Mon–Fri
 #   - workflow_dispatch: manual operator override (just-in-case button)
 #
 # Honest envelope:
-#   - Merge during 09:15-15:30 IST → blocked → auto-fires at 15:31 IST same day ✅
-#   - Merge over the weekend → auto-fires Monday 08:45 IST (pre-market) ✅
-#   - Merge before 08:45 IST on a weekday → auto-fires same day 08:45 IST ✅
+#   - Merge during 09:00-15:45 IST → blocked → auto-fires at 15:46 IST same day ✅
+#   - Merge over the weekend → auto-fires Monday 08:00 IST (instance-start) ✅
+#   - Merge before 08:00 IST on a weekday → auto-fires same day 08:00 IST ✅
+#   - Box failed to auto-start at 08:00 → the 08:00 cron self-starts it + deploys ✅
 #   - NSE holiday: cron fires; deploy-aws's own market-hours guard is a no-op
 #     outside trading hours, so the deploy runs harmlessly on holiday windows.
 #   - No new commits → idempotent skip (no restart, no extra cost).
@@ -32,10 +43,12 @@ name: deploy-aws-after-close
 
 on:
   schedule:
-    # 03:15 UTC = 08:45 IST (pre-market). 10:01 UTC = 15:31 IST (post-market).
+    # 02:30 UTC = 08:00 IST (instance-start). 03:15 UTC = 08:45 IST (pre-market).
+    # 10:16 UTC = 15:46 IST (post-market, just after the 15:45 no-deploy band).
     # Mon–Fri only.
+    - cron: '30 2 * * 1-5'
     - cron: '15 3 * * 1-5'
-    - cron: '1 10 * * 1-5'
+    - cron: '16 10 * * 1-5'
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -14,7 +14,7 @@
 # Safety nets that prevent the auto-trigger from causing harm:
 #   1. preflight job — skips entire workflow if AWS_ROLE_ARN / AWS_ACCESS_KEY_ID
 #      bootstrap secrets are absent (charter §C "100% no false-OK PR checks").
-#   2. guard_market_hours job — blocks deploy during 09:00-15:30 IST Mon-Fri
+#   2. guard_market_hours job — blocks deploy during 09:00-15:45 IST Mon-Fri
 #      unless workflow_dispatch with confirm_market_hours=yes.
 #   3. concurrency.group serializes deploys; never two at once.
 #   4. Existing rollback path triggers on failed smoke test.
@@ -209,7 +209,8 @@ jobs:
     steps:
       - name: Check current IST time against market window
         run: |
-          # 09:00-15:30 IST = 03:30-10:00 UTC.
+          # No-deploy band 09:00-15:45 IST = 03:30-10:15 UTC (operator lock
+          # 2026-06-03: "only between 9 am till 3.45 pm it should not happen").
           # Monday-Friday only (NSE trading days, ignoring holidays for now).
           UTC_HOUR=$(date -u +%H)
           UTC_MINUTE=$(date -u +%M)
@@ -218,17 +219,17 @@ jobs:
 
           echo "UTC time: $UTC_HOUR:$UTC_MINUTE (day $UTC_DOW), numeric $UTC_TIME_NUM"
 
-          # No-deploy window in UTC: 0330 (09:00 IST) to 1000 (15:30 IST)
-          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 330 ] && [ "$UTC_TIME_NUM" -lt 1000 ]; then
+          # No-deploy window in UTC: 0330 (09:00 IST) to 1015 (15:45 IST)
+          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 330 ] && [ "$UTC_TIME_NUM" -lt 1015 ]; then
             if [ "${{ github.event.inputs.confirm_market_hours }}" = "yes" ]; then
               echo "WARNING: deploying during market hours with explicit override"
             else
-              echo "BLOCK: deploying during 09:00-15:30 IST is forbidden without override."
+              echo "BLOCK: deploying during 09:00-15:45 IST is forbidden without override."
               echo "Re-run with confirm_market_hours=yes if this is an emergency fix."
               exit 1
             fi
           else
-            echo "OK: outside market hours, deploy can proceed"
+            echo "OK: outside the 09:00-15:45 IST no-deploy band, deploy can proceed"
           fi
 
   deploy:
@@ -441,8 +442,8 @@ jobs:
         # cannot see a build that crosses the open boundary.
         #
         # This step re-checks IST market hours IMMEDIATELY before the swap. If
-        # we are now inside 09:00-15:30 IST Mon-Fri, ABORT before touching the
-        # box: the binary is already built + in S3, so the 15:31 IST
+        # we are now inside 09:00-15:45 IST Mon-Fri, ABORT before touching the
+        # box: the binary is already built + in S3, so the 15:46 IST
         # post-market cron (deploy-aws-after-close) will redeploy it safely.
         # DEPLOY_SKIP_REASON suppresses the failure Telegram (this is an
         # intentional defer, not a failure) while keeping the run non-success
@@ -456,9 +457,9 @@ jobs:
           fi
           DOW=$(TZ='Asia/Kolkata' date +%u)
           HHMM=$(TZ='Asia/Kolkata' date +%H%M); HHMM=$((10#$HHMM))
-          if [ "$DOW" -le 5 ] && [ "$HHMM" -ge 900 ] && [ "$HHMM" -lt 1530 ]; then
+          if [ "$DOW" -le 5 ] && [ "$HHMM" -ge 900 ] && [ "$HHMM" -lt 1545 ]; then
             echo "DEPLOY_SKIP_REASON=market_hours_swap_abort" >> "$GITHUB_ENV"
-            echo "::warning::Market is OPEN ($HHMM IST) at swap time — the build crossed the 09:00 boundary (pre-open session starts 09:00 IST). ABORTING the binary swap to avoid a mid-session restart. The 15:31 IST post-market cron will redeploy this commit. (Override: re-run with confirm_market_hours=yes.)"
+            echo "::warning::Market is OPEN ($HHMM IST) at swap time — the build crossed into the 09:00-15:45 IST no-deploy band. ABORTING the binary swap to avoid a mid-session restart. The 15:46 IST post-market cron will redeploy this commit. (Override: re-run with confirm_market_hours=yes.)"
             exit 1
           fi
           echo "outside market hours ($HHMM IST, dow=$DOW) — safe to swap"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -186,7 +186,7 @@ jobs:
           # to avoid pulling in an extra action. Plan output is in the job log.
 
   # ─────────────────────────────────────────────────────────────────
-  # Job 2: market-hours guard — blocks apply during 09:00-15:30 IST Mon-Fri
+  # Job 2: market-hours guard — blocks apply during 09:00-15:45 IST Mon-Fri
   # ─────────────────────────────────────────────────────────────────
   guard-market-hours:
     name: Market-hours guard
@@ -196,7 +196,9 @@ jobs:
     steps:
       - name: Check current IST time against market window
         run: |
-          # 09:00-15:30 IST = 03:30-10:00 UTC.
+          # No-deploy band 09:00-15:45 IST = 03:30-10:15 UTC (operator lock
+          # 2026-06-03 — kept consistent with deploy-aws.yml: no prod mutation,
+          # app OR infra, during 09:00 till 3.45 pm IST).
           UTC_HOUR=$(date -u +%H)
           UTC_MINUTE=$(date -u +%M)
           UTC_DOW=$(date -u +%u)  # 1=Mon, 7=Sun
@@ -204,16 +206,16 @@ jobs:
 
           echo "UTC time: $UTC_HOUR:$UTC_MINUTE (day $UTC_DOW), numeric $UTC_TIME_NUM"
 
-          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 330 ] && [ "$UTC_TIME_NUM" -lt 1000 ]; then
+          if [ "$UTC_DOW" -le 5 ] && [ "$UTC_TIME_NUM" -ge 330 ] && [ "$UTC_TIME_NUM" -lt 1015 ]; then
             if [ "${{ github.event.inputs.confirm_market_hours }}" = "yes" ]; then
               echo "WARNING: applying infra changes during market hours with explicit override"
             else
-              echo "::error::BLOCK: applying infra changes during 09:00-15:30 IST is forbidden."
+              echo "::error::BLOCK: applying infra changes during 09:00-15:45 IST is forbidden."
               echo "Re-run via workflow_dispatch with confirm_market_hours=yes if this is a critical fix."
               exit 1
             fi
           else
-            echo "OK: outside market hours, apply can proceed"
+            echo "OK: outside the 09:00-15:45 IST no-deploy band, apply can proceed"
           fi
 
   # ─────────────────────────────────────────────────────────────────

--- a/crates/common/tests/aws_infra_wiring.rs
+++ b/crates/common/tests/aws_infra_wiring.rs
@@ -477,10 +477,11 @@ fn test_deploy_aws_workflow_has_market_hours_guard() {
         content.contains("guard_market_hours"),
         "deploy-aws.yml must have guard_market_hours job"
     );
-    // The 09:00-15:30 IST window in UTC is 03:30-10:00.
+    // The 09:00-15:45 IST no-deploy band in UTC is 03:30-10:15 (operator lock
+    // 2026-06-03: "only between 9 am till 3.45 pm it should not happen").
     assert!(
-        content.contains("330") && content.contains("1000"),
-        "deploy-aws.yml must encode the 09:00-15:30 IST window in UTC (330-1000)"
+        content.contains("330") && content.contains("1015"),
+        "deploy-aws.yml must encode the 09:00-15:45 IST window in UTC (330-1015)"
     );
 }
 
@@ -628,7 +629,7 @@ fn test_deploy_aws_regates_market_hours_at_swap_time() {
     // ~2 min at the bell. The start-time guard cannot see a build that crosses
     // the open boundary. This pins the SWAP-time re-gate: immediately before
     // the SSM swap, deploy-aws re-checks IST market hours and ABORTS (defers
-    // to the 15:31 cron) instead of restarting the live app mid-session.
+    // to the 15:46 cron) instead of restarting the live app mid-session.
     let content =
         std::fs::read_to_string(workspace_root().join(".github/workflows/deploy-aws.yml"))
             .expect("deploy-aws.yml must be readable"); // APPROVED: test
@@ -640,13 +641,13 @@ fn test_deploy_aws_regates_market_hours_at_swap_time() {
     assert!(
         content.contains("market_hours_swap_abort"),
         "the swap-time re-gate must set DEPLOY_SKIP_REASON=market_hours_swap_abort \
-         so the deferred run does not page the operator + the 15:31 cron redeploys"
+         so the deferred run does not page the operator + the 15:46 cron redeploys"
     );
-    // The swap-time gate must encode the 09:00-15:30 IST window (900/1530) and
+    // The swap-time gate must encode the 09:00-15:45 IST window (900/1545) and
     // honour the same operator override as the start-time guard.
     assert!(
-        content.contains("900") && content.contains("1530"),
-        "swap-time re-gate must encode the 09:00-15:30 IST market window (900/1530)"
+        content.contains("900") && content.contains("1545"),
+        "swap-time re-gate must encode the 09:00-15:45 IST market window (900/1545)"
     );
     assert!(
         content.contains("confirm_market_hours"),
@@ -656,28 +657,36 @@ fn test_deploy_aws_regates_market_hours_at_swap_time() {
 
 #[test]
 fn test_deploy_aws_after_close_workflow_fires_in_premarket_and_postmarket_only() {
-    // Operator lock 2026-05-30: "only pre-market AND post-market alone only
-    // our new codes merged ones should be deployed". Code-merge-driven
-    // deploys NEVER auto-fire during 09:00-15:30 IST trading hours.
-    //   - pre-market cron  = 03:15 UTC = 08:45 IST (after 08:30 instance boot)
-    //   - post-market cron = 10:01 UTC = 15:31 IST (after 15:30 NSE close)
+    // Operator lock 2026-06-03: "always deploy whenever the instance auto-starts
+    // at 8 am ... only between 9 am till 3.45 pm it should not happen." The ONLY
+    // no-deploy band is 09:00-15:45 IST; every other time auto-deploys main.
+    //   - instance-start cron = 02:30 UTC = 08:00 IST (self-starts a stopped box)
+    //   - pre-market cron      = 03:15 UTC = 08:45 IST (backup, before 09:15 open)
+    //   - post-market cron     = 10:16 UTC = 15:46 IST (just after the 15:45 band)
     let path = ".github/workflows/deploy-aws-after-close.yml";
     require_file_exists(
         path,
-        "auto-deploy in pre-market + post-market windows (operator lock 2026-05-30)",
+        "auto-deploy at 08:00 instance-start + outside the 09:00-15:45 IST band \
+         (operator lock 2026-06-03)",
     );
     let content = std::fs::read_to_string(workspace_root().join(path))
         .expect("deploy-aws-after-close.yml must be readable"); // APPROVED: test
 
+    assert!(
+        content.contains("30 2 * * 1-5"),
+        "deploy-aws-after-close.yml must include instance-start cron \
+         02:30 UTC Mon-Fri (08:00 IST) — self-starts the box + deploys even if \
+         the EventBridge instance-start fails (2026-06-03 incident fix)"
+    );
     assert!(
         content.contains("15 3 * * 1-5"),
         "deploy-aws-after-close.yml must include pre-market cron \
          03:15 UTC Mon-Fri (08:45 IST)"
     );
     assert!(
-        content.contains("1 10 * * 1-5"),
+        content.contains("16 10 * * 1-5"),
         "deploy-aws-after-close.yml must include post-market cron \
-         10:01 UTC Mon-Fri (15:31 IST)"
+         10:16 UTC Mon-Fri (15:46 IST — just after the 15:45 no-deploy band)"
     );
     // Must dispatch deploy-aws.yml — that's the whole point.
     assert!(
@@ -901,14 +910,14 @@ fn test_deploy_watchdog_lambda_is_wired() {
     .expect("deploy-watchdog-lambda.tf must be readable"); // APPROVED: test
 
     // Two weekday EventBridge schedules, 5 min after each GitHub deploy cron:
-    // 08:50 IST = 03:20 UTC, 15:36 IST = 10:06 UTC.
+    // 08:50 IST = 03:20 UTC, 15:51 IST = 10:21 UTC.
     assert!(
         tf.contains("cron(20 3 ? * MON-FRI *)"),
         "deploy-watchdog must run 08:50 IST (03:20 UTC Mon-Fri) — 5 min after the pre-market cron"
     );
     assert!(
-        tf.contains("cron(6 10 ? * MON-FRI *)"),
-        "deploy-watchdog must run 15:36 IST (10:06 UTC Mon-Fri) — 5 min after the post-market cron"
+        tf.contains("cron(21 10 ? * MON-FRI *)"),
+        "deploy-watchdog must run 15:51 IST (10:21 UTC Mon-Fri) — 5 min after the 15:46 post-market cron"
     );
     // It reads the repo-scoped GitHub token (same param as operator-control)
     // and can publish to the alerts topic.

--- a/crates/common/tests/github_workflow_guard.rs
+++ b/crates/common/tests/github_workflow_guard.rs
@@ -139,7 +139,7 @@ fn r5_uses_pinned_configure_aws_credentials_action() {
 fn r6_has_market_hours_guard_job() {
     let body = read(WORKFLOW);
     must_contain(&body, "guard-market-hours:", "guard-market-hours job");
-    must_contain(&body, "03:30-10:00 UTC", "IST market-hours window comment");
+    must_contain(&body, "03:30-10:15 UTC", "IST market-hours window comment");
     must_contain(&body, "confirm_market_hours", "override input present");
 }
 

--- a/deploy/aws/lambda/deploy-watchdog/handler.py
+++ b/deploy/aws/lambda/deploy-watchdog/handler.py
@@ -1,7 +1,7 @@
 """Deploy watchdog Lambda — AWS-native safety-net for the post-merge auto-deploy.
 
 The post-merge auto-deploy runs from `deploy-aws-after-close.yml`, a GitHub
-Actions cron (08:45 + 15:31 IST Mon-Fri). GitHub-hosted cron is best-effort:
+Actions cron (08:00 + 08:45 + 15:46 IST Mon-Fri). GitHub-hosted cron is best-effort:
 under platform load it can be delayed 10-30+ minutes or skipped entirely, which
 would leave the box running STALE code with no signal. aws-autopilot mitigates
 some of this, but it too runs on GitHub.
@@ -16,7 +16,7 @@ EventBridge triggers fire it:
     deployment should happen instantly when the instance is started"). Latest
     `main` is deployed within ~1-2 min of 08:00, not at the 08:45 cron.
   * 08:50 IST (03:20 UTC Mon-Fri) — backup, 5 min after the 08:45 pre-market cron.
-  * 15:36 IST (10:06 UTC Mon-Fri) — backup, 5 min after the 15:31 post-market cron.
+  * 15:51 IST (10:21 UTC Mon-Fri) — backup, 5 min after the 15:46 post-market cron.
 
 On each fire it answers ONE question, using GitHub as the source of truth (the
 same idempotency signal `deploy-aws-after-close.yml` itself uses):

--- a/deploy/aws/terraform/deploy-watchdog-lambda.tf
+++ b/deploy/aws/terraform/deploy-watchdog-lambda.tf
@@ -1,13 +1,13 @@
 # Deploy-watchdog Lambda — AWS-native safety-net for the post-merge auto-deploy.
 #
 # Operator decision 2026-06-02 ("AWS watchdog safety-net"): keep the existing
-# GitHub-Actions auto-deploy (deploy-aws-after-close.yml cron @ 08:45 + 15:31
-# IST), but add an AWS-native check a few minutes later that covers GitHub-cron
+# GitHub-Actions auto-deploy (deploy-aws-after-close.yml cron @ 08:00 + 08:45 +
+# 15:46 IST), but add an AWS-native check a few minutes later that covers GitHub-cron
 # misses (GitHub-hosted cron can be silently delayed/skipped under load).
 #
 # Two EventBridge schedules invoke the same Lambda with a `window` input:
 #   * 08:50 IST = 03:20 UTC Mon-Fri — 5 min after the pre-market cron.
-#   * 15:36 IST = 10:06 UTC Mon-Fri — 5 min after the post-market cron.
+#   * 15:51 IST = 10:21 UTC Mon-Fri — 5 min after the 15:46 post-market cron.
 #
 # The Lambda asks GitHub "is main HEAD already deployed?" (deployed = head_sha of
 # the most recent SUCCESSFUL deploy-aws.yml run — the same idempotency signal the
@@ -126,8 +126,8 @@ resource "aws_cloudwatch_event_rule" "deploy_watchdog_premarket" {
 
 resource "aws_cloudwatch_event_rule" "deploy_watchdog_postmarket" {
   name                = "tv-${var.environment}-deploy-watchdog-postmarket"
-  description         = "15:36 IST (Mon-Fri) — cover a missed 15:31 post-market auto-deploy"
-  schedule_expression = "cron(6 10 ? * MON-FRI *)"
+  description         = "15:51 IST (Mon-Fri) — cover a missed 15:46 post-market auto-deploy"
+  schedule_expression = "cron(21 10 ? * MON-FRI *)"
 }
 
 resource "aws_cloudwatch_event_target" "deploy_watchdog_premarket" {


### PR DESCRIPTION
## Summary

Implements the operator rule (2026-06-03): **auto-deploy the latest `main` to EC2 whenever the box auto-starts at 08:00 IST, and on any merge — EXCEPT during 09:00 → 15:45 IST (3:45 pm), when deploy must NOT happen.** Every other time deploys; only the 09:00–15:45 IST band is closed.

> "always deploy the app whenever the instance gets auto started at 8 am ... whenever any merge happens to main it should always be auto deployed to ec2 — only between 9 am till 3.45 pm it should not happen. except this time always auto deployment should happen."

### Root-cause it fixes
On 2026-06-03 the box's EventBridge **instance-start failed** (box still `stopped` at 08:15), so the `running` event never fired and no morning deploy ran. The new **02:30 UTC (08:00 IST) cron** dispatches `deploy-aws`, whose `Ensure instance running` step **self-starts a stopped box** in the 08:00–17:00 up-window — so a failed EventBridge start can no longer block the morning deploy. It does not depend on the EC2 `running` event at all.

## Before vs After

| Time (IST) | Before | After |
|---|---|---|
| 08:00 box auto-start | only if EC2 `running` event fires (failed 2026-06-03) | **08:00 cron self-starts box + deploys** (event-independent) |
| 08:45 pre-market | deploy ✅ | deploy ✅ (backup) |
| 09:00–15:30 | blocked | blocked |
| **15:30–15:45** | **deploy ✅** | **blocked** (band extended to 3:45 pm) |
| 15:31 post-market cron | fired (just after close) | moved → **15:46** (clears the 15:45 band) |
| any merge outside band | deploy ✅ | deploy ✅ |

## Changes
- **`deploy-aws-after-close.yml`** — crons now `02:30` (08:00 IST, instance-start/self-start), `03:15` (08:45 backup), `10:16` (15:46, was 15:31).
- **`deploy-aws.yml`** — `guard_market_hours` and the swap-time re-gate band `09:00–15:30` → `09:00–15:45` IST (`1000`→`1015` UTC; `1530`→`1545`).
- **`terraform-apply.yml`** — same band extension (coherent "no prod mutation 09:00–15:45 IST", app or infra).
- **`deploy-watchdog-lambda.tf` + `handler.py`** — post-market backup schedule `15:36` → `15:51` IST (5 min after the moved cron); docstrings updated.
- **Guards** — `aws_infra_wiring.rs` (1015 / 1545 / `30 2` + `16 10` crons / 15:51 watchdog) and `github_workflow_guard.rs` (`03:30-10:15 UTC`).

## Honest envelope
- Merge during 09:00–15:45 IST → blocked → auto-fires at **15:46 IST same day** ✅
- Merge over weekend / before 08:00 → auto-fires **Monday 08:00 IST** (instance-start) ✅
- Box fails to auto-start at 08:00 → the **08:00 cron self-starts it + deploys** before the 09:15 open ✅
- Idempotent: dispatcher compares `main` HEAD vs last successful deploy `head_sha`; no spurious restart on quiet days.
- This is **config/workflow only** — no Rust production code, no hot path, no tick path touched. Zero-tick-loss / O(1) guarantees unaffected.

## Test plan
- [x] `cargo test -p tickvault-common --test aws_infra_wiring --test github_workflow_guard` → **34 + 21 passed**
- [x] `cargo fmt -p tickvault-common --check` clean
- [x] all 3 workflow YAMLs parse (`yaml.safe_load`)
- [x] `.tf` `=` alignment preserved (terraform fmt-safe); watchdog `is_stale` logic untouched (docstring-only change)
- [x] no new `#[test]` fns → test-count baseline unchanged

https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqMSc4AkrVFVfigQcyhFd1)_