### PR TITLE
feat(app): verify + surface the pre-market prev-day OHLCV fetch

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,98 +1,90 @@
-# Implementation Plan: Cross-verify visibility + on-demand dry-run
+# Implementation Plan: Pre-market prev-day fetch — verify + see
 
 **Status:** APPROVED
 **Date:** 2026-06-05
-**Approved by:** Parthiban ("yes go ahead dude")
+**Approved by:** Parthiban (chose option A — "Verify + see existing fetch")
 **Crate(s) touched:** `app`
 
 ## Plan Items
 
-- [x] Item 1 — Pure, unit-tested scheduling decision in the `app` crate
-  - Files: `crates/app/src/cross_verify_1m_boot.rs`
-  - Tests: `start_decision_tests::*` (8 tests)
-- [x] Item 2 — Wire `TICKVAULT_CROSS_VERIFY_NOW` on-demand override into boot
+- [x] Item 1 — Pure coverage-verification helpers in the `app` crate
+  - Files: `crates/app/src/prev_day_ohlcv_boot.rs`
+  - Tests: `coverage_tests::*` (9 tests)
+- [x] Item 2 — Wire verify + CSV write after the boot fetch
   - Files: `crates/app/src/main.rs`
-- [x] Item 3 — `make cross-verify-show` (human-visible CSV window) + script
-  - Files: `Makefile`, `scripts/cross-verify-show.sh`
-- [x] Item 4 — `make cross-verify-now` (on-demand run)
-  - Files: `Makefile`
-- [x] Item 5 — Operator runbook
-  - Files: `docs/runbooks/cross-verify-1m.md`
+- [x] Item 3 — `make prev-day-show` + script (human-visible surface)
+  - Files: `Makefile`, `scripts/prev-day-show.sh`
+- [x] Item 4 — Operator runbook
+  - Files: `docs/runbooks/prev-day-ohlcv.md`
 
 ## Design
 
