### PR TITLE
fix(storage): retention sweep covers the REAL candle tables (candles_&lt;TF&gt;, not phantom _shadow)

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,90 +1,81 @@
-# Implementation Plan: Partition-retention coverage fix (storage cost runaway)
+# Implementation Plan: Retention sweep must cover the REAL candle tables
 
 **Status:** APPROVED
 **Date:** 2026-06-05
-**Approved by:** Parthiban ("proceed with everything fix everything … approved")
+**Approved by:** Parthiban ("fix everything … no illusion") + hostile-audit CRITICAL
 **Crate(s) touched:** `storage`
 
-## Context (verified, no illusion)
+## Context (verified — a real bug in the just-merged #1022)
 
-The partition manager's retention sweep (`detach_old_partitions`) iterates two
-hard-coded lists. Verified against the code:
-- `HOUR_PARTITIONED_TABLES` names **deleted** tables (greeks/depth/movers/option_chain — modules gone).
-- `DAY_PARTITIONED_TABLES` = `["candles_1s"]` only.
-- The **live growing** `PARTITION BY DAY` tables — the 10 `candles_*_shadow`, plus
-  `instrument_fetch_audit`, `instrument_lifecycle_audit`, `option_chain_minute_snapshot`,
-  `prev_day_ohlcv`, `cross_verify_1m_audit` — are in **neither list**, so their old
-  partitions are **never swept** → unbounded active-table growth.
-- `instrument_lifecycle` is `PARTITION BY DAY` but is the **never-delete SEBI
-  point-in-time** table — it MUST be excluded from sweeping.
-
-**Honest boundary (stated, not hidden):** `detach_old_partitions` uses
-`ALTER TABLE … DETACH PARTITION` — it moves old partitions to a local `detached/`
-dir (SEBI-safe, no DROP). There is **no S3 archiver module** in the codebase, so
-detach alone does **not** free EBS bytes — it bounds the *active* table and is the
-prerequisite for archival. Actually freeing EBS (S3 upload + local cleanup of
-detached partitions) is a SEPARATE piece that needs AWS provisioning; this PR does
-**not** claim to free EBS, only to fix the stale-coverage bug + prevent its return.
+#1022 set `DAY_PARTITIONED_TABLES` to 10 `candles_*_shadow` literals copied from
+the (stale) rule files. The ACTUAL live candle tables are `candles_1m` …
+`candles_1d` — **21 tables, NO `_shadow` suffix** — per `TfIndex::table_name()`
+(`crates/trading/src/candles/tf_index.rs:175-197`, the single source of truth:
+"there are **no** `_shadow` tables"), enumerated by
+`shadow_persistence::candle_table_names()`. Confirmed against the operator's
+QuestDB screenshot (`candles_1m`, `candles_10m`, …). So the candle tables — the
+dominant disk-growth source — are **still not swept**; #1022 fixed the audit
+tables but not the candles. The meta-guard missed it because it only checks
+string literals inside `partition_manager.rs` (tautological for a list of
+literals); the real names live in a `match` in another crate.
 
 ## Plan Items
 
-- [x] Item 1 — Fix the two lists to the live reality; add a documented exempt set
+- [x] Item 1 — Sweep the REAL candle tables from the single source
   - Files: `crates/storage/src/partition_manager.rs`
