### PR TITLE
feat(app): operator visibility + on-demand run for post-market cross-verify

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -81,3 +81,18 @@ summary. A new `"running on-demand NOW"` info log marks forced runs so they are
 distinguishable from the scheduled 15:31 run in the logs. No new metric/table
 needed — honest scope: this is cold-path operator tooling, not a hot path, so
 no O(1) / zero-tick-loss claims apply.
+
+## Per-Item Guarantee Matrix (cross-reference)
+
+This plan and every item in it are bound by the 15-row 100% guarantee matrix
+and the 7-row resilience demand matrix — see
+`.claude/rules/project/per-wave-guarantee-matrix.md`. All 15 + 7 rows apply to
+every item in this plan.
+
+**Honest envelope (per `wave-4-shared-preamble.md` §8):** any "100%" wording
+here means "100% inside the tested envelope, with ratcheted regression
+coverage" — the envelope being the 8 pure-decision unit tests + the 16 existing
+cross-verify tests + the design-first wall gate. This change is cold-path
+operator tooling and carries NO O(1) / zero-tick-loss / hot-path guarantee,
+because it does not touch the hot path; asserting otherwise would be the
+hallucination the operator forbids.

--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Cross-verify visibility + on-demand dry-run
+
+**Status:** APPROVED
+**Date:** 2026-06-05
+**Approved by:** Parthiban ("yes go ahead dude")
+**Crate(s) touched:** `app`
+
+## Plan Items
+
+- [x] Item 1 — Pure, unit-tested scheduling decision in the `app` crate
+  - Files: `crates/app/src/cross_verify_1m_boot.rs`
+  - Tests: `start_decision_tests::*` (8 tests)
+- [x] Item 2 — Wire `TICKVAULT_CROSS_VERIFY_NOW` on-demand override into boot
+  - Files: `crates/app/src/main.rs`
+- [x] Item 3 — `make cross-verify-show` (human-visible CSV window) + script
+  - Files: `Makefile`, `scripts/cross-verify-show.sh`
+- [x] Item 4 — `make cross-verify-now` (on-demand run)
+  - Files: `Makefile`
+- [x] Item 5 — Operator runbook
+  - Files: `docs/runbooks/cross-verify-1m.md`
+
+## Design
+
+The post-market 1-minute cross-verification already exists, is wired in
+`crates/app/src/main.rs`, and runs at 15:31 IST (`run_cross_verify_1m`). The
+gap is purely operator **visibility** and the ability to **prove** it without
+waiting for 15:31 on a live day. We add three things, reusing the existing,
+proven verification with zero changes to its comparison logic:
+
+1. A pure function `decide_cross_verify_start(now_secs_of_day, is_trading_day,
+   force_now) -> CrossVerifyStart` in the `app` crate that replaces the inline
+   scheduling. It is fully unit-tested. `main.rs` reads
+   `TICKVAULT_CROSS_VERIFY_NOW` and passes `force_now`.
+2. `make cross-verify-show` → `scripts/cross-verify-show.sh`: prints the latest
+   `data/cross-verify/*.csv` or an honest "not run yet + where else to look".
+3. `make cross-verify-now`: boots with the env var so the verification runs
+   immediately. A runbook documents all four human-visible surfaces.
+
+## Edge Cases
+
+- **Forced run on a non-trading day / quiet day** → `force_now` overrides the
+  gate, but the verification is fail-soft on empty `candles_1m`, so it yields an
+  empty/degraded report, never fabricated rows.
+- **No report on disk** → `cross-verify-show.sh` prints why (not 15:31 yet / dev
+  box / booted late) instead of an empty/confusing result.
+- **Dev box with no live creds** → `make cross-verify-now` stops at auth; the
+  Makefile target says so up-front (no false promise).
+- **Exact 15:31:00 boundary** → `>=` trigger means a boot at exactly 15:31 skips
+  the schedule (mid-evening boot), matching prior behaviour. Pinned by a test.
+
+## Failure Modes
+
+- Wrong seconds-of-day math → the pure function has boundary tests
+  (15:30 → sleep 60; 15:31 → skip; force always RunNow).
+- Env var typo / casing → accepts `1` or `true` (case-insensitive); anything
+  else = off (no accidental forced runs in prod).
+- Behaviour drift in the real run is unchanged (we did not touch
+  `run_cross_verify_1m` or the comparison/CSV/audit code).
+
+## Test Plan
+
+- `cargo test -p tickvault-app cross_verify_1m_boot` → 8 new decision tests +
+  existing module tests green.
+- `bash -n scripts/cross-verify-show.sh` + a live run → prints the honest
+  "no report yet" message (verified).
+- `cargo fmt --check` + design-first wall self-exemption (this diff touches one
+  impl crate `app` with an APPROVED plan referencing it).
+
+## Rollback
+
+Self-contained. Rollback = revert the commit: delete the two `make` targets +
+`scripts/cross-verify-show.sh` + the runbook, and restore the inline scheduling
+block in `main.rs` (the pure function + tests can stay harmlessly, or be
+reverted too). No schema, no data, no runtime/hot-path impact.
+
+## Observability
+
+Reuses the existing surfaces: `CROSS-VERIFY-1M-01/02` error codes, the
+`cross_verify_1m_audit` QuestDB table, the per-day CSV, and the Telegram
+summary. A new `"running on-demand NOW"` info log marks forced runs so they are
+distinguishable from the scheduled 15:31 run in the logs. No new metric/table
+needed — honest scope: this is cold-path operator tooling, not a hot path, so
+no O(1) / zero-tick-loss claims apply.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
         logs app-pid \
         audit coverage bench geiger typos quality doc bootstrap scoped-check full-qa parity-soak \
         dispatch dispatch-readonly dispatch-status dispatch-logs dispatch-check dispatch-audit \