-The post-market 1-minute cross-verification already exists, is wired in
-`crates/app/src/main.rs`, and runs at 15:31 IST (`run_cross_verify_1m`). The
-gap is purely operator **visibility** and the ability to **prove** it without
-waiting for 15:31 on a live day. We add three things, reusing the existing,
-proven verification with zero changes to its comparison logic:
+The pre-market prev-day fetch already exists and is wired
+(`run_prev_day_ohlcv_fetch` → `prev_day_ohlcv` table, returning a
+`PrevDayFetchSummary { fetched, skipped, failed }`). The gap is **verification**
+(did we get yesterday's candle for enough of the universe?) and **visibility**
+(a human can't see it). Symmetric to the post-market cross-verify shipped in
+#1020, with zero changes to the fetch itself:
 
-1. A pure function `decide_cross_verify_start(now_secs_of_day, is_trading_day,
-   force_now) -> CrossVerifyStart` in the `app` crate that replaces the inline
-   scheduling. It is fully unit-tested. `main.rs` reads
-   `TICKVAULT_CROSS_VERIFY_NOW` and passes `force_now`.
-2. `make cross-verify-show` → `scripts/cross-verify-show.sh`: prints the latest
-   `data/cross-verify/*.csv` or an honest "not run yet + where else to look".
-3. `make cross-verify-now`: boots with the env var so the verification runs
-   immediately. A runbook documents all four human-visible surfaces.
+1. Pure `evaluate_prev_day_coverage(expected, fetched) -> PrevDayCoverage`
+   (`Ok` ≥ 90% / `Degraded` / `Empty`) + `coverage_csv(...)` formatter +
+   `write_prev_day_coverage_csv(...)` FS wrapper. All unit-tested.
+2. `main.rs` captures `expected = subscription_targets.len()` before the fetch,
+   then after it: writes the coverage CSV and logs `info!`/`warn!`/`error!` per
+   outcome (degraded/empty route to Telegram via the ERROR/WARN sinks).
+3. `make prev-day-show` → `scripts/prev-day-show.sh`: prints the latest
+   `data/prev-day/*.csv` or an honest "not run yet + where else to look".
+   Runbook documents all surfaces.
 
 ## Edge Cases
 
-- **Forced run on a non-trading day / quiet day** → `force_now` overrides the
-  gate, but the verification is fail-soft on empty `candles_1m`, so it yields an
-  empty/degraded report, never fabricated rows.
-- **No report on disk** → `cross-verify-show.sh` prints why (not 15:31 yet / dev
-  box / booted late) instead of an empty/confusing result.
-- **Dev box with no live creds** → `make cross-verify-now` stops at auth; the
-  Makefile target says so up-front (no false promise).
-- **Exact 15:31:00 boundary** → `>=` trigger means a boot at exactly 15:31 skips
-  the schedule (mid-evening boot), matching prior behaviour. Pinned by a test.
+- **No JWT on a dev box** → the existing fetch skips and returns a zero summary;
+  coverage = `Empty`; the CSV records `empty`; `prev-day-show` says so. No fake data.
+- **Exactly 90% coverage** → `Ok` (inclusive boundary) — pinned by a test.
+- **Zero subscription targets** → `Empty` (guards divide-by-zero; pinned by a test).
+- **FS write failure** (read-only `data/`) → `warn!`, fetch result still logged;
+  boot never blocks.
 
 ## Failure Modes
 
-- Wrong seconds-of-day math → the pure function has boundary tests
-  (15:30 → sleep 60; 15:31 → skip; force always RunNow).
-- Env var typo / casing → accepts `1` or `true` (case-insensitive); anything
-  else = off (no accidental forced runs in prod).
-- Behaviour drift in the real run is unchanged (we did not touch
-  `run_cross_verify_1m` or the comparison/CSV/audit code).
+- Wrong coverage math → boundary tests (full=100/ok, 90/ok, 89/degraded, 0/empty,
+  expected=0/empty).
+- `error!`/`warn!` here carry NO known code prefix, so the tag-guard needs no
+  `code=` field; not a flush/persist/drain phrase, so the level meta-guard is satisfied.
+- The fetch's own behaviour is unchanged (we only read its returned summary).
 
 ## Test Plan
 
-- `cargo test -p tickvault-app cross_verify_1m_boot` → 8 new decision tests +
-  existing module tests green.
-- `bash -n scripts/cross-verify-show.sh` + a live run → prints the honest
-  "no report yet" message (verified).
-- `cargo fmt --check` + design-first wall self-exemption (this diff touches one
-  impl crate `app` with an APPROVED plan referencing it).
+- `cargo test -p tickvault-app prev_day_ohlcv_boot` → 25 green (9 new + 16 existing).
+- `bash scripts/prev-day-show.sh` → prints the honest "no report yet" message (verified).
+- `cargo fmt --check`; design-first wall self-check (impl crate `app` + this APPROVED plan referencing it); pub-fn-test guard satisfied (tests named to convention).
 
 ## Rollback
 
-Self-contained. Rollback = revert the commit: delete the two `make` targets +
-`scripts/cross-verify-show.sh` + the runbook, and restore the inline scheduling
-block in `main.rs` (the pure function + tests can stay harmlessly, or be
-reverted too). No schema, no data, no runtime/hot-path impact.
+Self-contained. Revert the commit: delete the `make` target +
+`scripts/prev-day-show.sh` + runbook, and remove the verify/CSV block from
+`main.rs` (the pure helpers + tests can stay harmlessly). No schema, no data, no
+hot-path impact.
 
 ## Observability
 
-Reuses the existing surfaces: `CROSS-VERIFY-1M-01/02` error codes, the
-`cross_verify_1m_audit` QuestDB table, the per-day CSV, and the Telegram
-summary. A new `"running on-demand NOW"` info log marks forced runs so they are
-distinguishable from the scheduled 15:31 run in the logs. No new metric/table
-needed — honest scope: this is cold-path operator tooling, not a hot path, so
-no O(1) / zero-tick-loss claims apply.
+A new `PROOF: prev-day OHLCV coverage OK` info line on success; `coverage
+DEGRADED`/`EMPTY` warn/error → Telegram on a thin/empty fetch (false-OK guard,
+audit Rule 11). The per-day coverage CSV (`data/prev-day/`) is the human
+surface; the `prev_day_ohlcv` QuestDB table holds the actual candles. No new
+metric/table — cold-path operator tooling.
 
 ## Per-Item Guarantee Matrix (cross-reference)
 
-This plan and every item in it are bound by the 15-row 100% guarantee matrix
-and the 7-row resilience demand matrix — see
+This plan and every item in it are bound by the 15-row 100% guarantee matrix and
+the 7-row resilience demand matrix — see
 `.claude/rules/project/per-wave-guarantee-matrix.md`. All 15 + 7 rows apply to
 every item in this plan.
 
 **Honest envelope (per `wave-4-shared-preamble.md` §8):** any "100%" wording
 here means "100% inside the tested envelope, with ratcheted regression
-coverage" — the envelope being the 8 pure-decision unit tests + the 16 existing
-cross-verify tests + the design-first wall gate. This change is cold-path
-operator tooling and carries NO O(1) / zero-tick-loss / hot-path guarantee,
-because it does not touch the hot path; asserting otherwise would be the
+coverage" — the envelope being the 9 new pure-function unit tests + the 16
+existing prev-day tests. This change is cold-path operator tooling + a
+completeness check; it carries NO O(1) / zero-tick-loss / hot-path guarantee
+because it does not touch the hot path. Asserting otherwise would be the
 hallucination the operator forbids.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
         logs app-pid \
         audit coverage bench geiger typos quality doc bootstrap scoped-check full-qa parity-soak \
         dispatch dispatch-readonly dispatch-status dispatch-logs dispatch-check dispatch-audit \
-        cross-verify-show cross-verify-now \
+        cross-verify-show cross-verify-now prev-day-show \
 
 # ---- Configuration ----
 APP_NAME       := tickvault
@@ -503,3 +503,7 @@ cross-verify-now: ## Run the post-market cross-verify NOW (on-demand, needs live
 	@echo "  Requires a booted app: Dhan auth + QuestDB + today's candles_1m."
 	@echo "  On a dev box without live credentials this will stop at auth — that is expected."
 	@TICKVAULT_CROSS_VERIFY_NOW=1 $(MAKE) run
+
+# ---- Pre-market prev-day OHLCV fetch coverage (operator visibility) ----
+prev-day-show: ## Show the latest pre-market prev-day fetch coverage report
+	@bash scripts/prev-day-show.sh

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2836,10 +2836,17 @@ async fn main() -> Result<()> {
                 let from = tickvault_app::prev_day_ohlcv_boot::previous_trading_day(today, |d| {
                     cal.is_trading_day(d)
                 });
+                // Capture the expected universe size BEFORE the Arc moves into
+                // the fetch, so the post-fetch coverage verification can compare.
+                let pd_expected = pd_universe.subscription_targets.len();
                 let pd_token = std::sync::Arc::clone(&token_handle);
                 let pd_qcfg = config.questdb.clone();
                 let pd_base = config.dhan.rest_api_base_url.clone();
                 tokio::spawn(async move {
+                    use tickvault_app::prev_day_ohlcv_boot::{
+                        PrevDayCoverage, evaluate_prev_day_coverage, prev_day_csv_dir,
+                        write_prev_day_coverage_csv,
+                    };
                     let summary = tickvault_app::prev_day_ohlcv_boot::run_prev_day_ohlcv_fetch(
                         pd_universe,
                         pd_token,
@@ -2849,12 +2856,37 @@ async fn main() -> Result<()> {
                         today,
                     )
                     .await;
-                    info!(
-                        fetched = summary.fetched,
-                        skipped = summary.skipped,
-                        failed = summary.failed,
-                        "prev-day OHLCV boot fetch done"
-                    );
+                    // Verify coverage (false-OK guard) + write the operator-
+                    // visible CSV (`make prev-day-show`). Fail-soft on FS error.
+                    if let Err(err) = write_prev_day_coverage_csv(
+                        prev_day_csv_dir(),
+                        today,
+                        pd_expected,
+                        &summary,
+                    ) {
+                        warn!(?err, "prev_day_ohlcv: coverage CSV write failed");
+                    }
+                    match evaluate_prev_day_coverage(pd_expected, summary.fetched) {
+                        PrevDayCoverage::Ok { pct } => info!(
+                            pct,
+                            fetched = summary.fetched,
+                            expected = pd_expected,
+                            "PROOF: prev-day OHLCV coverage OK"
+                        ),
+                        PrevDayCoverage::Degraded { pct } => warn!(
+                            pct,
+                            fetched = summary.fetched,
+                            expected = pd_expected,
+                            skipped = summary.skipped,
+                            failed = summary.failed,
+                            "prev-day OHLCV coverage DEGRADED — symbols missing yesterday's candle"
+                        ),
+                        PrevDayCoverage::Empty => error!(
+                            expected = pd_expected,
+                            failed = summary.failed,
+                            "prev-day OHLCV coverage EMPTY — no yesterday candles fetched"
+                        ),
+                    }
                 });
                 info!("prev-day OHLCV boot fetch task spawned");
             }

--- a/crates/app/src/prev_day_ohlcv_boot.rs
+++ b/crates/app/src/prev_day_ohlcv_boot.rs
@@ -189,6 +189,180 @@ pub struct PrevDayFetchSummary {
     pub failed: usize,
 }
 
+/// Minimum % of subscription targets that must have yesterday's daily candle
+/// for the pre-market fetch to count as healthy (mirrors the 90% live-vs-
+/// historical cross-match bar). Below this → degraded (false-OK guard,
+/// audit-findings Rule 11 — never report OK on a thin/empty set).
+pub const PREV_DAY_COVERAGE_MIN_PCT: u32 = 90;
+
+/// Directory for the per-day pre-market coverage report CSV.
+const PREV_DAY_CSV_DIR: &str = "data/prev-day";
+
+/// Where the pre-market coverage CSV is written (operator-visible surface).
+pub const fn prev_day_csv_dir() -> &'static str {
+    PREV_DAY_CSV_DIR
+}
+
+/// Verdict for the pre-market prev-day fetch coverage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrevDayCoverage {
+    /// Coverage met the bar.
+    Ok { pct: u32 },
+    /// Some symbols missing yesterday's candle (below the bar).
+    Degraded { pct: u32 },
+    /// No yesterday candles at all (or no targets) — nothing to vouch for.
+    Empty,
+}
+
+/// Pure verification: did the pre-market fetch get yesterday's daily candle for
+/// enough of the subscribed universe? `expected` = number of subscription
+/// targets; `fetched` = how many got a valid candle persisted. Never reports
+/// `Ok` on an empty set (audit-findings Rule 11 — no false-OK).
+pub fn evaluate_prev_day_coverage(expected: usize, fetched: usize) -> PrevDayCoverage {
+    if expected == 0 || fetched == 0 {
+        return PrevDayCoverage::Empty;
+    }
+    let pct = ((fetched as u64).saturating_mul(100) / expected as u64) as u32;
+    if pct >= PREV_DAY_COVERAGE_MIN_PCT {
+        PrevDayCoverage::Ok { pct }
+    } else {
+        PrevDayCoverage::Degraded { pct }
+    }
+}
+
+/// Render the one-row coverage report as CSV text (pure — unit-tested). A human
+/// opens this in Excel; `make prev-day-show` prints it.
+pub fn coverage_csv(
+    trading_date_ist: NaiveDate,
+    expected: usize,
+    summary: &PrevDayFetchSummary,
+) -> String {
+    let outcome = match evaluate_prev_day_coverage(expected, summary.fetched) {
+        PrevDayCoverage::Ok { .. } => "ok",
+        PrevDayCoverage::Degraded { .. } => "degraded",
+        PrevDayCoverage::Empty => "empty",
+    };
+    let pct = if expected == 0 {
+        0
+    } else {
+        ((summary.fetched as u64).saturating_mul(100) / expected as u64) as u32
+    };
+    format!(
+        "trading_date_ist,expected,fetched,skipped,failed,coverage_pct,outcome\n\
+         {trading_date_ist},{expected},{f},{s},{fl},{pct},{outcome}\n",
+        f = summary.fetched,
+        s = summary.skipped,
+        fl = summary.failed,
+    )
+}
+
+/// Write the coverage CSV to `data/prev-day/prev-day-coverage-YYYY-MM-DD.csv`.
+/// Thin FS wrapper around `coverage_csv`; the caller logs on `Err` (fail-soft).
+pub fn write_prev_day_coverage_csv(
+    dir: &str,
+    trading_date_ist: NaiveDate,
+    expected: usize,
+    summary: &PrevDayFetchSummary,
+) -> std::io::Result<std::path::PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let path = std::path::Path::new(dir).join(format!("prev-day-coverage-{trading_date_ist}.csv"));
+    std::fs::write(&path, coverage_csv(trading_date_ist, expected, summary))?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod coverage_tests {
+    use super::{
+        PREV_DAY_COVERAGE_MIN_PCT, PrevDayCoverage, PrevDayFetchSummary, coverage_csv,
+        evaluate_prev_day_coverage, prev_day_csv_dir, write_prev_day_coverage_csv,
+    };
+    use chrono::NaiveDate;
+
+    fn date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 6, 4).unwrap()
+    }
+
+    #[test]
+    fn test_evaluate_prev_day_coverage_full_is_ok() {
+        assert_eq!(
+            evaluate_prev_day_coverage(243, 243),
+            PrevDayCoverage::Ok { pct: 100 }
+        );
+    }
+
+    #[test]
+    fn test_evaluate_prev_day_coverage_at_threshold_is_ok() {
+        // 90 of 100 = exactly the bar.
+        assert_eq!(
+            evaluate_prev_day_coverage(100, PREV_DAY_COVERAGE_MIN_PCT as usize),
+            PrevDayCoverage::Ok { pct: 90 }
+        );
+    }
+
+    #[test]
+    fn test_evaluate_prev_day_coverage_below_threshold_is_degraded() {
+        assert_eq!(
+            evaluate_prev_day_coverage(100, 89),
+            PrevDayCoverage::Degraded { pct: 89 }
+        );
+    }
+
+    #[test]
+    fn test_evaluate_prev_day_coverage_zero_fetched_is_empty() {
+        assert_eq!(evaluate_prev_day_coverage(243, 0), PrevDayCoverage::Empty);
+    }
+
+    #[test]
+    fn test_evaluate_prev_day_coverage_zero_expected_is_empty() {
+        assert_eq!(evaluate_prev_day_coverage(0, 0), PrevDayCoverage::Empty);
+    }
+
+    #[test]
+    fn test_coverage_csv_has_header_and_row() {
+        let s = PrevDayFetchSummary {
+            fetched: 240,
+            skipped: 2,
+            failed: 1,
+        };
+        let csv = coverage_csv(date(), 243, &s);
+        assert!(csv.starts_with(
+            "trading_date_ist,expected,fetched,skipped,failed,coverage_pct,outcome\n"
+        ));
+        assert!(csv.contains("2026-06-04,243,240,2,1,98,ok\n"));
+    }
+
+    #[test]
+    fn test_coverage_csv_marks_empty_outcome() {
+        let s = PrevDayFetchSummary {
+            fetched: 0,
+            skipped: 0,
+            failed: 243,
+        };
+        let csv = coverage_csv(date(), 243, &s);
+        assert!(csv.contains(",0,0,243,0,empty\n"));
+    }
+
+    #[test]
+    fn test_write_prev_day_coverage_csv_writes_expected_content() {
+        let dir = std::env::temp_dir().join(format!("tv-prevday-{}", std::process::id()));
+        let dir_str = dir.to_string_lossy().to_string();
+        let s = PrevDayFetchSummary {
+            fetched: 243,
+            skipped: 0,
+            failed: 0,
+        };
+        let path = write_prev_day_coverage_csv(&dir_str, date(), 243, &s).expect("write ok");
+        let read = std::fs::read_to_string(&path).expect("read ok");
+        assert_eq!(read, coverage_csv(date(), 243, &s));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_prev_day_csv_dir_is_under_data() {
+        assert_eq!(prev_day_csv_dir(), "data/prev-day");
+    }
+}
+
 /// Fetch + persist the previous trading day's daily candle for every
 /// subscription target. Fail-soft per symbol; boot never blocks.
 ///