-  - Tests: `partition_manager::tests::test_*` (coverage + SEBI-exclusion)
-- [x] Item 2 — Anti-staleness meta-guard (can't-go-stale ratchet)
+  - Tests: `partition_manager::tests::test_*`
+- [x] Item 2 — Make the meta-guard cross-reference `candle_table_names()`
   - Files: `crates/storage/tests/partition_retention_coverage_guard.rs`
-  - Tests: `every_storage_table_constant_has_a_retention_decision`
 
 ## Design
 
-1. `HOUR_PARTITIONED_TABLES = ["ticks"]` (the only live HOUR table).
-2. `DAY_PARTITIONED_TABLES` = the 10 `candles_*_shadow` + `instrument_fetch_audit`
-   + `instrument_lifecycle_audit` + `option_chain_minute_snapshot` + `prev_day_ohlcv`
-   + `cross_verify_1m_audit`.
-3. `RETENTION_EXEMPT_TABLES = ["instrument_lifecycle"]` with a doc comment citing
-   the SEBI never-delete rule (daily-universe §5/§25). Make the three lists `pub`
-   so the meta-guard test can read them.
-4. Meta-guard: scan `crates/storage/src/*.rs` for table-name constants
-   (`const …TABLE… : &str = "x"`) and assert every one is in
-   `HOUR ∪ DAY ∪ EXEMPT`. New audit tables (which all follow that constant
-   pattern) are then **automatically** required to declare a retention decision —
-   the list can never silently go stale again.
+1. `DAY_PARTITIONED_TABLES` const → the **audit/data** tables only
+   (`instrument_fetch_audit`, `instrument_lifecycle_audit`,
+   `option_chain_minute_snapshot`, `prev_day_ohlcv`, `cross_verify_1m_audit`).
+   Remove all 10 phantom `candles_*_shadow` literals.
+2. `detach_old_partitions` gains a third loop over
+   `crate::shadow_persistence::candle_table_names()` (DAY granularity, exempt-skip)
+   — sweeps all 21 real candle tables **derived from the single source**, so the
+   names can never drift from what's actually created/written.
+3. Unit tests: assert the DAY const holds the 5 audit/data tables; assert
+   `candle_table_names()` returns 21 plain `candles_<TF>` names (no `_shadow`).
+4. Meta-guard: import `tickvault_storage::shadow_persistence::candle_table_names`
+   and assert (a) `partition_manager.rs` source references `candle_table_names`
+   (the candle sweep loop can't be silently deleted) and (b) every candle name is
+   a plain `candles_*` (no `_shadow`) so a future rename is caught.
 
 ## Edge Cases
 
-- A table listed but not yet created → `DETACH` query returns not-found → already
-  handled (logged `warn`, loop continues). No crash.
-- `instrument_lifecycle` accidentally added to a sweep list → a dedicated test
-  fails the build (SEBI guard).
-- A future `*_audit` table added without a retention decision → the meta-guard
-  fails the build.
-- Shadow tables generated (no single constant) → covered explicitly in the DAY list
-  + pinned by a unit test naming all 10.
+- `candles_1d` is created but unwritten (live-feed-purity rule 10) → empty →
+  `DETACH` is a harmless no-op. Sweeping all 21 (incl. 1d) is safe and avoids
+  special-casing.
+- A non-existent table name → `detach_partitions_for_table` returns `Ok(0)` on the
+  404 (existing behaviour) — but with the single-source derivation this can't
+  happen for candles.
+- `instrument_lifecycle` (exempt) is not a candle name → unaffected.
 
 ## Failure Modes
 
-- Wrong table name in a list → `DETACH` no-ops harmlessly (warn). Not data loss.
-- Over-sweep (detaching a never-delete table) → prevented by the EXEMPT set + SEBI test.
-- The meta-guard itself going stale → it derives the expected set by *scanning source*,
-  so it tracks reality, not a hand-maintained copy.
+- `candle_table_names()` drift → impossible by construction (single source).
+- Someone deletes the candle sweep loop → meta-guard source-scan fails the build.
+- Vec/alloc concern → N/A: the detach cycle is cold-path (periodic), not hot path.
 
 ## Test Plan
 
-- `cargo test -p tickvault-storage partition_manager` → list-coverage + SEBI-exclusion tests green.
-- `cargo test -p tickvault-storage --test partition_retention_coverage_guard` → meta-guard green.
-- `cargo fmt --check`; design-first wall (impl crate `storage` + this APPROVED plan referencing it).
+- `cargo test -p tickvault-storage partition_manager` → updated coverage + SEBI tests green.
+- `cargo test -p tickvault-storage --test partition_retention_coverage_guard` → meta-guard (now candle-aware) green.
+- `cargo clippy --workspace -- -D warnings -W clippy::perf` green (the real CI command).
 
 ## Rollback
 
-Single-file logic change + one test file. Revert the commit to restore the prior
-lists. No schema change, no data migration, no runtime behaviour beyond which
-tables the existing detach cycle visits.
+Single-file logic change + meta-guard update. Revert restores #1022's (buggy)
+state. No schema/data/runtime change beyond which tables the existing detach
+cycle visits.
 
 ## Observability
 
-The existing `detach_old_partitions` already logs `info!(table, detached=count)`
-per swept table — now those logs will actually cover the live tables. No new
-metric/table. Cold-path maintenance task; no hot-path / O(1) involvement.
+`detach_old_partitions` already logs `info!(table, detached=count)` per table —
+now it actually logs the 21 candle tables. No new metric. Cold-path; no hot-path / O(1) involvement.
 
 ## Per-Item Guarantee Matrix (cross-reference)
 
@@ -92,11 +83,10 @@ This plan and every item in it are bound by the 15-row 100% guarantee matrix and
 the 7-row resilience demand matrix — see
 `.claude/rules/project/per-wave-guarantee-matrix.md`. All 15 + 7 rows apply.
 
-**Honest envelope (per `wave-4-shared-preamble.md` §8):** any "100%" wording here
-means "100% inside the tested envelope, with ratcheted regression coverage" — the
-envelope being the list-coverage unit tests + the source-scanning meta-guard. This
-is a cold-path storage-retention fix; it carries NO O(1) / zero-tick-loss /
-hot-path guarantee, and it does NOT by itself free EBS (the S3-archival of
-detached partitions is a separate, AWS-dependent piece, flagged honestly). No
-hallucination: stating it "fixes the cost" outright would be false — it fixes the
-stale-coverage bug + prevents regression.
+**Honest envelope (per `wave-4-shared-preamble.md` §8):** any "100%" means "100%
+inside the tested envelope, with ratcheted regression coverage" — here the
+single-source candle derivation + the candle-aware meta-guard. Cold-path
+storage-retention fix; NO O(1) / hot-path / zero-tick-loss claim, and it still
+does NOT free EBS by itself (S3 archival of detached partitions remains the
+separate AWS-dependent piece). No illusion: this corrects the candle-table gap
+#1022 left open.

--- a/crates/storage/src/partition_manager.rs
+++ b/crates/storage/src/partition_manager.rs
@@ -40,8 +40,11 @@ const PARTITION_DDL_TIMEOUT_SECS: u64 = 30;
 // only live HOUR-partitioned table.
 pub(crate) const HOUR_PARTITIONED_TABLES: &[&str] = &["ticks"];
 
-/// Tables with DAY partitioning that the retention sweep DETACHes past the hot
-/// window.
+/// DAY-partitioned **audit + daily-data** tables the retention sweep DETACHes
+/// past the hot window. The 21 live **candle** tables (`candles_1m` …
+/// `candles_1d`) are NOT listed here — they are swept by iterating
+/// [`crate::shadow_persistence::candle_table_names`] (the single source of
+/// truth, `TfIndex::table_name()`) so the candle names can never drift.
 ///
 /// **Honest boundary:** `detach_old_partitions` uses `ALTER TABLE … DETACH
 /// PARTITION` — it moves old partitions to a local `detached/` dir (SEBI-safe,
@@ -50,17 +53,6 @@ pub(crate) const HOUR_PARTITIONED_TABLES: &[&str] = &["ticks"];
 /// implemented. This list bounds the *active* table and is the prerequisite for
 /// archival; it does not by itself reclaim disk.
 pub(crate) const DAY_PARTITIONED_TABLES: &[&str] = &[
-    // Live multi-timeframe candle shadow tables (Engine B seal writes).
-    "candles_1s_shadow",
-    "candles_1m_shadow",
-    "candles_5m_shadow",
-    "candles_15m_shadow",
-    "candles_30m_shadow",
-    "candles_1h_shadow",
-    "candles_2h_shadow",
-    "candles_3h_shadow",
-    "candles_4h_shadow",
-    "candles_1d_shadow",
     // Audit + daily-data tables (SEBI 5y → detach to S3 cold when archival ships).
     "instrument_fetch_audit",
     "instrument_lifecycle_audit",
@@ -154,9 +146,34 @@ impl PartitionManager {
             }
         }
 
-        // DAY-partitioned tables (same exempt guard as the HOUR loop).
+        // DAY-partitioned audit/data tables (same exempt guard as the HOUR loop).
         for table in DAY_PARTITIONED_TABLES {
             if RETENTION_EXEMPT_TABLES.contains(table) {
+                continue;
+            }
+            match self
+                .detach_partitions_for_table(table, cutoff_days, "DAY")
+                .await
+            {
+                Ok(count) => {
+                    total_detached = total_detached.saturating_add(count);
+                    if count > 0 {
+                        info!(table, detached = count, "partitions detached");
+                    }
+                }
+                Err(err) => {
+                    warn!(?err, table, "failed to detach partitions");
+                }
+            }
+        }
+
+        // The 21 live candle tables (`candles_1m` … `candles_1d`), DAY-partitioned.
+        // Derived from `candle_table_names()` (the single source of truth,
+        // `TfIndex::table_name()`) so the swept names can NEVER drift from what is
+        // actually created/written. This is the dominant disk-growth source —
+        // #1022 named phantom `candles_*_shadow` tables and missed it.
+        for table in crate::shadow_persistence::candle_table_names() {
+            if RETENTION_EXEMPT_TABLES.contains(&table) {
                 continue;
             }
             match self
@@ -359,20 +376,11 @@ mod tests {
     }
 
     #[test]
-    fn test_live_day_tables_are_all_covered() {
-        // Every live PARTITION BY DAY table that grows MUST be swept. This pins
-        // the 2026-06-05 fix so the lists can't silently drop a live table again.
+    fn test_day_list_holds_the_audit_data_tables() {
+        // The DAY const holds ONLY the audit/data tables; candle tables are
+        // swept via candle_table_names() in detach_old_partitions (see
+        // test_candle_tables_are_real_plain_names).
         for live in [
-            "candles_1s_shadow",
-            "candles_1m_shadow",
-            "candles_5m_shadow",
-            "candles_15m_shadow",
-            "candles_30m_shadow",
-            "candles_1h_shadow",
-            "candles_2h_shadow",
-            "candles_3h_shadow",
-            "candles_4h_shadow",
-            "candles_1d_shadow",
             "instrument_fetch_audit",
             "instrument_lifecycle_audit",
             "option_chain_minute_snapshot",
@@ -381,7 +389,26 @@ mod tests {
         ] {
             assert!(
                 DAY_PARTITIONED_TABLES.contains(&live),
-                "live growing table not covered by retention sweep: {live}"
+                "audit/data table not covered by retention sweep: {live}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_candle_tables_are_real_plain_names_not_shadow() {
+        // The candle tables swept by detach_old_partitions come from the single
+        // source of truth. They MUST be plain `candles_<TF>` (no `_shadow`) and
+        // number 21 — this is the exact bug #1022 had (phantom `_shadow` names).
+        let names = crate::shadow_persistence::candle_table_names();
+        assert_eq!(names.len(), 21, "expected 21 live candle tables");
+        for name in names {
+            assert!(
+                name.starts_with("candles_"),
+                "candle table name not canonical: {name}"
+            );
+            assert!(
+                !name.contains("_shadow"),
+                "candle table must be plain (no _shadow): {name}"
             );
         }
     }

--- a/crates/storage/tests/partition_retention_coverage_guard.rs
+++ b/crates/storage/tests/partition_retention_coverage_guard.rs
@@ -98,3 +98,29 @@ fn guard_helpers_are_sane() {
     // the DDL string (has spaces/uppercase) must NOT be treated as a table name
     assert!(!table_name_constants(sample).iter().any(|t| t.contains(' ')));
 }
+
+/// The 21 live candle tables are swept by iterating `candle_table_names()` (the
+/// single source of truth) in `detach_old_partitions`. This cross-references
+/// that source — closing the gap where #1022's meta-guard was blind to candle
+/// tables (it only saw literals inside `partition_manager.rs`). Catches both
+/// (a) deletion of the candle sweep loop and (b) a future `_shadow` rename.
+#[test]
+fn candle_tables_are_swept_via_single_source() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let pm =
+        fs::read_to_string(src.join("partition_manager.rs")).expect("read partition_manager.rs");
+    assert!(
+        pm.contains("candle_table_names()"),
+        "partition_manager must sweep candle tables via candle_table_names() — the candle \
+         retention loop is missing (the #1022 phantom-`_shadow`-name bug would return)"
+    );
+
+    let names = tickvault_storage::shadow_persistence::candle_table_names();
+    assert_eq!(names.len(), 21, "expected 21 live candle tables");
+    for n in names {
+        assert!(
+            n.starts_with("candles_") && !n.contains("_shadow"),
+            "candle table name must be plain candles_<TF> (no _shadow): {n}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**Follow-up fix to #1022** — caught by a hostile workspace audit and **verified against the code** (`tf_index.rs`) + the operator's QuestDB screenshot.

#1022 set the DAY retention list to phantom `candles_*_shadow` tables (copied from **stale rule files**). The actual live candle tables are **`candles_1m` … `candles_1d` — 21 tables, NO `_shadow` suffix** (per `TfIndex::table_name()`, which states "there are **no** `_shadow` tables"). So the candle tables — **the dominant disk-growth source** — were *still not swept* after #1022. The meta-guard that should have caught this was blind (it only checked string literals inside `partition_manager.rs`).

## Before → After

| | After #1022 (buggy) | This PR |
|---|---|---|
| Candle tables swept | ❌ 10 phantom `candles_*_shadow` (match **zero** real tables) | ✅ 21 real `candles_<TF>` via `candle_table_names()` (single source — can't drift) |
| DAY const | 10 phantom + 5 audit | 5 audit/data only; candles swept by the single-source loop |
| Meta-guard | blind to candle names | ✅ cross-references `candle_table_names()` — catches loop deletion + a future `_shadow` rename |

## Honest scope (unchanged from #1022)
`DETACH` moves partitions to a local `detached/` dir (SEBI-safe, never DROP). It bounds the *active* table; **actually freeing EBS** still needs the S3 archival of detached partitions (separate, AWS-dependent, not here). This PR makes the sweep finally cover the candle tables it was supposed to.

## Tests
- `partition_manager::tests` — DAY audit/data list + `candle_table_names()` yields 21 plain `candles_<TF>` (no `_shadow`). **16/16 green.**
- `tests/partition_retention_coverage_guard.rs` — now candle-aware. **3/3 green.**
- `cargo clippy --workspace -- -D warnings -W clippy::perf` (the real CI command) **green**.

## Note (re a separate false alarm)
A verify-build agent reported "26 clippy errors" — that was a **false alarm** from running `--all-targets` (lints test fixtures CI never checks). The real CI clippy command is green; this was confirmed, not assumed.

https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_