+        cross-verify-show cross-verify-now \
 
 # ---- Configuration ----
 APP_NAME       := tickvault
@@ -492,3 +493,13 @@ dispatch-audit: ## Common preset — ask Claude to run the 100% audit
 
 verify-option-chain-minute-snapshot: ## 7-query verification of the option-chain minute-snapshot pipeline (PR #5 of 5)
 	@bash scripts/verify-option-chain-minute-snapshot.sh
+
+# ---- Post-market 1-minute cross-verification (operator visibility) ----
+cross-verify-show: ## Show the latest post-market cross-verify CSV (where a human looks)
+	@bash scripts/cross-verify-show.sh
+
+cross-verify-now: ## Run the post-market cross-verify NOW (on-demand, needs live auth + QuestDB)
+	@echo "  Running post-market 1-minute cross-verify on-demand (TICKVAULT_CROSS_VERIFY_NOW=1)."
+	@echo "  Requires a booted app: Dhan auth + QuestDB + today's candles_1m."
+	@echo "  On a dev box without live credentials this will stop at auth — that is expected."
+	@TICKVAULT_CROSS_VERIFY_NOW=1 $(MAKE) run

--- a/crates/app/src/cross_verify_1m_boot.rs
+++ b/crates/app/src/cross_verify_1m_boot.rs
@@ -55,6 +55,124 @@ const SECONDS_PER_MINUTE: i64 = 60;
 /// Nanoseconds per second (IST-epoch → nanos).
 const NANOS_PER_SEC: i64 = 1_000_000_000;
 