--- a/docs/runbooks/prev-day-ohlcv.md
+++ b/docs/runbooks/prev-day-ohlcv.md
@@ -1,0 +1,66 @@
+# Runbook: Pre-market prev-day OHLCV fetch + coverage verification
+
+> **What this answers:** "Where do I SEE the pre-market historical fetch, and
+> did it actually get yesterday's data for everything?"
+> **Authority:** `.claude/rules/project/live-feed-purity.md` rule 9 (the
+> bounded prev-day fetch).
+> **Code:** `crates/app/src/prev_day_ohlcv_boot.rs`, wired in
+> `crates/app/src/main.rs`.
+> **Sibling:** `docs/runbooks/cross-verify-1m.md` (the post-market twin).
+
+## TL;DR
+
+| Question | Answer |
+|---|---|
+| Pre-market historical fetch? | **Exists & runs at boot** — pulls yesterday's single daily candle (O/H/L/C/V + OI) per subscribed spot SID → `prev_day_ohlcv` table. |
+| Is it verified? | **Yes (new)** — after the fetch, a coverage check confirms how many of the ~243 SIDs got a valid candle; below 90% → degraded, zero → empty (no false-OK). |
+| Fastest way to see it? | `make prev-day-show` |
+
+## What it does
+
+At boot (after auth + instruments load), `run_prev_day_ohlcv_fetch` fetches
+**yesterday's one daily candle** per subscribed spot SID via Dhan REST
+`POST /v2/charts/historical` (daily, non-inclusive `toDate`) and writes it to
+the `prev_day_ohlcv` table — **never** `ticks` (live-feed-purity stands). This
+is the bounded fetch re-allowed 2026-06-01; it is **not** the deleted broad
+intraday chain.
+
+Then the new coverage verification (`evaluate_prev_day_coverage`, a pure
+unit-tested function) compares `fetched` against the universe size:
+
+| Outcome | Meaning | Signal |
+|---|---|---|
+| `ok` (≥ 90%) | Healthy — most/all symbols have yesterday's candle | `info!` "PROOF: prev-day OHLCV coverage OK" |
+| `degraded` (< 90%, > 0) | Some symbols missing yesterday's candle | `warn!` (→ Telegram) |
+| `empty` (0) | Nothing fetched — investigate | `error!` (→ Telegram) |
+
+`ok` is **never** reported on an empty/thin set (audit-findings Rule 11).
+
+## Where a human can see it
+
+| Surface | How |
+|---|---|
+| 📄 **CSV** | `make prev-day-show` (or open `data/prev-day/prev-day-coverage-YYYY-MM-DD.csv`) — columns: `expected, fetched, skipped, failed, coverage_pct, outcome` |
+| 📊 **QuestDB** | `make questdb` → `SELECT count(*) FROM prev_day_ohlcv` (the actual candles) |
+| 📝 **Logs** | the `PROOF: prev-day OHLCV coverage OK` / `coverage DEGRADED` / `coverage EMPTY` line in `data/logs/errors.jsonl.*` |
+
+## "I can't see anything" — why
+
+- The fetch runs **once at boot** after successful auth. On a dev box with no
+  live Dhan credentials it is skipped (logged), so there is no report — that is
+  correct, and `make prev-day-show` says so.
+- Coverage `empty` on a real boot means the REST fetch returned nothing for the
+  whole universe — check Dhan Data-API health + the JWT.
+
+## Honest scope
+
+This is **cold-path operator tooling + a completeness check** — it does **not**
+touch the hot path, so no O(1) / zero-tick-loss claims apply. It does **not**
+re-add the deleted broad pre-market intraday chain (that would reverse the
+2026-05-26 lock); it only verifies + surfaces the already-existing bounded
+prev-day fetch.
+
+## Cross-references
+
+- `.claude/rules/project/live-feed-purity.md` rule 9 — the bounded prev-day fetch contract
+- `docs/runbooks/cross-verify-1m.md` — the post-market 1-minute twin

