### PR TITLE
fix(ci): make Coverage & Perf actually run — skip DHAT tests under llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,8 +239,17 @@ jobs:
       - name: Run coverage (workspace, JSON output)
         run: |
           cargo llvm-cov clean --workspace
+          # DHAT zero-alloc tests (dhat_instrument_registry / dhat_token_handle /
+          # dhat_tick_persistence) assert EXACT heap-allocation counts. Under
+          # llvm-cov the coverage instrumentation ITSELF adds allocations, so
+          # those assertions fail (exit 101) and abort the whole coverage run —
+          # this is why "Coverage & Perf" was RED on main for days and never
+          # produced coverage.json. DHAT-vs-coverage is a known incompatibility.
+          # Skip the dhat_* tests HERE only; they STILL run + enforce zero-alloc
+          # in the normal Test (core)/Test (storage) jobs, so the guarantee holds.
           cargo llvm-cov --workspace --no-fail-fast --json \
-            --output-path target/llvm-cov/coverage.json
+            --output-path target/llvm-cov/coverage.json \
+            -- --skip dhat_
 
       - name: Enforce per-crate coverage thresholds
         run: bash scripts/coverage-gate.sh target/llvm-cov/coverage.json


### PR DESCRIPTION
## Summary

**The real reason your PRs merge "all green" but the system isn't actually 100%-verified:** the `Coverage & Perf` job (the only thing that enforces 100% coverage) **runs post-merge only** (`ci.yml` `if: github.event_name == 'push'`) **and has been 🔴 RED on `main` for days.**

### Root cause (real CI evidence, run #2925)
```
error: 3 targets failed:
  dhat_instrument_registry · dhat_token_handle · dhat_tick_persistence
process didn't exit successfully ... exit status 101
```
The 3 **DHAT tests** assert *exact* zero heap-allocation counts. `cargo-llvm-cov`'s coverage instrumentation **itself adds allocations**, so those assertions fail → the whole coverage run aborts → **no `coverage.json`** → the 100% threshold check is `skipped` → job RED. DHAT-vs-coverage is a known, expected incompatibility. Because the job runs post-merge, a red check never blocked a single merge — the "illusion."

## Fix
`-- --skip dhat_` on the coverage run, so the 3 `dhat_*` tests are skipped **under llvm-cov only**. They **still run + enforce zero-alloc in the normal `Test (core)` / `Test (storage)` jobs**, so the O(1)/zero-alloc guarantee is unchanged.

## Honest envelope (no illusion)
This fixes the **crash** so coverage actually *produces a number*. It does **NOT** by itself prove 100% — once the run succeeds, `coverage-gate.sh` runs the real per-crate threshold check and will report the **true** coverage, which may reveal genuine gaps. **That real number is the point.** I'm not claiming this turns coverage green; I'm making the tool able to measure at all.

## Test plan
- [x] `python3 -c yaml.safe_load` — `ci.yml` parses cleanly
- [x] Root cause confirmed from the live failing job log (exit 101 on 3 dhat targets), not guessed
- [ ] Post-merge `Coverage & Perf` produces `coverage.json` and reports the real % (verifiable on the next push to `main`)

This is **step 1** of the GitHub-hardening you approved (fix the broken coverage job). Next: make Coverage/Bench run on PRs + branch-protection-as-code (terraform) so nothing can merge without every check truly green.

🤖 From a `/loop` investigation session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_