### PR TITLE
fix(operator-control): docker-reset removes tv-questdb-data volume BY NAME (data survived the nuke)

### DIFF
--- a/deploy/aws/lambda/operator-control/handler.py
+++ b/deploy/aws/lambda/operator-control/handler.py
@@ -525,12 +525,30 @@ def lambda_handler(event, _context):
             if not force:
                 return _resp(409, {"error": 'docker-reset is the FULL nuke (deletes volumes + images + ALL data incl. SEBI audit tables) — re-send with {"force": true}', "action": action})
             compose_dir = "/opt/tickvault/repo/deploy/docker"
+            # The data lives in the NAMED volume `tv-questdb-data` (container
+            # `tv-questdb`). `docker compose down -v` in compose_dir does NOT
+            # reliably remove it — QuestDB may run outside this compose project
+            # (the documented wipe-questdb caveat), so `down -v` leaves the
+            # named volume intact and `up` re-attaches the SAME old data. The
+            # fix: force-remove the container BY NAME (releases the volume),
+            # then remove the volume BY NAME, then `up` recreates it EMPTY.
             cmds = [
                 "set +e",
                 "systemctl stop tickvault || true",
+                # 1. force-remove the data containers BY NAME (releases volumes)
+                "docker rm -f tv-questdb tv-loki tv-alloy 2>/dev/null || true",
+                # 2. remove the QuestDB data volume BY NAME (the actual ticks/candles)
+                "docker volume rm tv-questdb-data 2>/dev/null || true",
+                # 3. compose-level teardown for anything still managed there
                 f"cd {compose_dir} || exit 0",
                 "docker compose down -v --remove-orphans || true",
+                # 4. belt-and-suspenders: volume again (in case compose re-held it)
+                "docker volume rm tv-questdb-data 2>/dev/null || true",
+                # 5. images + any leftover unused volumes
                 "docker system prune -af --volumes || true",
+                # 6. verify the volume is GONE before recreating (loud if not)
+                "docker volume inspect tv-questdb-data >/dev/null 2>&1 && echo 'WARN: tv-questdb-data still present' || echo 'OK: tv-questdb-data removed'",
+                # 7. recreate everything fresh (empty volume) + restart app
                 "docker compose up -d || true",
                 "systemctl enable tickvault || true",
                 "systemctl restart tickvault || true",

--- a/deploy/aws/terraform/operator-control-lambda.tf
+++ b/deploy/aws/terraform/operator-control-lambda.tf
@@ -1,6 +1,6 @@
 # Operator portal Lambda — action backend for the single-page operator portal
 # (Overview / Data / GitHub / Logs / AWS / Latency tabs).
-# Re-trigger marker: bump to fire terraform-apply (re-zips handler.py). (2026-06-04a — ship docker-reset button from PR #1012)
+# Re-trigger marker: bump to fire terraform-apply (re-zips handler.py). (2026-06-04b — docker-reset removes tv-questdb-data volume BY NAME)
 #
 # WHY: the operator wants ONE place (console URL + Telegram) to view AND control
 # the box, without the AWS console or GitHub UI. Grafana = view; this = control.


### PR DESCRIPTION
## The bug you hit live
You ran **Full Docker reset → NUKE**, but the ticks/candles were still there. **Cause:** the reset ran `docker compose down -v` inside `/opt/tickvault/repo/deploy/docker`, but **QuestDB runs outside that compose project on the box** — the existing `wipe-questdb` code even documents this (*"down -v proved unreliable — QuestDB started outside the compose project / volume in-use"*). So `down -v` left the **named volume `tv-questdb-data` intact**, and `up` re-attached the **same old data**. The nuke deleted containers + images but **not the data**. That was my mistake — I used `down -v` despite the documented warning.

## The fix
Remove the data **by name**, which works regardless of how QuestDB was started:
1. `systemctl stop tickvault`
2. `docker rm -f tv-questdb tv-loki tv-alloy` — force-remove containers **by name** (releases the volume)
3. `docker volume rm tv-questdb-data` — **delete the actual ticks/candles volume by name**
4. `docker compose down -v --remove-orphans` (compose-managed leftovers)
5. `docker volume rm tv-questdb-data` again (belt-and-suspenders)
6. `docker system prune -af --volumes` (images + unused volumes)
7. **verify**: echo `WARN: tv-questdb-data still present` if it survived, else `OK: tv-questdb-data removed`
8. `docker compose up -d` → recreates the volume **EMPTY** → fresh QuestDB
9. restart app

Marker bumped so `terraform-apply` re-zips + redeploys the Lambda with the fix.

## Note (also told the operator)
The `localhost:9000` console is the **local Mac** QuestDB — the AWS nuke can't touch a laptop. But this flaw was real on AWS too, so it's fixed regardless. For an **immediate** wipe today, the **🗑️ Wipe ALL data** button (SQL `TRUNCATE`) deletes every tick + candle reliably right now.

## Verification
- Lambda unittest **31/31 green**, `py_compile` clean.
- Net diff vs main = 2 files (handler cmds + terraform marker).

https://claude.ai/code/session_01UeN1tUvUdZG9qKpT35U8SJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeN1tUvUdZG9qKpT35U8SJ)_