### PR TITLE
fix(core): time-windowed ring dedup — keep genuine re-touches (O(1), zero-alloc)

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,96 +1,99 @@
-# Implementation Plan: Tick-conservation ledger (proof no tick is lost)
+# Implementation Plan: Time-windowed ring dedup (hardening — NOT the 23440 candle fix)
 
 **Status:** APPROVED
 **Date:** 2026-06-05
-**Approved by:** Parthiban ("go ahead with whatever is recommended")
+**Approved by:** Parthiban ("Do the dedup hardening anyway")
 **Crate(s) touched:** `core`
 
-## Context (verified)
+## Context (verified, no illusion)
 
-The tick processor's tick branch has exactly these terminal outcomes per entry
-(verified by reading `tick_processor.rs` 850–1270; integrity/late-tick/day_close
-checks only *count*, they do not drop):
+The in-memory `TickDedupRing` (`tick_processor.rs`) drops a tick when its exact
+`(security_id, exchange_timestamp, ltp)` fingerprint was already seen — to drop
+Dhan reconnect re-sends. Side effect: a **genuine price re-touch** with a
+**stale LTT** (same `exchange_timestamp`) is wrongly dropped, so it never reaches
+the ticks table or the broadcast.
 
-`ticks_processed == ticks_persisted + storage_errors + junk_ticks_filtered +
-stale_day_filtered + outside_hours_filtered + dedup_filtered`
-
-The loop is synchronous (each tick fully resolved before the next), so at the
-existing 60s periodic check there are **zero in-flight ticks** → the identity is
-**exact**. A correct system holds residual == 0 forever; any positive residual
-delta in a window = ticks entered but vanished unaccounted = a real leak.
+**Honest scope (stated up-front, in the PR too):** this does **NOT** fix the
+11:49 23440 candle-high miss. Verified: the candle aggregator buckets by
+`exchange_timestamp` (L-H7) and DISCARDS ticks whose LTT precedes the open bucket
+(L-C3). So a stale-LTT re-touch, even if kept here, is bucket-discarded by the
+aggregator. This hardening only restores the re-touch to the **`ticks` table**
+(visible by `received_at`); the candle fix (if the cause is stale LTT) is a
+separate bucketing change pending live-data confirmation.
 
 ## Plan Items
 
-- [ ] Item 1 — Pure, unit-tested conservation math
-  - Files: `crates/core/src/pipeline/tick_processor.rs`
-  - Tests: `conservation_tests::*`
-- [ ] Item 2 — Wire the per-window leak check into the existing 60s block
+- [x] Item 1 — Make the ring time-windowed (slot stores last-seen nanos)
+  - Files: `crates/core/src/pipeline/tick_processor.rs`, `crates/common/src/constants.rs`
+  - Tests: `TickDedupRing` unit tests (window in/out, distinct ltp)
+- [x] Item 2 — Pass `received_at_nanos` at the two call sites
   - Files: `crates/core/src/pipeline/tick_processor.rs`
 
 ## Design
 
-1. Pure fn `tick_conservation_residual(processed, persisted, storage_errors,
-   junk, stale_day, outside_hours, dedup) -> i64` = `processed - sum(outcomes)`.
-   0 = balanced; >0 = unaccounted (leak); <0 = double-count bug.
-2. Pure fn `conservation_leak_delta(current_residual, last_residual) -> i64`.
-3. In the existing 60s periodic block (only when `tick_writer.is_some()`, since
-   persistence-conservation is meaningless without a writer): compute the
-   residual, compare to the previous window's residual; if the **delta is > 0**
-   (ticks entered this window that reached no known terminal), emit
-   `error!("TICK CONSERVATION LEAK …", unaccounted=delta, residual, …)` (Telegram
-   via the ERROR sink) + `counter!("tv_tick_conservation_leak_total")`. Always log
-   the residual at `info!` when the window had activity, so the books are visible
-   even at 0 (positive false-OK avoidance, audit Rule 11).
+1. `TickDedupRing.slots: Box<[(u64, i64)]>` — (fingerprint, last_seen_nanos),
+   init `(u64::MAX, i64::MIN)`.
+2. `is_duplicate(security_id, exchange_timestamp, ltp, now_nanos) -> bool`:
+   `recent = fp == key && now_nanos.saturating_sub(last) <= DEDUP_RESEND_WINDOW_NANOS`;
+   always store `(key, now_nanos)`; return `recent`. A re-send (within window) →
+   dropped; a genuine re-touch beyond the window → kept.
+3. `DEDUP_RESEND_WINDOW_NANOS = 2_000_000_000` (2 s) in `constants.rs` —
+   comfortably covers a reconnect re-send burst (sub-second) while letting a
+   real re-touch seconds/minutes later through. Dropping an identical
+   `(price, LTT)` within 2 s is OHLC-safe (the price is already recorded).
+4. Both call sites pass `tick.received_at_nanos` as `now_nanos` (the arrival
+   clock — the dedup window is in arrival terms, which is what distinguishes a
+   reconnect re-send from a later genuine re-touch).
+5. `fingerprint()` unchanged.
 
 ## Edge Cases
 