+/// IST seconds-of-day for the post-market cross-verify trigger (15:31:00).
+const CROSS_VERIFY_TRIGGER_SECS_OF_DAY_IST: u32 = 15 * 3600 + 31 * 60; // 55_860
+
+/// Decision for WHEN the post-market 1-minute cross-verify should fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossVerifyStart {
+    /// Not a trading day and not forced → do not run.
+    SkipNonTradingDay,
+    /// Past 15:31 IST on a normal (non-forced) boot → mid-evening boot, skip.
+    SkipPastTrigger,
+    /// Run immediately — operator forced an on-demand run.
+    RunNow,
+    /// Sleep this many seconds, then run at 15:31:00 IST.
+    SleepThenRun(u64),
+}
+
+/// Pure decision: given the current IST seconds-of-day, whether today is a
+/// trading day, and whether the operator forced an on-demand run, decide when
+/// the cross-verify should fire.
+///
+/// `force_now` (set by the `TICKVAULT_CROSS_VERIFY_NOW` env var via
+/// `make cross-verify-now`) overrides BOTH the trading-day gate and the 15:31
+/// schedule so an operator can prove the pipeline end-to-end on demand without
+/// waiting for 15:31 IST on a live trading day. The run itself remains
+/// fail-soft on empty/partial data, so a forced run on a quiet day simply
+/// produces an empty/degraded report rather than fabricating anything.
+pub fn decide_cross_verify_start(
+    now_secs_of_day_ist: u32,
+    is_trading_day: bool,
+    force_now: bool,
+) -> CrossVerifyStart {
+    if force_now {
+        return CrossVerifyStart::RunNow;
+    }
+    if !is_trading_day {
+        return CrossVerifyStart::SkipNonTradingDay;
+    }
+    if now_secs_of_day_ist >= CROSS_VERIFY_TRIGGER_SECS_OF_DAY_IST {
+        return CrossVerifyStart::SkipPastTrigger;
+    }
+    CrossVerifyStart::SleepThenRun(u64::from(
+        CROSS_VERIFY_TRIGGER_SECS_OF_DAY_IST - now_secs_of_day_ist,
+    ))
+}
+
+#[cfg(test)]
+mod start_decision_tests {
+    use super::{
+        CROSS_VERIFY_TRIGGER_SECS_OF_DAY_IST, CrossVerifyStart, decide_cross_verify_start,
+    };
+
+    #[test]
+    fn test_decide_cross_verify_start_trigger_constant_is_1531_ist() {
+        assert_eq!(CROSS_VERIFY_TRIGGER_SECS_OF_DAY_IST, 55_860);
+    }
+
+    #[test]
+    fn test_decide_cross_verify_start_trading_day_before_1531_sleeps() {
+        // 15:30:00 IST → sleep 60s to 15:31:00.
+        let now = 15 * 3600 + 30 * 60;
+        assert_eq!(
+            decide_cross_verify_start(now, true, false),
+            CrossVerifyStart::SleepThenRun(60)
+        );
+    }
+
+    #[test]
+    fn test_decide_cross_verify_start_at_exact_trigger_skips_past() {
+        let now = CROSS_VERIFY_TRIGGER_SECS_OF_DAY_IST;
+        assert_eq!(
+            decide_cross_verify_start(now, true, false),
+            CrossVerifyStart::SkipPastTrigger
+        );
+    }
+
+    #[test]
+    fn test_decide_cross_verify_start_after_1531_skips_past() {
+        let now = 16 * 3600;
+        assert_eq!(
+            decide_cross_verify_start(now, true, false),
+            CrossVerifyStart::SkipPastTrigger
+        );
+    }
+
+    #[test]
+    fn test_decide_cross_verify_start_non_trading_day_skips() {
+        let now = 10 * 3600;
+        assert_eq!(
+            decide_cross_verify_start(now, false, false),
+            CrossVerifyStart::SkipNonTradingDay
+        );
+    }
+
+    #[test]
+    fn test_decide_cross_verify_start_force_overrides_non_trading_day() {
+        assert_eq!(
+            decide_cross_verify_start(10 * 3600, false, true),
+            CrossVerifyStart::RunNow
+        );
+    }
+
+    #[test]
+    fn test_decide_cross_verify_start_force_overrides_past_trigger() {
+        assert_eq!(
+            decide_cross_verify_start(20 * 3600, true, true),
+            CrossVerifyStart::RunNow
+        );
+    }
+
+    #[test]
+    fn test_decide_cross_verify_start_force_overrides_before_trigger() {
+        assert_eq!(
+            decide_cross_verify_start(9 * 3600, true, true),
+            CrossVerifyStart::RunNow
+        );
+    }
+}
+
 /// One 1-minute candle, keyed by its IST-minute bucket. `volume` is `i64`
 /// (exact integer compare). Prices are `f64` (our `candles_1m` and Dhan REST
 /// are both f64 — exact compare per the operator's "exact match").

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -3624,35 +3624,53 @@ async fn main() -> Result<()> {
                 let cv_base = config.dhan.rest_api_base_url.clone();
                 let cv_calendar = std::sync::Arc::clone(&trading_calendar);
                 tokio::spawn(async move {
-                    use chrono::{FixedOffset, NaiveTime, TimeZone, Utc};
+                    use chrono::{FixedOffset, TimeZone, Timelike, Utc};
+                    use tickvault_app::cross_verify_1m_boot::{
+                        CrossVerifyStart, decide_cross_verify_start,
+                    };
                     use tickvault_common::constants::IST_UTC_OFFSET_SECONDS;
                     let Some(ist_offset) = FixedOffset::east_opt(IST_UTC_OFFSET_SECONDS) else {
                         return;
                     };
                     let now_ist = ist_offset.from_utc_datetime(&Utc::now().naive_utc());
                     let today_ist = now_ist.date_naive();
-                    if !cv_calendar.is_trading_day(today_ist) {
-                        info!("cross_verify_1m: skipping (non-trading day)");
-                        return;
-                    }
                     if cv_targets.is_empty() {
                         info!("cross_verify_1m: no spot targets — skipping");
                         return;
                     }
-                    let Some(target_time) = NaiveTime::from_hms_opt(15, 31, 0) else {
-                        return;
-                    };
-                    let now_time = now_ist.time();
-                    if now_time >= target_time {
-                        debug!(
-                            now = %now_time,
-                            "cross_verify_1m: skipping (past 15:31 — mid-evening boot)"
-                        );
-                        return;
+                    // Operator on-demand override: `make cross-verify-now` sets
+                    // TICKVAULT_CROSS_VERIFY_NOW=1 to run the verification right
+                    // now (proving the pipeline without waiting for 15:31 IST on
+                    // a live trading day). Fail-soft: a forced run on a quiet day
+                    // just yields an empty/degraded report, never fabricated data.
+                    let force_now = std::env::var("TICKVAULT_CROSS_VERIFY_NOW")
+                        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                        .unwrap_or(false);
+                    let now_secs_of_day = now_ist.time().num_seconds_from_midnight();
+                    let is_trading_day = cv_calendar.is_trading_day(today_ist);
+                    match decide_cross_verify_start(now_secs_of_day, is_trading_day, force_now) {
+                        CrossVerifyStart::SkipNonTradingDay => {
+                            info!("cross_verify_1m: skipping (non-trading day)");
+                            return;
+                        }
+                        CrossVerifyStart::SkipPastTrigger => {
+                            debug!(
+                                now = %now_ist.time(),
+                                "cross_verify_1m: skipping (past 15:31 — mid-evening boot)"
+                            );
+                            return;
+                        }
+                        CrossVerifyStart::RunNow => {
+                            info!(
+                                "cross_verify_1m: TICKVAULT_CROSS_VERIFY_NOW set — running \
+                                 on-demand NOW (operator dry-run)"
+                            );
+                        }
+                        CrossVerifyStart::SleepThenRun(secs_until) => {
+                            info!(secs_until, "cross_verify_1m: sleeping until 15:31:00 IST");
+                            tokio::time::sleep(std::time::Duration::from_secs(secs_until)).await;
+                        }
                     }
-                    let secs_until = (target_time - now_time).num_seconds().max(0) as u64;
-                    info!(secs_until, "cross_verify_1m: sleeping until 15:31:00 IST");
-                    tokio::time::sleep(std::time::Duration::from_secs(secs_until)).await;
 
                     // IST-midnight-as-epoch nanos (our candles_1m `ts` stores
                     // IST wall-clock as an epoch — data-integrity.md). The day

--- a/docs/runbooks/cross-verify-1m.md
+++ b/docs/runbooks/cross-verify-1m.md
@@ -1,0 +1,70 @@
+# Runbook: Post-market 1-minute cross-verification
+
+> **What this answers:** "Where, as a human, do I SEE the historical
+> cross-verification?" — and "is it even running?"
+> **Authority:** `.claude/rules/project/live-feed-purity.md` rule 11,
+> `.claude/rules/project/cross-verify-1m-error-codes.md`.
+> **Code:** `crates/app/src/cross_verify_1m_boot.rs`,
+> `crates/storage/src/cross_verify_1m_audit_persistence.rs`, wired in
+> `crates/app/src/main.rs`.
+
+## TL;DR
+
+| Question | Answer |
+|---|---|
+| Pre-market historical fetch? | **Removed on purpose** (operator directive 2026-05-26, spot-only). It does not run. |
+| Post-market cross-verification? | **Runs at 15:31 IST every trading day** — 1-minute OHLCV, exact match, per subscribed spot SID. |
+| Fastest way to see it? | `make cross-verify-show` |
+| See it without waiting for 15:31? | `make cross-verify-now` (needs a booted app: live auth + QuestDB) |
+
+## What it does
+
+At **15:31:00 IST** each trading day, for every subscribed **spot** instrument
+(the ~243 daily-universe SIDs — indices + F&O underlyings) it fetches Dhan's
+authoritative intraday **1-minute** candles (`POST /v2/charts/intraday`,
+interval `"1"`) and compares OHLCV **timestamp-by-timestamp, EXACT match**
+against our live `candles_1m`. The per-day **mismatch count** is the quality
+signal — a stable low number is sampling noise (our feed is sampled; Dhan's
+candles are built from their full tape), a sudden spike or sustained
+open/close drift is a real problem.
+
+It is **read-only** on `candles_1m`; it writes only to its own audit
+table + CSV. It never writes to `ticks` (live-feed-purity stands).
+
+## The 4 places a human can see it
+
+| Surface | How | Note |
+|---|---|---|
+| 📄 **CSV** | `make cross-verify-show` (or open `data/cross-verify/cross-verify-1m-YYYY-MM-DD.csv`) | Easiest. One row per mismatching `(SID, minute, field)`. |
+| 📊 **QuestDB** | `make questdb` → `localhost:9000` → `SELECT * FROM cross_verify_1m_audit WHERE trading_date_ist = today()` | Full, queryable, trendable across days. |
+| 📱 **Telegram** | per-day summary at ~15:31 IST: *compared / mismatches / missing* | Pushed to you. |
+| 📝 **Logs** | `CROSS-VERIFY-1M-01` (mismatch) / `-02` (fetch degraded) in `data/logs/errors.jsonl.*`, plus a `"PROOF: cross_verify_1m fired"` info line | Forensic. |
+
+## "I can't see anything" — why, and what to do
+
+1. **It only fires at 15:31 IST on a trading day, with the app running.**
+   If the app wasn't up through a trading-day close, there is no report — that
+   is correct, not a bug. `make cross-verify-show` says so plainly.
+2. **Dev box without live Dhan + QuestDB candles** produces nothing real — and
+   the tooling will not fabricate a sample. `make cross-verify-now` will boot
+   and stop at auth if there are no live credentials; that is expected.
+3. **Booted late (after 15:31)** → the scheduled run skips ("mid-evening
+   boot"). Use `make cross-verify-now` to force it for today's data.
+
+## On-demand run (prove it works)
+
+`make cross-verify-now` sets `TICKVAULT_CROSS_VERIFY_NOW=1`, which makes the
+boot-time task run the verification **immediately** instead of sleeping to
+15:31. It overrides the trading-day + schedule gates (so you can run it any
+time) but **not** correctness: on a quiet day with no `candles_1m`, it
+produces an empty/degraded report — never invented data.
+
+The scheduling decision is a pure, unit-tested function
+(`decide_cross_verify_start` in `cross_verify_1m_boot.rs`); the env var only
+flips its `force_now` input.
+
+## Cross-references
+
+- `.claude/rules/project/cross-verify-1m-error-codes.md` — CROSS-VERIFY-1M-01/02 triage
+- `.claude/rules/project/live-feed-purity.md` rule 11 — the narrowed re-allow
+- `docs/runbooks/phase-1-monitoring-rubric.md` — cross-verify match-rate target

--- a/scripts/cross-verify-show.sh
+++ b/scripts/cross-verify-show.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# cross-verify-show.sh — the human-visible window into the post-market
+# 1-minute cross-verification (operator directive 2026-06-02).
+#
+# It answers "as a human, how do I SEE the cross-verification?" with no
+# illusion: it shows the real CSV if one exists, and otherwise tells you
+# plainly WHY there's nothing yet and where else to look.
+set -uo pipefail
+
+DIR="data/cross-verify"
+TABLE="cross_verify_1m_audit"
+
+echo "================ Post-market 1-minute cross-verification ================"
+echo "What it does: at 15:31 IST each trading day it compares OUR candles_1m"
+echo "against Dhan's authoritative 1-minute candles, EXACT match, per spot SID."
+echo "-------------------------------------------------------------------------"
+
+latest=""
+if [ -d "$DIR" ]; then
+  # newest cross-verify-1m-YYYY-MM-DD.csv by name (dates sort lexically)
+  latest="$(ls -1 "$DIR"/cross-verify-1m-*.csv 2>/dev/null | sort | tail -1)"
+fi
+
+if [ -n "$latest" ] && [ -f "$latest" ]; then
+  rows="$(($(wc -l < "$latest") - 1))"   # minus header
+  [ "$rows" -lt 0 ] && rows=0
+  echo "Latest report : $latest"
+  echo "Mismatch rows : $rows   (0 = every minute matched exactly — good)"
+  echo "-------------------------------------------------------------------------"
+  echo "First lines (open in Excel for the full grid):"
+  head -11 "$latest" | sed 's/^/  /'
+  echo "-------------------------------------------------------------------------"
+  echo "All reports:"
+  ls -1t "$DIR"/cross-verify-1m-*.csv 2>/dev/null | sed 's/^/  /'
+else
+  echo "No report on disk yet. That is EXPECTED if any of these are true:"
+  echo "  - The app has not run through a 15:31 IST trading-day close yet."
+  echo "  - You are on a dev box with no live Dhan feed / QuestDB candles."
+  echo ""
+  echo "To produce one on demand (needs a booted app + live auth + QuestDB):"
+  echo "    make cross-verify-now"
+  echo ""
+  echo "Other places the same result shows up:"
+  echo "  - QuestDB table : $TABLE  (open 'make questdb' → localhost:9000)"
+  echo "  - Telegram      : a per-day summary at ~15:31 IST (compared / mismatches / missing)"
+  echo "  - Logs          : CROSS-VERIFY-1M-01 (mismatch) / -02 (fetch degraded) in errors.jsonl"
+fi
+echo "========================================================================="


### PR DESCRIPTION
## Summary

Closes the *"as a human, how do I SEE the historical cross-verification?"* gap. The post-market 1-minute cross-verify **already runs at 15:31 IST** — this makes it **visible** and **provable on demand**, with zero changes to the comparison/CSV/audit logic.

## What it does

| Before | After |
|---|---|
| Cross-verify runs at 15:31 IST but no signpost; you'd have to know the file path | `make cross-verify-show` → prints the latest CSV, or an **honest** "not run yet + where else to look" |
| Could only see it after a live 15:31 close | `make cross-verify-now` runs it on demand (overrides the schedule, **not** correctness — fail-soft, never fabricates) |
| No operator doc | `docs/runbooks/cross-verify-1m.md` lists all 4 human-visible surfaces |

## Changes
- `crates/app/src/cross_verify_1m_boot.rs` — extracted a **pure, unit-tested** `decide_cross_verify_start(now_secs_of_day, is_trading_day, force_now)` (8 boundary tests) replacing inline scheduling.
- `crates/app/src/main.rs` — reads `TICKVAULT_CROSS_VERIFY_NOW` → `force_now`.
- `Makefile` + `scripts/cross-verify-show.sh` — the two operator targets.
- `docs/runbooks/cross-verify-1m.md` — the runbook.
- `.claude/plans/active-plan.md` — the design-first plan (this is the first PR gated by the wall merged in #1019; the plan is APPROVED and references the `app` crate, so the wall passes it).

## The 4 surfaces a human can see (documented)
CSV (`data/cross-verify/*.csv`) · QuestDB `cross_verify_1m_audit` · Telegram per-day summary · logs (`CROSS-VERIFY-1M-01/02`).

## Honest scope (no illusion)
This is **cold-path operator tooling** — it does not touch the hot path, so **no O(1) / zero-tick-loss claims** apply to it. Pre-market historical fetch remains intentionally removed (operator directive 2026-05-26); this PR does not re-add it. On a dev box without live Dhan + QuestDB there is genuinely nothing to display, and the tooling says so rather than fabricating a sample.

## Tests
- `cargo test -p tickvault-app cross_verify_1m_boot` → **24/24 green** (8 new decision tests + 16 existing).
- `scripts/cross-verify-show.sh` run locally → prints the honest "no report yet" message.
- Design-first wall (from #1019) passes this diff; pub-fn-test guard satisfied (tests named to convention).

https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_