### PR TITLE
fix(deploy): capture on-box journal when app dies in the 60s verify window

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -643,21 +643,24 @@ jobs:
 
       - name: Monitor first 60 seconds for crashes
         run: |
+          REGION="${{ vars.AWS_REGION || 'ap-south-1' }}"
+          IID="${{ secrets.EC2_INSTANCE_ID }}"
           # Poll the app systemd state every 10 seconds for 60 seconds.
-          # If it goes inactive, the deploy failed — roll back.
+          # If it goes inactive, the deploy failed — capture WHY (the on-box
+          # journal) BEFORE rolling back, then roll back.
           FAIL=0
           for i in 1 2 3 4 5 6; do
             STATE=$(aws ssm send-command \
-              --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
-              --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+              --region "$REGION" \
+              --instance-ids "$IID" \
               --document-name "AWS-RunShellScript" \
               --parameters 'commands=["systemctl is-active tickvault"]' \
               --query 'Command.CommandId' --output text)
             sleep 5
             RESULT=$(aws ssm get-command-invocation \
-              --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
+              --region "$REGION" \
               --command-id "$STATE" \
-              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+              --instance-id "$IID" \
               --query 'StandardOutputContent' --output text | tr -d '[:space:]')
             echo "Check $i: systemd state = $RESULT"
             if [ "$RESULT" != "active" ]; then
@@ -667,10 +670,46 @@ jobs:
             sleep 5
           done
           if [ "$FAIL" -eq 1 ]; then
+            # ── Z+ L1 DETECT (2026-06-05 fix, deploy run #176) ───────────────
+            # The app started but DIED inside this 60s verify window — the most
+            # common real failure (a delayed boot-step panic between T+5s and
+            # T+60s). The on-box restart-failure path dumps the journal, but a
+            # crash caught HERE previously rolled back with ZERO diagnostic, so
+            # the operator saw "FAILED" and never learned WHY. Capture the raw
+            # app stdout/stderr + systemd status NOW, before the rollback swaps
+            # the binary back, so the reason reaches BOTH the deploy log AND the
+            # Telegram failure alert. "100% logging — no silent failures."
+            echo "===== APP DIED IN VERIFY WINDOW — capturing on-box diagnostics ====="
+            DIAG_CMD=$(aws ssm send-command \
+              --region "$REGION" \
+              --instance-ids "$IID" \
+              --document-name "AWS-RunShellScript" \
+              --comment "tickvault verify-window crash diagnostics sha=${{ github.sha }}" \
+              --parameters 'commands=["echo ===== systemctl status =====","systemctl status tickvault.service --no-pager -l 2>&1 | tail -n 40 || true","echo ===== app stdout/stderr ONLY last 120 =====","journalctl -u tickvault.service -n 120 --no-pager --output=cat 2>&1 || true"]' \
+              --query 'Command.CommandId' --output text 2>/dev/null || echo "")
+            DIAG=""
+            if [ -n "$DIAG_CMD" ]; then
+              sleep 6
+              DIAG=$(aws ssm get-command-invocation \
+                --region "$REGION" \
+                --command-id "$DIAG_CMD" \
+                --instance-id "$IID" \
+                --query 'StandardOutputContent' --output text 2>/dev/null || echo "(diagnostics fetch failed)")
+            fi
+            echo "----- ON-BOX CRASH DIAGNOSTICS -----"
+            echo "$DIAG"
+            echo "------------------------------------"
+            # Hand the last ~12 lines to the failure-notify step so the operator
+            # sees the reason on Telegram WITHOUT opening the Actions run.
+            {
+              echo "CRASH_DIAG<<EOF_DIAG"
+              echo "$DIAG" | tail -n 12
+              echo "EOF_DIAG"
+            } >> "$GITHUB_ENV"
             echo "ROLLBACK: tickvault is not active after deploy — rolling back"
             aws ssm send-command \
-              --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
-              --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+              --region "$REGION" \
+              --instance-ids "$IID" \
               --document-name "AWS-RunShellScript" \
               --parameters 'commands=["set -euo pipefail","if [ ! -d /opt/tickvault ]; then echo SKIP_ROLLBACK_NO_DIR; exit 0; fi","cd /opt/tickvault","if [ -f bin/tickvault.backup ]; then mv bin/tickvault.backup bin/tickvault; systemctl restart tickvault; fi"]'
             exit 1
@@ -724,8 +763,17 @@ jobs:
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
           IST_TIME="$(TZ='Asia/Kolkata' date +'%I:%M %p IST')"