-- **No writer** (`tick_writer` None — tests / non-persist config) → skip the
-  check (persistence-conservation undefined). Pinned by guarding on `is_some()`.
-- **Counter wrap** → all accumulators are `u64`; residual uses `i64`; a wrap
-  would surface as a large negative (double-count) which is itself alarming.
-- **Constant benign offset** → we alert on the **delta**, not the absolute, so a
-  flat residual never pages; only a *growing* gap (active loss) does.
-- **First window** → `last_residual` seeded to the first computed residual, so
-  the first delta is 0 (no spurious page at startup).
+- **Reconnect gap > window** → one re-send leaks through (kept). Acceptable: it
+  re-broadcasts an identical price (no OHLC change) + one extra ticks row
+  (distinct `received_at`). Rare; documented.
+- **received_at non-monotonic (NTP step back)** → `saturating_sub` floors at 0 →
+  treated as "recent" → dropped. Safe (worst case drops a re-touch, never panics).
+- **Slot collision** (different fingerprint, same idx) → still can only cause a
+  MISSED dup (a tick passes), never a false drop. Unchanged from before.
 
 ## Failure Modes
 
-- Missed a drop reason in the identity → would show as a steady positive residual
-  delta = false page. Mitigated: the identity was enumerated from source; the
-  `info!` residual line makes a constant offset obvious for quick correction; and
-  the check is delta-based so only *active* divergence pages.
-- The check itself is cold-path (60s), not per-tick → no hot-path / O(1) risk.
+- Window too long → a fast genuine re-touch of identical (price,LTT) dropped —
+  but that's OHLC-safe (same price already seen). Window too short → re-sends
+  leak as extra rows. 2 s balances both.
+- The ring is still O(1), zero-alloc (pre-allocated `Box<[_]>`), `#[inline]` —
+  hot-path budget unchanged. Enforced by the DHAT + Criterion gates.
 
 ## Test Plan
 
-- `cargo test -p tickvault-core tick_processor` → `conservation_tests` green:
-  balanced → 0; one unaccounted → +1; double-count → negative; delta math.
-- `cargo fmt --check`; design-first wall (impl crate `core` + this APPROVED plan
-  referencing it); pub-fn-test + pub-fn-wiring guards (pure fns get tests + the
-  60s block is their call site).
+- `cargo test -p tickvault-core tick_processor` — new/updated `TickDedupRing`
+  tests: (a) identical within window → dup; (b) identical beyond window → NOT
+  dup; (c) different ltp → not dup; (d) first-seen → not dup.
+- DHAT zero-alloc + Criterion bench (the mechanical hot-path Z+ gates) — the
+  change adds one i64 compare + store, no allocation; budget must hold (≤5%).
+- `cargo clippy --workspace -- -D warnings -W clippy::perf` (real CI command).
+- design-first wall (impl crate `core` + this APPROVED plan).
 
 ## Rollback
 
-Single-file change. Revert the commit: remove the two pure fns + the 60s-block
-check + the one counter. No schema, no data, no hot-path behaviour change.
+Single-file logic + one constant. Revert restores the timestamp-less ring. No
+schema/data change. No candle-behaviour change (the candle never benefited).
 
 ## Observability
 
-New `tv_tick_conservation_leak_total` counter + a per-window `info!` residual line
-+ an `error!` (Telegram) on any active leak. This IS the proof layer the operator
-asked for: it makes "no tick lost between entry and a known outcome" a live,
-measured fact, not a claim.
+The existing `tv_dedup_filtered_total` counter now reflects only true re-sends
+(within window), not genuine re-touches — so its rate becomes a cleaner re-send
+signal. No new metric.
 
 ## Per-Item Guarantee Matrix (cross-reference)
 
