### PR TITLE
fix(operator-control): harden docker-reset so the nuke really wipes everything

### DIFF
--- a/deploy/aws/lambda/operator-control/handler.py
+++ b/deploy/aws/lambda/operator-control/handler.py
@@ -509,45 +509,62 @@ def lambda_handler(event, _context):
             #
             # Sequence (each step fail-soft so one hiccup can't wedge the box):
             #   1. stop the app (systemd) so it releases the QuestDB connection
-            #      (the in-use volume is exactly why `down -v` was unreliable
-            #      for wipe-questdb — stopping the app first fixes that).
-            #   2. `docker compose down -v --remove-orphans` — drop containers
-            #      + named volumes (QuestDB data, loki, alloy).
-            #   3. `docker system prune -af --volumes` — delete images +
-            #      any remaining unused volumes (the "delete images" intent).
-            #   4. `docker compose up -d` — re-pull the SHA256-pinned images
-            #      and recreate containers on EMPTY volumes.
-            #   5. restart the app — it recreates `ticks` + candle tables fresh
-            #      via `ensure_*_table_dedup_keys`, so the new table is born
-            #      with the correct DEDUP UPSERT KEYS (incl. received_at) — a
-            #      fresh start also clears the stale "sub-second dedup OLD"
-            #      condition. Next instance start is also clean (empty volumes).
+            #      and the volume (an in-use volume is exactly why `volume rm`
+            #      silently failed before).
+            #   2. remove EVERY container that mounts `tv-questdb-data` — by
+            #      VOLUME, not by name — so QuestDB is caught even when it runs
+            #      under a different container name / compose project (the
+            #      documented "outside the compose project" case). THIS is the
+            #      fix for "the nuke didn't wipe the data": the old code removed
+            #      only the literal name `tv-questdb`, so an off-project QuestDB
+            #      kept the volume in-use and `volume rm` no-op'd under `|| true`.
+            #   3. compose down -v + `docker system prune -af --volumes` — drop
+            #      remaining containers, named volumes, and images.
+            #   4. HARD GATE: if `tv-questdb-data` still exists it is still
+            #      in-use → DO NOT `up` (that would re-attach the SAME old
+            #      ticks — the silent-survival bug). Fail LOUD + `exit 1` so the
+            #      operator sees the nuke did not complete, instead of a fake OK.
+            #   5. wipe the HOST app caches too (instrument-cache, spill, dlq)
+            #      under /opt/tickvault/data — these are host dirs the Docker
+            #      nuke cannot see, so "reuse the existing list" survived every
+            #      reset. Logs are preserved for forensics.
+            #   6. `docker compose up -d` on the now-empty volume + restart app —
+            #      it recreates `ticks` + candle + audit tables fresh via
+            #      `ensure_*_table_dedup_keys` with the correct DEDUP keys.
             if not force:
                 return _resp(409, {"error": 'docker-reset is the FULL nuke (deletes volumes + images + ALL data incl. SEBI audit tables) — re-send with {"force": true}', "action": action})
             compose_dir = "/opt/tickvault/repo/deploy/docker"