--- a/scripts/prev-day-show.sh
+++ b/scripts/prev-day-show.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# prev-day-show.sh — the human-visible window into the PRE-market prev-day
+# OHLCV fetch + its coverage verification.
+#
+# Symmetric to scripts/cross-verify-show.sh (post-market). No illusion: shows
+# the real coverage report if one exists, otherwise says plainly WHY there's
+# nothing yet and where else to look.
+set -uo pipefail
+
+DIR="data/prev-day"
+TABLE="prev_day_ohlcv"
+
+echo "================ Pre-market prev-day OHLCV fetch (coverage) ================"
+echo "What it does: at boot it pulls YESTERDAY's single daily candle (O/H/L/C/V +"
+echo "OI) for every subscribed spot SID into the $TABLE table, then verifies how"
+echo "many of the universe actually got one (coverage %)."
+echo "---------------------------------------------------------------------------"
+
+latest=""
+if [ -d "$DIR" ]; then
+  latest="$(ls -1 "$DIR"/prev-day-coverage-*.csv 2>/dev/null | sort | tail -1)"
+fi
+
+if [ -n "$latest" ] && [ -f "$latest" ]; then
+  echo "Latest coverage report : $latest"
+  echo "---------------------------------------------------------------------------"
+  cat "$latest" | sed 's/^/  /'
+  echo "---------------------------------------------------------------------------"
+  echo "Reading it: outcome=ok (>=90% got yesterday's candle) is healthy;"
+  echo "            degraded = some symbols missing; empty = nothing fetched (investigate)."
+  echo "All reports:"
+  ls -1t "$DIR"/prev-day-coverage-*.csv 2>/dev/null | sed 's/^/  /'
+else
+  echo "No coverage report on disk yet. That is EXPECTED if:"
+  echo "  - The app has not completed a boot fetch yet, or"
+  echo "  - You are on a dev box with no live Dhan auth (the fetch is skipped)."
+  echo ""
+  echo "Other places the same data shows up:"
+  echo "  - QuestDB table : $TABLE  (open 'make questdb' → localhost:9000 →"
+  echo "                    SELECT count(*) FROM $TABLE)"
+  echo "  - Logs          : a 'PROOF: prev-day OHLCV coverage OK' info line, or a"
+  echo "                    'coverage DEGRADED/EMPTY' warning/error in errors.jsonl"
+fi
+echo "==========================================================================="


