### PR TITLE
ci: enforce the design-first wall as a PR gate

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,72 +1,81 @@
-# Implementation Plan: Fix flaky spill-recovery count test (storage)
+# Implementation Plan: CI-enforce the design-first wall
 
 **Status:** APPROVED
 **Date:** 2026-06-05
-**Approved by:** Parthiban (standing directive: keep CI green, fix flakes) — follow-up to #1029, whose new trading tests shifted nextest ordering and exposed this latent flake.
-**Crate(s) touched:** `storage`
+**Approved by:** Parthiban — chose "CI-enforce the plan wall".
+**Crate(s) touched:** none (CI workflow only: `.github/workflows/ci.yml`)
 
-## Context (verified from the CI log, no illusion)
+## Context
 
-CI "Test (storage)" failed on #1029:
-`tick_persistence::tests::test_recover_stale_spill_file_on_startup` asserted it
-recovered exactly **50** ticks but got **60**. Root cause: `recover_stale_spill_files()`
-scans the WHOLE shared `data/spill/` dir for every `ticks-*.bin`. A leftover
-`ticks-*.bin` from another test in the same nextest run (the spill tests share
-the real dir under `spill_dir_test_lock`, but a count test never pre-cleans)
-inflated the count by 10 → 60. It passed locally (different ordering) and on the
-#1029 re-run (auto-merged before this fix), so the flake is STILL latent in main
-and will randomly fail future CI.
+The design-first wall (`.claude/hooks/plan-gate.sh`) blocks an implementation
+push (`crates/*/src/**.rs`) that has no APPROVED plan referencing the changed
+crate. Today it runs ONLY in the local pre-push hooks
+(`.claude/hooks/pre-push-gate.sh` + `scripts/git-hooks/pre-push`), so a push
+that bypasses local hooks (`--no-verify`, a web edit, a fork) escapes it. This
+item runs the SAME hook as a GitHub CI gate on every PR.
 
 ## Plan Items
 
-- [x] Item 1 — Add `purge_stale_tick_spill_files(dir)` test helper
-  - Files: `crates/storage/src/tick_persistence.rs`
-  - Tests: existing `test_recover_*` suite (8) now deterministic
-- [x] Item 2 — Pre-clean stale `ticks-*.bin` in the two exact-count recovery tests
-  - Files: `crates/storage/src/tick_persistence.rs`
-  - Tests: `test_recover_stale_spill_file_on_startup`, `test_recover_skips_current_active_spill`
+- [x] Item 1 — Add a `design-first-wall` job to `ci.yml` (pull_request only)
+  - Files: `.github/workflows/ci.yml`
+  - Tests: `bash .claude/hooks/plan-gate.sh` already self-tested by
+    `.claude/hooks/plan-gate.selftest.sh` (11 cases); CI step re-runs the gate
 
 ## Design
 
-The exact-count recovery tests call `purge_stale_tick_spill_files(real_spill_dir)`
-right after `create_dir_all` (under the existing `spill_dir_test_lock`), removing
-any pre-existing `ticks-*.bin` so they begin from a known-empty dir. The helper is
-idempotent and ignores a missing dir / per-file errors.
+1. New job `design-first-wall`, `if: github.event_name == 'pull_request'`,
+   `runs-on: ubuntu-latest`, mirrors the `commit-lint` job shape.
+2. `actions/checkout@v6` with `fetch-depth: 0` so the base commit is present.
+3. Run `bash .claude/hooks/plan-gate.sh "${{ github.workspace }}"` with
+   `PLAN_GATE_BASE=${{ github.event.pull_request.base.sha }}` — the hook's
+   documented env override (L6), giving the exact PR base for the
+   `${BASE}...HEAD` diff (no reliance on `origin/main` ref resolution).
+   `CLAUDE_PROJECT_DIR=${{ github.workspace }}`.
+4. Exit non-zero (gate's exit 2) fails the job → the PR check goes red.
 
 ## Edge Cases
 
-- Missing spill dir → `read_dir` errors → helper no-ops (safe).
-- Non-`ticks-*.bin` files in the dir → untouched (only the matched pattern removed).
-- Concurrent spill tests → all serialized by `spill_dir_test_lock`, so the
-  pre-clean + write + recover sequence is atomic w.r.t. other spill tests.
+- **Docs/CI-only PR (incl. THIS one)** → no `crates/*/src/**.rs` change → gate
+  PASSES (so this PR is self-consistent; it does not block itself).
+- **`PLAN-EXEMPT:` commit** → gate honours it (≤1 impl file) → PASS.
+- **Plan archived before merge** → gate would BLOCK (no active plan). The
+  current Claude workflow commits plan + code together and archives only
+  AFTER merge, so the plan is present on the PR branch — compatible. Documented
+  so a future archive-before-merge flow knows to use `PLAN-EXEMPT:` or keep the
+  plan until merge.
 
 ## Failure Modes
 
-- Test-only change; zero production code touched. Worst case a future test adds a
-  spill file under a different name — out of scope (the pattern matches the
-  production `ticks-*.bin` naming).
+- The job only READS git + runs the hook; it cannot mutate the repo. Worst case
+  is a false RED, recoverable by adding the plan or a `PLAN-EXEMPT:` line.
+- Not yet a REQUIRED check (branch protection is an operator UI setting) — the
+  job runs + reports; the operator marks it required to make it merge-blocking.
+  Stated honestly in the PR.
 
 ## Test Plan
 
-- `cargo test -p tickvault-storage --lib test_recover` — 8 green (deterministic).
-- `cargo clippy -p tickvault-storage -- -D warnings -W clippy::perf` clean.
-- design-first wall (impl crate `storage` + this APPROVED plan).
+- `bash .claude/hooks/plan-gate.sh "$PWD"` locally (this PR = no impl src) → exit 0.
+- `PLAN_GATE_BASE=origin/main bash .claude/hooks/plan-gate.sh "$PWD"` → exit 0.
+- `bash .claude/hooks/plan-gate.selftest.sh` → 11/11 pass (gate logic unchanged).
+- YAML sanity: the job parses (no tab/indent errors).
 
 ## Rollback
 
-Revert the helper + the two call sites. No production behaviour change.
+Delete the `design-first-wall` job from `ci.yml`. No code/schema impact; the
+local pre-push hooks still enforce the wall.
 
 ## Observability
 
-None — test isolation only. CI "Test (storage)" stops flaking.
+The PR Checks tab gains a "Design-First Wall" check — green/red per PR. No new
+metric (CI-native signal).
 
 ## Per-Item Guarantee Matrix (cross-reference)
 
-Bound by the 15-row 100% guarantee matrix + 7-row resilience matrix — see
+Bound by the 15-row guarantee matrix + 7-row resilience matrix — see
 `.claude/rules/project/per-wave-guarantee-matrix.md`.
 
 **Honest envelope:** "100% inside the tested envelope, with ratcheted regression
-coverage" = the 8 deterministic `test_recover_*` tests. This is a test-only flake
-fix making a recovery-COUNT assertion deterministic regardless of nextest parallel
-ordering. No production logic change; the zero-tick-loss spill→recover behaviour is
-unchanged.
+coverage" = the `plan-gate.selftest.sh` 11-case suite (the gate logic this CI
+job invokes). This adds a CI surface for an EXISTING, tested gate; it does not
+change the gate logic. It becomes merge-blocking only once the operator marks
+the check required in branch protection — stated, not assumed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,34 @@ jobs:
           exit $failed
 
   # -------------------------------------------------------------------------