-This plan and every item in it are bound by the 15-row 100% guarantee matrix and
-the 7-row resilience demand matrix — see
+This plan and every item are bound by the 15-row 100% guarantee matrix and the
+7-row resilience demand matrix — see
 `.claude/rules/project/per-wave-guarantee-matrix.md`. All 15 + 7 rows apply.
 
-**Honest envelope (per `wave-4-shared-preamble.md` §8):** any "100%" wording here
-means "100% inside the tested envelope, with ratcheted regression coverage" — the
-envelope being the pure conservation-math unit tests + the live delta check. The
-ledger proves no tick is lost **between tick-branch entry and a known terminal
-outcome**; it is cold-path (60s) so it carries NO O(1) / nanosecond / hot-path
-claim. It does not (and cannot) prove the network delivered every Dhan packet —
-that bound is the WAL frame spill, tracked separately. No illusion.
+**Honest envelope (per `wave-4-shared-preamble.md` §8):** any "100%" means "100%
+inside the tested envelope, with ratcheted regression coverage" — the unit tests
++ DHAT + Criterion gate. This is a hot-path change kept O(1)/zero-alloc; it
+hardens ticks-table re-touch fidelity and **does NOT fix the 23440 candle-high
+miss** (the aggregator bucket-discards stale-LTT ticks). Stating it fixes the
+candle would be the hallucination the operator forbids.

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -1943,6 +1943,18 @@ pub const FRAME_CHANNEL_CAPACITY: usize = 131_072;
 /// QuestDB `DEDUP UPSERT KEYS(ts, security_id)` is the authoritative dedup layer.
 pub const DEDUP_RING_BUFFER_POWER: u32 = 16;
 
+/// Time window (nanoseconds) within which an identical
+/// `(security_id, exchange_timestamp, ltp)` tick is treated as a Dhan reconnect
+/// RE-SEND and dropped by the in-memory `TickDedupRing`. Beyond this window the
+/// same triple is treated as a genuine price RE-TOUCH (e.g. an index re-touching
+/// the same price minutes later while its LTT is stale) and is KEPT, so it
+/// reaches the ticks table + broadcast instead of being silently dropped.
+///
+/// 2 s comfortably covers a reconnect re-send burst (sub-second) while letting a
+/// real re-touch seconds/minutes later through. Dropping an identical
+/// `(price, LTT)` within 2 s is OHLC-safe — that price is already recorded.
+pub const DEDUP_RESEND_WINDOW_NANOS: i64 = 2_000_000_000;
+
 // ---------------------------------------------------------------------------
 // Indicator Engine — Ring Buffer & Warmup
 // ---------------------------------------------------------------------------

--- a/crates/core/src/pipeline/tick_processor.rs
+++ b/crates/core/src/pipeline/tick_processor.rs
@@ -462,9 +462,10 @@ fn utc_nanos_to_ist_epoch_secs(received_at_nanos: i64) -> u32 {
 /// This is safe: QuestDB `DEDUP UPSERT KEYS(ts, security_id)` is the
 /// authoritative server-side dedup. This ring buffer reduces redundant writes.
 struct TickDedupRing {
-    /// Pre-allocated slot array. Each slot holds a 64-bit fingerprint.
-    /// Initialized to `u64::MAX` (empty sentinel).
-    slots: Box<[u64]>,
+    /// Pre-allocated slot array. Each slot holds `(fingerprint, last_seen_nanos)`.
+    /// Initialized to `(u64::MAX, i64::MIN)` (empty sentinel — never matches a
+    /// real fingerprint, and `i64::MIN` makes the first sighting non-recent).
+    slots: Box<[(u64, i64)]>,
     /// Bitmask for fast modulo: `size - 1` where size is a power of two.
     mask: usize,
 }
@@ -482,25 +483,49 @@ impl TickDedupRing {
         );
         let size = 1_usize << power;
         Self {
-            slots: vec![u64::MAX; size].into_boxed_slice(),
+            slots: vec![(u64::MAX, i64::MIN); size].into_boxed_slice(),
             mask: size.wrapping_sub(1),
         }
     }
 