### PR DESCRIPTION
## Summary

The **pre-market twin** of #1020. The pre-market historical fetch already exists (pulls yesterday's daily candle per spot SID into `prev_day_ohlcv` at boot) — this adds a **coverage verification** + a **human-visible surface**, with **zero changes to the fetch itself**. Option A from the operator: verify + see, **no lock reversal**.

## Before → After

| | Before | After |
|---|---|---|
| Pre-market fetch | runs at boot, but no proof it covered the universe | coverage verified: `ok` ≥90% / `degraded` / `empty` (never false-OK) |
| Visibility | none — you'd have to query QuestDB and know the table | `make prev-day-show` prints the coverage report, or an honest "not run yet" |
| Docs | none | `docs/runbooks/prev-day-ohlcv.md` |

## Changes
- `crates/app/src/prev_day_ohlcv_boot.rs` — pure, unit-tested `evaluate_prev_day_coverage` / `coverage_csv` / `write_prev_day_coverage_csv` (**9 tests**).
- `crates/app/src/main.rs` — after the boot fetch: write the coverage CSV + `info!`/`warn!`/`error!` per outcome (degraded/empty → Telegram).
- `Makefile` + `scripts/cross-verify` sibling `scripts/prev-day-show.sh` — `make prev-day-show`.
- `docs/runbooks/prev-day-ohlcv.md` — runbook.
- `.claude/plans/active-plan.md` — design-first plan (option A), carries the per-wave guarantee-matrix cross-reference.

## Honest scope (no illusion)
**Cold-path operator tooling + a completeness check** — it does **not** touch the hot path, so **no O(1) / zero-tick-loss claims** apply. It does **NOT** re-add the deleted broad pre-market intraday chain (that would reverse the 2026-05-26 lock); it only verifies + surfaces the already-existing bounded prev-day fetch. On a dev box with no live auth, the fetch is skipped and the tooling **says so** rather than fabricating a sample.

## Tests
- `cargo test -p tickvault-app prev_day_ohlcv_boot` → **25/25 green** (9 new + 16 existing).
- `scripts/prev-day-show.sh` run locally → honest "no report yet" message.
- Local gates: design-first wall ✓, per-wave guarantee-matrix ✓, pub-fn-test guard ✓ (stable 114).

https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_