+          MSG="🆘 Deploy FAILED at ${IST_TIME} (version ${SHORT_SHA}). The app was auto-stopped to avoid repeated alerts; the next deploy re-enables it. Check the run: ${{ github.run_id }}"
+          # If the app started then crashed inside the 60s verify window, the
+          # Monitor step captured WHY into CRASH_DIAG — forward it so the
+          # operator sees the actual reason on the phone, not just "FAILED".
+          # printf keeps every YAML block-scalar line indented (a bare
+          # unindented continuation line would terminate the `run: |` block).
+          if [ -n "${CRASH_DIAG:-}" ]; then
+            MSG="$(printf '%s\n\nWhy it died (last lines on the box):\n%s' "$MSG" "$CRASH_DIAG")"
+          fi
           aws sns publish \
             --region ${{ vars.AWS_REGION || 'ap-south-1' }} \
             --topic-arn arn:aws:sns:${{ vars.AWS_REGION || 'ap-south-1' }}:${{ steps.acct.outputs.id }}:tv-prod-alerts \
             --subject "🆘 tickvault deploy FAILED" \
-            --message "🆘 Deploy FAILED at ${IST_TIME} (version ${SHORT_SHA}). The app was auto-stopped to avoid repeated alerts; the next deploy re-enables it. Check the run: ${{ github.run_id }}"
+            --message "$MSG"


### PR DESCRIPTION
## Summary

`deploy-aws` run **#176** (commit `833fcb6`, 2026-06-04 16:56 IST) failed — and that failure left the box **disabled overnight**, which is why the next morning's **08:00 auto-start FAILED**. The evidence from the run log:

| Verify check (GitHub-side, every ~10s) | systemd state |
|---|---|
| Check 1 | `active` |
| Check 2 | `active` |
| Check 3 | `active` |
| Check 4 | `active` |
| Check 5 | `active` |
| **Check 6 (~60s)** | **(empty — not active)** → ROLLBACK + `systemctl disable tickvault` |

**Conclusion: the app DID start.** It ran fine for ~50 seconds, then the process **crashed/exited between T+50s and T+60s** (a delayed boot-step death). The deploy correctly rolled back — but then `systemctl disable tickvault` left the service disabled, so the 08:00 EC2 auto-start couldn't bring it up.

**The blind spot this PR fixes:** the on-box *restart-failure* path already dumps `journalctl`, but a crash caught **later** by the GitHub-side 60s poll rolled back with **ZERO diagnostic**. The operator (and the next session) saw `deploy FAILED` and **never learned WHY** the app died at 50s. That is a Z+ **L1 DETECT** violation and breaches the charter's *"100% logging — no silent failures."*

## What changed (1 file, `.github/workflows/deploy-aws.yml`)

1. **Monitor step** — when the 60s poll detects the app is no longer `active`, it now runs an SSM command to capture `systemctl status tickvault` + `journalctl -u tickvault --output=cat -n 120` (raw app stdout/stderr) **before** the rollback swaps the binary back. The output is echoed into the deploy log.
2. **Failure-notify step** — the last ~12 captured lines are handed forward via `CRASH_DIAG` and appended to the Telegram failure alert, so the operator sees the actual reason on their phone without opening Actions.

## Honest envelope (no hallucination)

This PR fixes the **blindness**, not necessarily the **crash**. I could not read the EC2 journal from the build sandbox (no SSH/AWS creds there), so I do **not** yet know the exact panic line that killed the app at ~50s. This change guarantees the reason is captured on the **next** occurrence. Because the workflow auto-triggers on a `deploy-aws.yml` push to `main`, merging this will redeploy `main` and **re-enable** the service; if it crashes again at ~50s, the journal will now be captured (deploy log + Telegram) — turning a silent failure into a diagnosable one. (A hostile-review agent is separately auditing `main.rs` boot steps for the likely T+50s exit; findings will be posted as a follow-up.)

## Test plan
- [x] `python3 -c "yaml.safe_load(...)"` — YAML parses cleanly
- [x] `cargo test -p tickvault-common --test aws_infra_wiring` — **34/34 green**
- [x] `cargo test -p tickvault-common --test github_workflow_guard` — **21/21 green**
- [x] No negative-assertion ratchet tripped (verified: 15MB-cap & empty-AWS_ACCOUNT_ID guards untouched; all `must_contain` strings preserved)

## Zero-Loss Guarantee Charter check
- [x] Logging: turns a silent deploy failure into a logged + Telegram-forwarded reason (closes the gap)
- [x] Alerting: failure alert now carries the crash reason
- [x] No new hot-path code; deploy-time only (zero runtime/latency impact)
- [x] Evidence pasted (run #176 check-by-check table above), not claimed
- [x] "100%" wording carries the honest envelope qualifier
- [N/A] Code/perf/DB coverage — CI-only workflow change, no Rust runtime code

🤖 Investigation + fix driven from a `/loop` session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_