-            # The data lives in the NAMED volume `tv-questdb-data` (container
-            # `tv-questdb`). `docker compose down -v` in compose_dir does NOT
-            # reliably remove it — QuestDB may run outside this compose project
-            # (the documented wipe-questdb caveat), so `down -v` leaves the
-            # named volume intact and `up` re-attaches the SAME old data. The
-            # fix: force-remove the container BY NAME (releases the volume),
-            # then remove the volume BY NAME, then `up` recreates it EMPTY.
+            data_dir = "/opt/tickvault/data"
             cmds = [
                 "set +e",
+                # 1. stop the app so it releases the QuestDB connection + volume
                 "systemctl stop tickvault || true",
-                # 1. force-remove the data containers BY NAME (releases volumes)
+                # 2. ROBUST: remove EVERY container mounting the data volume, by
+                #    VOLUME not by name — catches an off-project / renamed QuestDB
+                #    that the old by-name `docker rm -f tv-questdb` missed, which
+                #    left the volume in-use so `volume rm` silently no-op'd.
+                "docker ps -aq --filter volume=tv-questdb-data | xargs -r docker rm -f 2>/dev/null || true",
+                # also drop the well-known sidecar containers by name
                 "docker rm -f tv-questdb tv-loki tv-alloy 2>/dev/null || true",
-                # 2. remove the QuestDB data volume BY NAME (the actual ticks/candles)
-                "docker volume rm tv-questdb-data 2>/dev/null || true",
                 # 3. compose-level teardown for anything still managed there
                 f"cd {compose_dir} || exit 0",
                 "docker compose down -v --remove-orphans || true",
-                # 4. belt-and-suspenders: volume again (in case compose re-held it)
-                "docker volume rm tv-questdb-data 2>/dev/null || true",
-                # 5. images + any leftover unused volumes
+                # 4. the volume is now unreferenced — remove it, then prune images
+                "docker volume rm -f tv-questdb-data 2>/dev/null || true",
                 "docker system prune -af --volumes || true",
-                # 6. verify the volume is GONE before recreating (loud if not)
-                "docker volume inspect tv-questdb-data >/dev/null 2>&1 && echo 'WARN: tv-questdb-data still present' || echo 'OK: tv-questdb-data removed'",
+                # 5. HARD GATE — fail LOUD instead of silently re-attaching stale
+                #    data. If the volume survived, it is still in-use; do NOT `up`.
+                "if docker volume inspect tv-questdb-data >/dev/null 2>&1; then "
+                "echo 'DOCKER-RESET-FAILED: tv-questdb-data still present (in-use) — NOT recreating to avoid re-attaching stale data. Holders:'; "
+                "docker ps -a --filter volume=tv-questdb-data --format '{{.Names}} ({{.Status}})'; "
+                "echo docker-reset-FAILED; exit 1; "
+                "fi",
+                "echo 'OK: tv-questdb-data removed'",
+                # 6. wipe HOST app caches too (the Docker nuke can't see these) —
+                #    instrument-cache (the 'reused existing list' that survived),
+                #    spill + dlq. Logs are KEPT for forensics.
+                f"rm -rf {data_dir}/instrument-cache {data_dir}/spill {data_dir}/dlq 2>/dev/null || true",
+                "echo 'OK: host caches wiped (instrument-cache, spill, dlq); logs preserved'",
                 # 7. recreate everything fresh (empty volume) + restart app
                 "docker compose up -d || true",
                 "systemctl enable tickvault || true",

--- a/deploy/aws/lambda/operator-control/test_handler.py
+++ b/deploy/aws/lambda/operator-control/test_handler.py
@@ -287,6 +287,30 @@ class WipeGate(unittest.TestCase):
         # Membership = market-hours-blocked during 09:15-15:30 IST.
         self.assertIn("docker-reset", handler._DESTRUCTIVE)
 
+    def test_docker_reset_forced_is_hardened_full_nuke(self) -> None:
+        # Regression 2026-06-05: "the nuke didn't wipe the data". The forced
+        # docker-reset must (a) remove containers by VOLUME (not just the literal
+        # name tv-questdb, which missed an off-project QuestDB), (b) fail LOUD
+        # without recreating if the volume survives, and (c) wipe the HOST app
+        # caches the Docker nuke can't see (instrument-cache/spill/dlq).
+        captured: dict = {}
+        orig = handler._ssm_shell
+        handler._ssm_shell = lambda cmds: (captured.__setitem__("cmds", cmds) or "cmd-123")  # type: ignore[assignment]
+        try:
+            resp = self._docker_reset(force=True)
+        finally:
+            handler._ssm_shell = orig  # type: ignore[assignment]
+        self.assertEqual(resp["statusCode"], 200)
+        joined = "\n".join(captured["cmds"])
+        # (a) robust container removal by VOLUME, not just by name
+        self.assertIn("--filter volume=tv-questdb-data", joined)
+        # (b) hard fail-loud gate — must NOT recreate if the volume survives
+        self.assertIn("DOCKER-RESET-FAILED", joined)
+        # (c) host caches wiped too (the dirs the Docker nuke cannot see)
+        self.assertIn("/opt/tickvault/data/instrument-cache", joined)
+        self.assertIn("/opt/tickvault/data/spill", joined)
+        self.assertIn("/opt/tickvault/data/dlq", joined)
+
 
 class HtmlWipeButton(unittest.TestCase):
     def test_html_has_wipe_button(self) -> None:

--- a/deploy/aws/terraform/operator-control-lambda.tf
+++ b/deploy/aws/terraform/operator-control-lambda.tf
@@ -1,6 +1,6 @@
 # Operator portal Lambda — action backend for the single-page operator portal
 # (Overview / Data / GitHub / Logs / AWS / Latency tabs).
-# Re-trigger marker: bump to fire terraform-apply (re-zips handler.py). (2026-06-04b — docker-reset removes tv-questdb-data volume BY NAME)
+# Re-trigger marker: bump to fire terraform-apply (re-zips handler.py). (2026-06-05 — docker-reset hardened: remove containers BY VOLUME, fail-loud gate if volume survives, wipe host caches)
 #
 # WHY: the operator wants ONE place (console URL + Telegram) to view AND control
 # the box, without the AWS console or GitHub UI. Grafana = view; this = control.


### PR DESCRIPTION
## Summary

The operator hit it again: the **full Docker reset (the "nuke") did not wipe the data.** I traced it to **three independent reasons**, only one of which the old nuke even addressed (#1014 fixed by-name volume removal, but that wasn't enough).

| Where data lives | Old nuke result | Root cause |
|---|---|---|
| QuestDB `ticks`/candles → volume `tv-questdb-data` | **survived** | `docker rm -f tv-questdb` (by **name**) missed an off-project/renamed QuestDB → volume stayed in-use → `docker volume rm … \|\| true` silently no-op'd → `up` re-attached the **same old ticks** |
| Silent survival | **hidden** | verify only echoed `WARN: still present`, then ran `up` anyway → operator saw a fake "OK" |
| App caches → host dir `/opt/tickvault/data` (instrument-cache, spill, dlq) | **survived** | these are **host dirs**, not Docker volumes — the Docker nuke can't see them. This is the `"reused the existing list (243 rows)"` that kept appearing after a "full" reset |

## What changed (`deploy/aws/lambda/operator-control/handler.py`)

1. **Remove containers BY VOLUME, not by name** — `docker ps -aq --filter volume=tv-questdb-data | xargs -r docker rm -f`, so QuestDB is released even under a different container name / compose project (the documented "outside the compose project" case).
2. **HARD GATE — fail loud, don't fake-OK** — if `tv-questdb-data` still exists after removal it's still in-use; print `DOCKER-RESET-FAILED` + the holder containers and `exit 1` **without** recreating, instead of `up`-ing onto stale data.
3. **Wipe the host caches too** — `rm -rf /opt/tickvault/data/{instrument-cache,spill,dlq}` so "nuke" means everything. **Logs preserved** for forensics.
4. **terraform marker bumped** (`operator-control-lambda.tf`) so `terraform-apply` re-zips + redeploys the Lambda (it triggers on `deploy/aws/terraform/**`, not the lambda path).

## Why this is safe to merge now (box is LIVE pre-market)

This changes **only the operator-control Lambda** (deployed by `terraform-apply`). It does **not** touch the running app, QuestDB, or `deploy-aws`, and does **not** run any destructive command — it only changes what the nuke *would* do **when the operator explicitly types `NUKE` + force=true**. Zero impact on today's session.

## Test plan
- [x] `python3 -m unittest test_handler` — **32/32 green** (was 31; added `test_docker_reset_forced_is_hardened_full_nuke` asserting all three invariants: by-volume removal, fail-loud gate, host-cache wipe)
- [x] `handler.py` + `test_handler.py` syntax OK (`ast.parse`)
- [x] Existing guards intact: `docker-reset` still force-required (409 without force) + still in `_DESTRUCTIVE` (market-hours blocked)

## Honest envelope
This makes the nuke **actually** wipe Docker volumes + images **and** the host caches, and **fail loudly** rather than silently re-attach stale data. It does not change the SEBI-audit-loss warning or the `type NUKE` double-confirm. If a container genuinely cannot be removed (extreme edge), the gate now leaves the stack **down + loud** rather than **up + lying** — the correct failure mode for a nuke.

🤖 From a `/loop` investigation session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_