### PR TITLE
test(storage): seal-path compound-failure chaos — SIGKILL replay + disk-full→DLQ (zero-tick-loss PR-7, G6+G7)

### DIFF
--- a/.claude/plans/active-plan-zero-tick-loss-hardening.md
+++ b/.claude/plans/active-plan-zero-tick-loss-hardening.md
@@ -167,11 +167,19 @@ This plan closes them, each with a ratchet test so they can't regress.
   sampled metric). 3/3 green in 0.08s.
   - Files: `crates/storage/tests/chaos_midnight_seal_burst.rs`.
 
-- [ ] **PR-7 (G6+G7) — compound-failure chaos tests.** (a) SIGKILL mid-batch-flush
-  → DEDUP absorbs, zero dup/loss; (b) disk-full + QuestDB-down simultaneously →
-  DLQ NDJSON captures every payload.
-  - Files: `crates/storage/tests/chaos_sigkill_mid_flush.rs`,
-    `crates/storage/tests/chaos_disk_full_plus_questdb_down.rs`.
+- [x] **PR-7 (G6+G7) — compound-failure chaos tests.** (PR #TBD) Verified the
+  TICK path already has both (`chaos_sigkill_replay.rs` + `chaos_disk_full.rs`),
+  so — per audit Rule 13 (no redundant tests) — PR-7 targets the genuinely
+  uncovered **SEAL absorption path** (PR-6's new surface): (a) `chaos_seal_sigkill_spill_replay.rs`
+  — 20K seals spilled then SIGKILL (drop without clear); fresh writer `read_all`
+  recovers all 20K byte-exact, in order, and idempotently (re-read = identical
+  set → DEDUP-safe, zero dup/loss); (b) `chaos_seal_disk_full_dlq_capture.rs` —
+  spill dir made unusable (regular-file-at-path → cross-platform, no flaky
+  chmod) + QuestDB down → ring overflow → spill FAILS → DLQ captures every one
+  of 2,500 overflow seals (dropped=0; DLQ NDJSON read back == 2,500). Both run
+  in normal CI. 2/2 green.
+  - Files: `crates/storage/tests/chaos_seal_sigkill_spill_replay.rs`,
+    `crates/storage/tests/chaos_seal_disk_full_dlq_capture.rs`.
 
 - [ ] **PR-8 (H1+H2) — hot-path zero-copy + lossless candles (BIGGER — needs
   its own approval/agent pass).** Pass `Bytes` (Arc clone) into the WAL append

--- a/crates/storage/tests/chaos_seal_disk_full_dlq_capture.rs
+++ b/crates/storage/tests/chaos_seal_disk_full_dlq_capture.rs
@@ -1,0 +1,127 @@
+//! Chaos test (zero-tick-loss PR-7, G7) — disk-full + QuestDB-down at once,
+//! for the SEAL absorption path.
+//!
+//! The tick path already has this compound-failure coverage
+//! (`chaos_disk_full.rs`). The SEAL absorption pipeline added in PR-6 did NOT
+//! — PR-6 deliberately deferred the "tier-2 spill fails → tier-3 DLQ catches
+//! it" case to this PR. This test closes it.
+//!
+//! Scenario: QuestDB is DOWN (so seals can never reach the shadow tables and
+//! pile into the absorption pipeline) AND the spill disk is unusable. The
+//! locked design escalates: ring overflow → spill (FAILS) → DLQ NDJSON
+//! (recoverable text). The ONLY loss path is `SubmitOutcome::Dropped`, which
+//! needs the DLQ to ALSO fail. With a writable DLQ dir, every overflowing
+//! seal MUST be captured in the DLQ — zero drop.
+//!
+//! Cross-platform failure injection: instead of a flaky `chmod` read-only
+//! directory, we point the spill dir at a path that already exists as a
+//! regular FILE. `SealSpillWriter::append_seal` calls `create_dir_all(spill_dir)`
+//! first, which deterministically errors on every OS when the path is a file
+//! — forcing the tier-2 → tier-3 escalation. This runs in normal CI (no
+//! `#[ignore]`, no `unsafe`, no platform gate).
+//!
+//! Honest envelope: this proves bounded zero-loss when spill is dead but the
+//! DLQ is writable. The truly-terminal case (DLQ ALSO unwritable →
+//! `Dropped` → AGGREGATOR-DROP-01 Critical) is by design the end of the line
+//! and is asserted as the typed `Dropped` outcome elsewhere.
+
+use std::path::PathBuf;
+
+use tickvault_storage::seal_absorption::{SealAbsorptionPipeline, SubmitOutcome};
+use tickvault_storage::seal_dlq::SealDlqWriter;
+use tickvault_trading::candles::{BufferedSeal, LiveCandleState, TfIndex};
+
+const NOW_UNIX_SECS: i64 = 1_767_268_800;
+
+fn unique_base(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "tv-pr7-g7-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ))
+}
+
+fn mk_seal(i: usize) -> BufferedSeal {
+    let mut state = LiveCandleState::empty();
+    state.bucket_start_ist_secs = 1_716_000_900u32.wrapping_add(i as u32);
+    state.open = 100.0;
+    state.high = 105.0;
+    state.low = 99.0;
+    state.close = 100.0 + (i % 100) as f64;
+    state.volume = 1234;
+    state.bucket_start_cumulative = 1000;
+    state.oi = 50_000;
+    state.tick_count = 5;
+    BufferedSeal::new((i % 11_000) as u32 + 1, 0, TfIndex::M1, state)
+}
+
+#[test]
+fn test_seal_spill_dead_dlq_captures_every_overflow_zero_drop() {
+    const SMALL_RING: usize = 500;
+    const BURST: usize = 3_000; // 2_500 overflow → spill (dead) → DLQ
+    const OVERFLOW: usize = BURST - SMALL_RING;
+
+    let base = unique_base("dlq-capture");
+    std::fs::create_dir_all(&base).expect("base dir");
+
+    // Make the spill dir UNUSABLE by creating a regular file at its path —
+    // `create_dir_all` inside append_seal will error on every OS, forcing the
+    // tier-2 → tier-3 (DLQ) escalation. This stands in for "spill disk full".
+    let spill_path = base.join("spill_is_a_file");
+    std::fs::write(&spill_path, b"not a directory").expect("write spill blocker file");
+
+    // The DLQ lives on a SEPARATE, writable location — the critical invariant
+    // (mirrors chaos_disk_full.rs): even when spill is dead, the audit trail
+    // survives.
+    let dlq_dir = base.join("dlq");
+
+    let mut pipeline = SealAbsorptionPipeline::with_capacity_and_dirs_for_test(
+        SMALL_RING,
+        spill_path.clone(),
+        dlq_dir.clone(),
+    );
+
+    let mut buffered = 0usize;
+    let mut spilled = 0usize;
+    let mut dlq = 0usize;
+    let mut dropped = 0usize;
+    for i in 0..BURST {
+        match pipeline.submit(mk_seal(i), NOW_UNIX_SECS) {
+            SubmitOutcome::Buffered => buffered += 1,
+            SubmitOutcome::Spilled => spilled += 1,
+            SubmitOutcome::DlqWritten => dlq += 1,
+            SubmitOutcome::Dropped(_) => dropped += 1,
+        }
+    }
+
+    // Headline guarantee: not a single seal lost, even with spill dead.
+    assert_eq!(
+        dropped, 0,
+        "DLQ must catch every overflow when spill is dead — zero drop"
+    );
+    // Spill is dead, so NOTHING may report Spilled.
+    assert_eq!(
+        spilled, 0,
+        "spill dir is unusable — no seal may report Spilled"
+    );
+    // The ring fills, then every overflow escalates straight to the DLQ.
+    assert_eq!(buffered, SMALL_RING, "ring fills to capacity first");
+    assert_eq!(dlq, OVERFLOW, "every overflow seal must be DLQ-captured");
+    // Conservation.
+    assert_eq!(buffered + spilled + dlq + dropped, BURST);
+
+    // The DLQ NDJSON file must actually contain every captured payload as
+    // recoverable text — read it back through the real reader.
+    let reader = SealDlqWriter::with_dlq_dir_for_test(dlq_dir.clone());
+    let recovered = reader.read_all(NOW_UNIX_SECS).expect("DLQ read_all");
+    assert_eq!(
+        recovered.len(),
+        OVERFLOW,
+        "DLQ file must hold exactly the {OVERFLOW} captured seals as recoverable text"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}

--- a/crates/storage/tests/chaos_seal_sigkill_spill_replay.rs
+++ b/crates/storage/tests/chaos_seal_sigkill_spill_replay.rs
@@ -1,0 +1,104 @@
+//! Chaos test (zero-tick-loss PR-7, G6) — SIGKILL mid-flush replay for the
+//! SEAL absorption path, proving zero loss + dedup-safe idempotent recovery.
+//!
+//! The tick path already has SIGKILL-replay coverage (`chaos_sigkill_replay.rs`).
+//! The SEAL spill — written when the aggregator's ILP flush to QuestDB fails
+//! mid-batch — had no equivalent. This test closes it.
+//!
+//! Scenario: a process spilled N sealed candles to disk (each `append_seal`
+//! flushes the `write(2)`, so the bytes are durable) and then died via
+//! `SIGKILL`. Drop impls did NOT run, but the durable records are on disk. A
+//! fresh process must recover EVERY seal byte-exact via `read_all` — zero
+//! loss — and the recovery must be IDEMPOTENT: reading the spill again yields
+//! the identical set (recovery is non-destructive), so a re-run after a crash
+//! mid-replay cannot lose or reorder a seal. Downstream, QuestDB's DEDUP
+//! UPSERT on the shadow-candle key collapses any double-replay into one row,
+//! so idempotent recovery + DEDUP = zero duplicate.
+//!
+//! This is pure on-disk durability + readback — deterministic, cross-platform,
+//! no subprocess, no `unsafe`.
+
+use std::path::PathBuf;
+
+use tickvault_storage::seal_spill::{SealSpillWriter, SerializedSeal};
+use tickvault_trading::candles::{BufferedSeal, LiveCandleState, TfIndex};
+
+const NOW_UNIX_SECS: i64 = 1_767_268_800;
+
+fn unique_dir(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "tv-pr7-g6-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ))
+}
+
+fn mk_serialized(i: usize) -> SerializedSeal {
+    let mut state = LiveCandleState::empty();
+    state.bucket_start_ist_secs = 1_716_000_900u32.wrapping_add(i as u32);
+    state.open = 100.0 + (i % 7) as f64;
+    state.high = 110.0 + (i % 13) as f64;
+    state.low = 90.0 - (i % 5) as f64;
+    state.close = 100.0 + (i % 100) as f64;
+    state.volume = 1_000 + i as u64;
+    state.bucket_start_cumulative = 1000;
+    state.oi = 50_000 + i as i64;
+    state.tick_count = 5;
+    let buffered = BufferedSeal::new((i % 11_000) as u32 + 1, 0, TfIndex::M1, state);
+    SerializedSeal::from(&buffered)
+}
+
+#[test]
+fn test_seal_spill_survives_sigkill_and_replays_loss_free_and_idempotent() {
+    const N: usize = 20_000;
+
+    let dir = unique_dir("replay");
+
+    // --- Process 1: spill N seals, then "die" via SIGKILL (drop without clear).
+    let originals: Vec<SerializedSeal> = (0..N).map(mk_serialized).collect();
+    {
+        let writer = SealSpillWriter::with_spill_dir_for_test(dir.clone());
+        for seal in &originals {
+            writer
+                .append_seal(seal, NOW_UNIX_SECS)
+                .expect("append must succeed on a writable dir");
+        }
+        // SIGKILL semantics: no clear_spill_for_date, no graceful shutdown —
+        // the writer is simply dropped. Each append already flushed to the OS,
+        // so the file is durable.
+    }
+
+    // --- Process 2: fresh writer recovers from the SAME spill dir.
+    let recovery = SealSpillWriter::with_spill_dir_for_test(dir.clone());
+    let recovered = recovery
+        .read_all(NOW_UNIX_SECS)
+        .expect("read_all after crash");
+
+    // Zero loss: every spilled seal is recovered, in order, byte-exact.
+    assert_eq!(
+        recovered.len(),
+        N,
+        "every spilled seal must survive the crash"
+    );
+    assert_eq!(
+        recovered, originals,
+        "recovered seals must match the spilled originals exactly (no loss, no reorder, no corruption)"
+    );
+
+    // Idempotent recovery: read_all is non-destructive — a second read (e.g.
+    // after the replay itself is interrupted by a second crash) yields the
+    // identical set. Combined with QuestDB DEDUP UPSERT, double-replay = zero
+    // duplicate rows.
+    let recovered_again = recovery
+        .read_all(NOW_UNIX_SECS)
+        .expect("idempotent read_all");
+    assert_eq!(
+        recovered_again, originals,
+        "recovery must be idempotent — re-reading the spill yields the same seals"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary

**PR-7 of the zero-tick-loss-hardening plan — closes G6+G7.**

**Verified before writing (audit Rule 13 — no redundant tests):** the **tick path** already has both compound-failure tests (`chaos_sigkill_replay.rs` + `chaos_disk_full.rs`). So PR-7 targets the genuinely uncovered **seal-absorption path** — PR-6's new surface, which until now had only the happy-path burst test.

| Test (G) | Scenario | Proves |
|---|---|---|
| **G6** `chaos_seal_sigkill_spill_replay.rs` | spill 20K seals (each flushed → durable), then SIGKILL (drop writer, no clear); fresh writer recovers | all 20K recovered **byte-exact, in order**; recovery **idempotent** (re-read = identical set) → with QuestDB DEDUP UPSERT, double-replay = **zero duplicate**, zero loss |
| **G7** `chaos_seal_disk_full_dlq_capture.rs` | QuestDB down **and** spill disk unusable; small ring + 3K burst | ring overflow → spill **fails** → DLQ captures all 2,500 overflow (dropped=0, spilled=0, dlq=2,500); DLQ NDJSON **read back == 2,500** recoverable records on a separate writable dir |

## Cross-platform failure injection (no flaky chmod)
G7 makes the spill dir unusable by pointing it at a **regular file** — `append_seal`'s `create_dir_all` then errors deterministically on every OS, forcing the tier-2 → tier-3 (DLQ) escalation. So unlike the tick-path `chaos_disk_full.rs` (which is `#[ignore]` + Unix-only chmod), **both PR-7 tests run in normal CI**.

## Honest envelope
Bounded zero-loss when spill is dead **but the DLQ is writable**. The terminal case (DLQ *also* unwritable → `Dropped` → AGGREGATOR-DROP-01 Critical) is by design the end of the line — not claimed here.

## Verification
- ✅ 2/2 green (0.12s + 0.18s)
- ✅ `cargo clippy … --test chaos_seal_* -- -D warnings` → exit 0
- ✅ banned-pattern + pub-fn guards clean (test-only; no new pub fn / metric / ErrorCode → no cross-ref/tag/triage impact)

https://claude.ai/code/session_01UeN1tUvUdZG9qKpT35U8SJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeN1tUvUdZG9qKpT35U8SJ)_