+  # Design-First Wall — no implementation change (crates/*/src/**.rs) may land
+  # without an APPROVED plan referencing the changed crate. Runs the SAME hook
+  # the local pre-push gate uses (.claude/hooks/plan-gate.sh), so a push that
+  # bypassed local hooks (--no-verify, a web edit, a fork) is still caught.
+  # See .claude/rules/project/design-first-wall.md.
+  # -------------------------------------------------------------------------
+  design-first-wall:
+    name: "Design-First Wall"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Enforce design-first wall (plan-gate)
+        shell: bash
+        env:
+          # The hook's documented base-ref override (L6): use the exact PR base
+          # commit for the ${BASE}...HEAD changed-file diff — no reliance on
+          # origin/main ref resolution inside the runner.
+          PLAN_GATE_BASE: ${{ github.event.pull_request.base.sha }}
+          CLAUDE_PROJECT_DIR: ${{ github.workspace }}
+        run: bash .claude/hooks/plan-gate.sh "${{ github.workspace }}"
+
+  # -------------------------------------------------------------------------
   # Build & Verify — fmt + clippy + lib tests per crate.
   #
   # Split fmt + clippy (fast, one runner) from per-crate `cargo nextest run


### PR DESCRIPTION
## Summary

Runs the **design-first wall** (`.claude/hooks/plan-gate.sh`) as a GitHub CI gate on every PR — the same hook the local pre-push hook already uses. Today the wall only runs locally, so a push that bypassed local hooks (`--no-verify`, a web edit, a fork) escaped it. Now an implementation change (`crates/*/src/**.rs`) without an **APPROVED plan referencing the changed crate** fails the new **Design-First Wall** check.

## How it works
- New `design-first-wall` job, `pull_request`-only, mirrors the `commit-lint` job.
- `actions/checkout@v6` `fetch-depth: 0`; runs `bash .claude/hooks/plan-gate.sh`.
- Feeds the hook its documented `PLAN_GATE_BASE` override = `${{ github.event.pull_request.base.sha }}` → exact PR-base changed-file diff (no reliance on `origin/main` ref resolution in the runner).
- Gate exit 2 → job red.

## Self-consistency
This PR changes only `.github/workflows/ci.yml` + `.claude/plans/active-plan.md` (no `crates/*/src`), so the gate **passes on its own PR** (verified locally: `plan-gate: PASS — no crates/*/src/*.rs logic changed`).

## Honest envelope
"100% inside the tested envelope, with ratcheted regression coverage" = the existing `plan-gate.selftest.sh` 11-case suite (the gate logic this job invokes; unchanged here). This adds a **CI surface** for an already-tested gate — it does **not** change the gate logic. It becomes **merge-blocking only once you mark "Design-First Wall" a required check in branch protection** (a GitHub UI setting I can't change from here) — stated, not assumed.

## Note on branch
Opened from `claude/ci-design-first-wall` (you approved a fresh branch): the prior `claude/admiring-hypatia-4hoCX` was stuck — its remote tip still held the already-merged pre-squash #1029/#1030 commits, and force-push is denied in this environment. Its content is fully merged; nothing lost.

## Test plan
- [x] `PLAN_GATE_BASE=origin/main bash .claude/hooks/plan-gate.sh "$PWD"` → exit 0 (this PR)
- [x] `bash .claude/hooks/plan-gate.selftest.sh` → 11/11 pass
- [x] `bash .claude/hooks/per-item-guarantee-check.sh` → PASS
- [x] `ci.yml` parses (yaml.safe_load)

https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUoNwVs9qdb2aEYvJf3j31)_