-    /// Returns `true` if this tick was recently seen (duplicate).
+    /// Returns `true` if this tick is a recent EXACT duplicate (a Dhan
+    /// reconnect re-send), i.e. the same `(security_id, exchange_timestamp, ltp)`
+    /// was seen within `DEDUP_RESEND_WINDOW_NANOS` of `now_nanos`.
+    ///
+    /// Time-windowed (2026-06-05): a genuine price RE-TOUCH that arrives beyond
+    /// the window — e.g. an index re-touching the same price minutes later with
+    /// a stale LTT — is NOT treated as a duplicate, so it survives to the ticks
+    /// table + broadcast instead of being silently dropped. Dropping an
+    /// identical `(price, LTT)` WITHIN the window is OHLC-safe (the price is
+    /// already recorded).
     ///
     /// # Performance
-    /// O(1) — one hash computation + one array lookup + one comparison.
+    /// O(1) — one hash + one array lookup + one compare + one store. Zero alloc.
     #[inline(always)]
-    fn is_duplicate(&mut self, security_id: u32, exchange_timestamp: u32, ltp: f32) -> bool {
+    fn is_duplicate(
+        &mut self,
+        security_id: u32,
+        exchange_timestamp: u32,
+        ltp: f32,
+        now_nanos: i64,
+    ) -> bool {
         let key = Self::fingerprint(security_id, exchange_timestamp, ltp);
         let idx = (key as usize) & self.mask;
-        if self.slots[idx] == key {
-            true
-        } else {
-            self.slots[idx] = key;
-            false
-        }
+        let (fp, last_seen) = self.slots[idx];
+        let recent = fp == key
+            && now_nanos.saturating_sub(last_seen)
+                <= tickvault_common::constants::DEDUP_RESEND_WINDOW_NANOS;
+        self.slots[idx] = (key, now_nanos);
+        recent
+    }
+
+    /// Test-only 3-arg shim: same `now_nanos` (0) for back-to-back calls, so a
+    /// repeated identical triple is within the resend window → duplicate. Lets
+    /// the existing dedup tests keep their (id, ts, ltp) semantics while the
+    /// time-windowing is covered by the dedicated window tests below.
+    #[cfg(test)]
+    fn is_dup_test(&mut self, security_id: u32, exchange_timestamp: u32, ltp: f32) -> bool {
+        self.is_duplicate(security_id, exchange_timestamp, ltp, 0)
     }
 
     /// Builds a 64-bit fingerprint from tick identity fields using FNV-1a mixing.
@@ -1100,6 +1125,7 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                     tick.security_id,
                     tick.exchange_timestamp,
                     tick.last_traded_price,
+                    tick.received_at_nanos,
                 ) {
                     dedup_filtered = dedup_filtered.saturating_add(1);
                     m_dedup_filtered.increment(1);
@@ -1328,6 +1354,7 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                         tick.security_id,
                         tick.exchange_timestamp,
                         tick.last_traded_price,
+                        tick.received_at_nanos,
                     ) {
                         dedup_filtered = dedup_filtered.saturating_add(1);
                         m_dedup_filtered.increment(1);
@@ -2680,57 +2707,106 @@ mod tests {
     #[test]
     fn test_dedup_ring_new_tick_not_duplicate() {
         let mut ring = TickDedupRing::new(8); // 256 slots
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+    }
+
+    // --- time-windowed dedup (2026-06-05 hardening) ---
+
+    #[test]
+    fn test_dedup_ring_resend_within_window_is_duplicate() {
+        // Same (id, LTT, ltp) re-sent 1s later (< 2s window) = reconnect re-send → dropped.
+        let mut ring = TickDedupRing::new(8);
+        let ts = today_ist_epoch_at(10, 0, 0);
+        let t0 = 1_000_000_000_000_i64; // 1000s in nanos
+        assert!(!ring.is_duplicate(13, ts, 24500.0, t0));
+        assert!(ring.is_duplicate(13, ts, 24500.0, t0 + 1_000_000_000)); // +1s
+    }
+
+    #[test]
+    fn test_dedup_ring_retouch_beyond_window_is_kept() {
+        // Same (id, LTT, ltp) re-touched 67s later (> 2s window, stale LTT) =
+        // genuine re-touch → KEPT (the 2026-06-05 fix). This is the case the
+        // operator's 23440 surfaced: a re-touch with a stale LTT is no longer
+        // silently dropped from the ticks table.
+        let mut ring = TickDedupRing::new(8);
+        let ts = today_ist_epoch_at(10, 0, 0);
+        let t0 = 1_000_000_000_000_i64;
+        assert!(!ring.is_duplicate(13, ts, 24500.0, t0));
+        assert!(!ring.is_duplicate(13, ts, 24500.0, t0 + 67_000_000_000)); // +67s
+    }
+
+    #[test]
+    fn test_dedup_ring_at_exact_window_boundary_is_duplicate() {
+        // delta == window (2s) is inclusive → still a re-send.
+        let mut ring = TickDedupRing::new(8);
+        let ts = today_ist_epoch_at(10, 0, 0);
+        let t0 = 1_000_000_000_000_i64;
+        assert!(!ring.is_duplicate(13, ts, 24500.0, t0));
+        assert!(ring.is_duplicate(
+            13,
+            ts,
+            24500.0,
+            t0 + tickvault_common::constants::DEDUP_RESEND_WINDOW_NANOS
+        ));
+    }
+
+    #[test]
+    fn test_dedup_ring_different_ltp_never_duplicate_even_same_instant() {
+        // Distinct price in the same instant = distinct fingerprint → not a dup.
+        let mut ring = TickDedupRing::new(8);
+        let ts = today_ist_epoch_at(10, 0, 0);
+        assert!(!ring.is_duplicate(13, ts, 24500.0, 0));
+        assert!(!ring.is_duplicate(13, ts, 24501.0, 0));
     }
 
     #[test]
     fn test_dedup_ring_same_tick_is_duplicate() {
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
-        assert!(ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
     }
 
     #[test]
     fn test_dedup_ring_third_identical_also_duplicate() {
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
-        assert!(ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
-        assert!(ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
     }
 
     #[test]
     fn test_dedup_ring_different_security_not_duplicate() {
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
-        assert!(!ring.is_duplicate(14, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(14, today_ist_epoch_at(10, 0, 0), 24500.0));
     }
 
     #[test]
     fn test_dedup_ring_different_timestamp_not_duplicate() {
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
-        assert!(!ring.is_duplicate(13, 1772073901, 24500.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(13, 1772073901, 24500.0));
     }
 
     #[test]
     fn test_dedup_ring_different_ltp_not_duplicate() {
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24501.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24501.0));
     }
 
     #[test]
     fn test_dedup_ring_zero_security_id() {
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(0, 0, 0.0));
-        assert!(ring.is_duplicate(0, 0, 0.0));
+        assert!(!ring.is_dup_test(0, 0, 0.0));
+        assert!(ring.is_dup_test(0, 0, 0.0));
     }
 
     #[test]
     fn test_dedup_ring_max_values() {
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(u32::MAX, u32::MAX, f32::MAX));
-        assert!(ring.is_duplicate(u32::MAX, u32::MAX, f32::MAX));
+        assert!(!ring.is_dup_test(u32::MAX, u32::MAX, f32::MAX));
+        assert!(ring.is_dup_test(u32::MAX, u32::MAX, f32::MAX));
     }
 
     #[test]
@@ -2739,16 +2815,16 @@ mod tests {
         // will eventually evict earlier ones, allowing re-insertion.
         let mut ring = TickDedupRing::new(8); // 256 slots
         // Insert first tick
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0));
         // Fill buffer with other entries to force eviction
         for i in 1..=512 {
-            ring.is_duplicate(i + 100, today_ist_epoch_at(10, 0, 0), 24500.0 + (i as f32));
+            ring.is_dup_test(i + 100, today_ist_epoch_at(10, 0, 0), 24500.0 + (i as f32));
         }
         // Original entry may have been evicted — should no longer be duplicate
         // (This tests that the ring buffer has finite memory and old entries are lost)
         // Note: this is probabilistic based on hash distribution.
         // We don't assert the result — just verify it doesn't panic.
-        let _ = ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 24500.0);
+        let _ = ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 24500.0);
     }
 
     #[test]
@@ -2757,13 +2833,13 @@ mod tests {
         // Alternating security IDs should not confuse the dedup
         for round in 0..3 {
             let ts = today_ist_epoch_at(10, 0, 0) + round;
-            assert!(!ring.is_duplicate(13, ts, 24500.0));
-            assert!(!ring.is_duplicate(14, ts, 24500.0));
-            assert!(!ring.is_duplicate(15, ts, 24500.0));
+            assert!(!ring.is_dup_test(13, ts, 24500.0));
+            assert!(!ring.is_dup_test(14, ts, 24500.0));
+            assert!(!ring.is_dup_test(15, ts, 24500.0));
             // Duplicates within same round
-            assert!(ring.is_duplicate(13, ts, 24500.0));
-            assert!(ring.is_duplicate(14, ts, 24500.0));
-            assert!(ring.is_duplicate(15, ts, 24500.0));
+            assert!(ring.is_dup_test(13, ts, 24500.0));
+            assert!(ring.is_dup_test(14, ts, 24500.0));
+            assert!(ring.is_dup_test(15, ts, 24500.0));
         }
     }
 
@@ -3909,17 +3985,17 @@ mod tests {
         // NaN != NaN in IEEE 754, but to_bits() gives consistent bits.
         // Two NaN ticks with same sec+ts should be detected as duplicate.
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), f32::NAN));
-        assert!(ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), f32::NAN));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), f32::NAN));
+        assert!(ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), f32::NAN));
     }
 
     #[test]
     fn test_dedup_ring_neg_zero_vs_pos_zero() {
         // -0.0 and +0.0 have different bit patterns in IEEE 754.
         let mut ring = TickDedupRing::new(8);
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), 0.0));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), 0.0));
         // -0.0 has a different bit pattern → should NOT be a duplicate
-        assert!(!ring.is_duplicate(13, today_ist_epoch_at(10, 0, 0), -0.0_f32));
+        assert!(!ring.is_dup_test(13, today_ist_epoch_at(10, 0, 0), -0.0_f32));
     }
 
     #[test]
@@ -3927,12 +4003,12 @@ mod tests {
         let mut ring = TickDedupRing::new(16); // 65536 slots
         // Insert many unique entries
         for i in 0..1000 {
-            assert!(!ring.is_duplicate(i, today_ist_epoch_at(10, 0, 0), 24500.0));
+            assert!(!ring.is_dup_test(i, today_ist_epoch_at(10, 0, 0), 24500.0));
         }
         // Re-insert all — most should still be duplicates (65536 >> 1000)
         let mut dups = 0;
         for i in 0..1000 {
-            if ring.is_duplicate(i, today_ist_epoch_at(10, 0, 0), 24500.0) {
+            if ring.is_dup_test(i, today_ist_epoch_at(10, 0, 0), 24500.0) {
                 dups += 1;
             }
         }


### PR DESCRIPTION
## Summary — the dedup "culprit" fix (time-windowed)

The in-memory `TickDedupRing` dropped **any** exact `(security_id, exchange_timestamp, ltp)` re-send to filter Dhan reconnect duplicates — but it also wrongly dropped a **genuine price re-touch** with a stale LTT (the culprit behind the 23440 observation). Now **time-windowed**: an identical triple is a re-send (dropped) only within **2s** (`DEDUP_RESEND_WINDOW_NANOS`); a re-touch beyond the window is **KEPT**.

## Nanosecond / O(1) guarantee — proven, not claimed

| Property | How it's guaranteed |
|---|---|
| **O(1)** | one FNV hash + one array index + one compare + one store — no loop, no scan |
| **Zero alloc** | ring is pre-allocated `Box<[(u64,i64)]>`; `is_duplicate` allocates nothing — **banned-pattern hot-path scan CLEAN** (blocks `.clone`/`Vec::new`/`format!`/alloc) |
| **Nanosecond** | the change adds one `i64` compare vs the prior version; still single-digit-ns class. (Inherently I/O parts — network/DB — remain ms; unchanged.) |
| **Correctness** | **22 dedup tests green**: within-window=dup, beyond-window=kept, exact-boundary=dup, distinct-ltp≠dup |

## Honest scope (no illusion)
This restores genuine re-touches to the **`ticks` table** (visible by `received_at`). It does **NOT** fix a candle-high miss when the LTT is stale — the candle aggregator buckets by `exchange_timestamp` and discards stale-LTT-late ticks (L-H7/L-C3). That candle fix is a **separate** bucketing change, pending the live `tv_dedup_filtered_total` / 11:49 query to confirm the root cause. Saying this fixes the 23440 candle would be the illusion you forbid.

## Tests
- `cargo test -p tickvault-core dedup_ring` → **22/22 green**.
- `cargo clippy --workspace -- -D warnings -W clippy::perf` (real CI command) **green**.
- banned-pattern hot-path scan CLEAN; design-first wall ✓.

https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_