### PR TITLE
test(storage): mechanically enforce the §28 indicator/strategy operator boundary

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,81 +1,109 @@
-# Implementation Plan: CI-enforce the design-first wall
+# Implementation Plan: §28 indicator/strategy operator-boundary guard
 
 **Status:** APPROVED
-**Date:** 2026-06-05
-**Approved by:** Parthiban — chose "CI-enforce the plan wall".
-**Crate(s) touched:** none (CI workflow only: `.github/workflows/ci.yml`)
+**Date:** 2026-06-06
+**Approved by:** Parthiban — AskUserQuestion "implement the guard test" (2026-06-06).
+**Crate(s) touched:** none under `src/` — adds `crates/storage/tests/operator_boundary_indicator_strategy_guard.rs` (a test) + docs/plan files only. (Design-first wall does not trigger on `tests/`, but this plan exists for plan-enforcement + the per-wave guarantee matrix.)
 
 ## Context
 
-The design-first wall (`.claude/hooks/plan-gate.sh`) blocks an implementation
-push (`crates/*/src/**.rs`) that has no APPROVED plan referencing the changed
-crate. Today it runs ONLY in the local pre-push hooks
-(`.claude/hooks/pre-push-gate.sh` + `scripts/git-hooks/pre-push`), so a push
-that bypasses local hooks (`--no-verify`, a web edit, a fork) escapes it. This
-item runs the SAME hook as a GitHub CI gate on every PR.
+`.claude/rules/project/daily-universe-scope-expansion-2026-05-27.md` §28 (operator
+boundary, 2026-05-27 verbatim "as of now don't even touch indicators and strategies
+area dude okay?") PROMISES a mechanical ratchet:
+
+> `crates/storage/tests/operator_boundary_indicator_strategy_guard.rs::test_indicator_engine_states_field_unchanged_since_2026_05_27`
+> (source-scan: SHA-256 the relevant lines of `engine.rs`; any modification fails the
+> build until the boundary is lifted)
+
+Deep-research agent verification (2026-06-06) confirmed the test FILE DOES NOT EXIST —
+the boundary is currently enforced only by human discipline, not mechanically. This
+item ships the missing ratchet.
 
 ## Plan Items
 
-- [x] Item 1 — Add a `design-first-wall` job to `ci.yml` (pull_request only)
-  - Files: `.github/workflows/ci.yml`
-  - Tests: `bash .claude/hooks/plan-gate.sh` already self-tested by
-    `.claude/hooks/plan-gate.selftest.sh` (11 cases); CI step re-runs the gate
+- [x] Item 1 — Add `crates/storage/tests/operator_boundary_indicator_strategy_guard.rs`
+  - Files: `crates/storage/tests/operator_boundary_indicator_strategy_guard.rs`
+  - Tests: `test_indicator_engine_states_field_unchanged_since_2026_05_27`,
+    `test_indicator_strategy_boundary_files_unchanged`,
+    `test_boundary_manifest_covers_every_src_file`
 
 ## Design
 
-1. New job `design-first-wall`, `if: github.event_name == 'pull_request'`,
-   `runs-on: ubuntu-latest`, mirrors the `commit-lint` job shape.
-2. `actions/checkout@v6` with `fetch-depth: 0` so the base commit is present.
-3. Run `bash .claude/hooks/plan-gate.sh "${{ github.workspace }}"` with
-   `PLAN_GATE_BASE=${{ github.event.pull_request.base.sha }}` — the hook's
-   documented env override (L6), giving the exact PR base for the
-   `${BASE}...HEAD` diff (no reliance on `origin/main` ref resolution).
-   `CLAUDE_PROJECT_DIR=${{ github.workspace }}`.
-4. Exit non-zero (gate's exit 2) fails the job → the PR check goes red.
+The boundary is "do not touch `crates/trading/src/indicator/` or
+`crates/trading/src/strategy/`". The strongest mechanical enforcement is a
+content-pin of EVERY `.rs` file under both directories. Any edit (even a comment)
+flips the pin → build fails → forces a conscious boundary-lift (re-bless + rule
+edit).
+
+- **Hash:** inline FNV-1a 64-bit (offset `0xcbf29ce484222325`, prime
+  `0x100000001b3`). Chosen over `sha2` because new workspace deps need operator
+  approval (CLAUDE.md), and FNV-1a is deterministic + version-stable for a
+  persisted pin (unlike `std::hash::DefaultHasher`). This is regression-evidence,
+  not adversarial crypto, so FNV-1a is sufficient.
+- **Manifest:** a `const BOUNDARY_FILES: &[(path, fnv1a64, byte_len, line_count)]`
+  baked from the current tree (computed 2026-06-06).
+- **Repo-root resolution:** `CARGO_MANIFEST_DIR` (`crates/storage`) → `parent().parent()`
+  — same pattern as `crates/core/tests/indices4only_scope_lock_guard.rs`.
+- **`test_indicator_engine_states_field_unchanged_since_2026_05_27`** (the §28-named
+  test): asserts `engine.rs` still contains the exact `states: Vec<IndicatorState>,`
+  field line AND its (fnv, len) matches the pin — satisfies the §28 "states field
+  unchanged" contract specifically.
+- **`test_indicator_strategy_boundary_files_unchanged`**: every manifest file matches
+  its pinned (fnv, len).
+- **`test_boundary_manifest_covers_every_src_file`**: the manifest is neither missing
+  a file that exists on disk nor referencing a file that was deleted (catches a NEW
+  file added to the frozen dirs, or a deletion).
 
 ## Edge Cases
 
-- **Docs/CI-only PR (incl. THIS one)** → no `crates/*/src/**.rs` change → gate
-  PASSES (so this PR is self-consistent; it does not block itself).
-- **`PLAN-EXEMPT:` commit** → gate honours it (≤1 impl file) → PASS.
-- **Plan archived before merge** → gate would BLOCK (no active plan). The
-  current Claude workflow commits plan + code together and archives only
-  AFTER merge, so the plan is present on the PR branch — compatible. Documented
-  so a future archive-before-merge flow knows to use `PLAN-EXEMPT:` or keep the
-  plan until merge.
+- **New `.rs` added to a frozen dir** → `test_boundary_manifest_covers_every_src_file`
+  fails (disk has a file the manifest doesn't) — boundary still enforced.
+- **A frozen file deleted** → same test fails (manifest references a missing file).
+- **Reformatting / comment-only edit** → fnv changes → fails. Intended: §28 is
+  "don't even touch".
+- **Line-ending/whitespace drift** → fnv + byte_len change → fails. Intended.
+- **Test run from a different CWD** → repo root is derived from `CARGO_MANIFEST_DIR`,
+  not CWD, so it is stable.
 
 ## Failure Modes
 
-- The job only READS git + runs the hook; it cannot mutate the repo. Worst case
-  is a false RED, recoverable by adding the plan or a `PLAN-EXEMPT:` line.
-- Not yet a REQUIRED check (branch protection is an operator UI setting) — the
-  job runs + reports; the operator marks it required to make it merge-blocking.
-  Stated honestly in the PR.
+- The test only READS files; it cannot mutate the repo. Worst case is a false RED
+  when the operator legitimately edits the frozen area — resolved by re-blessing the
+  manifest AND updating §28 (the intended "lift the boundary" ritual). The failure
+  message spells this out.
+- If `CARGO_MANIFEST_DIR` resolution ever breaks (repo restructure), the test fails
+  closed (missing files) rather than silently passing.
 
 ## Test Plan
 
-- `bash .claude/hooks/plan-gate.sh "$PWD"` locally (this PR = no impl src) → exit 0.
-- `PLAN_GATE_BASE=origin/main bash .claude/hooks/plan-gate.sh "$PWD"` → exit 0.
-- `bash .claude/hooks/plan-gate.selftest.sh` → 11/11 pass (gate logic unchanged).
-- YAML sanity: the job parses (no tab/indent errors).
+- `cargo test -p tickvault-storage --test operator_boundary_indicator_strategy_guard`
+  → all 3 tests green on the current (un-edited) tree.
+- Negative check (manual, not committed): touch a byte in `engine.rs` → test goes RED;
+  revert → GREEN. (Verified locally during implementation, not part of the committed
+  suite.)
+- `cargo build --workspace` stays green (test-only addition).
 
 ## Rollback
 
-Delete the `design-first-wall` job from `ci.yml`. No code/schema impact; the
-local pre-push hooks still enforce the wall.
+- Single test file + plan/docs. `git revert <sha>` removes the guard entirely; zero
+  runtime/production impact (it is a dev/test-time ratchet only).
 
 ## Observability
 
-The PR Checks tab gains a "Design-First Wall" check — green/red per PR. No new
-metric (CI-native signal).
+- This is a build-time ratchet, not a runtime path — no Prometheus/Telegram/audit
+  surface applies. Its "signal" is a failing `cargo test` / CI check, which is the
+  correct and only observability for a source-scan guard (mirrors
+  `indices4only_scope_lock_guard.rs`, `dedup_segment_meta_guard.rs`). N/A for the
+  7-layer runtime telemetry by design.
 
-## Per-Item Guarantee Matrix (cross-reference)
+## Per-Item Guarantee Matrix (per `.claude/rules/project/per-wave-guarantee-matrix.md`)
 
-Bound by the 15-row guarantee matrix + 7-row resilience matrix — see
-`.claude/rules/project/per-wave-guarantee-matrix.md`.
-
-**Honest envelope:** "100% inside the tested envelope, with ratcheted regression
-coverage" = the `plan-gate.selftest.sh` 11-case suite (the gate logic this CI
-job invokes). This adds a CI surface for an EXISTING, tested gate; it does not
-change the gate logic. It becomes merge-blocking only once the operator marks
-the check required in branch protection — stated, not assumed.
+| Demand | This item |
+|---|---|
+| 100% testing | 3 tests cover field-pin, all-file-pin, and add/delete drift |
+| 100% scenarios | edge cases above (add/delete/reformat/whitespace/CWD) each map to a test arm |
+| 100% code review | adversarial self-review of the guard logic before PR |
+| O(1)/perf | N/A — test-time only, not a hot path; no runtime allocation introduced |
+| zero-loss / WS / QuestDB | N/A — does not touch tick/WS/DB paths |
+| uniqueness/dedup | N/A — no storage key |
+| honest envelope | guard detects ANY content change to the 12 frozen files; it does NOT prevent edits, it FAILS THE BUILD on them (the §28 "until the boundary is lifted" mechanism) |

--- a/.claude/plans/archive/2026-06-05-ci-design-first-wall.md
+++ b/.claude/plans/archive/2026-06-05-ci-design-first-wall.md
@@ -1,0 +1,81 @@
+# Implementation Plan: CI-enforce the design-first wall
+
+**Status:** APPROVED
+**Date:** 2026-06-05
+**Approved by:** Parthiban — chose "CI-enforce the plan wall".
+**Crate(s) touched:** none (CI workflow only: `.github/workflows/ci.yml`)
+
+## Context
+
+The design-first wall (`.claude/hooks/plan-gate.sh`) blocks an implementation
+push (`crates/*/src/**.rs`) that has no APPROVED plan referencing the changed
+crate. Today it runs ONLY in the local pre-push hooks
+(`.claude/hooks/pre-push-gate.sh` + `scripts/git-hooks/pre-push`), so a push
+that bypasses local hooks (`--no-verify`, a web edit, a fork) escapes it. This
+item runs the SAME hook as a GitHub CI gate on every PR.
+
+## Plan Items
+
+- [x] Item 1 — Add a `design-first-wall` job to `ci.yml` (pull_request only)
+  - Files: `.github/workflows/ci.yml`
+  - Tests: `bash .claude/hooks/plan-gate.sh` already self-tested by
+    `.claude/hooks/plan-gate.selftest.sh` (11 cases); CI step re-runs the gate
+
+## Design
+
+1. New job `design-first-wall`, `if: github.event_name == 'pull_request'`,
+   `runs-on: ubuntu-latest`, mirrors the `commit-lint` job shape.
+2. `actions/checkout@v6` with `fetch-depth: 0` so the base commit is present.
+3. Run `bash .claude/hooks/plan-gate.sh "${{ github.workspace }}"` with
+   `PLAN_GATE_BASE=${{ github.event.pull_request.base.sha }}` — the hook's
+   documented env override (L6), giving the exact PR base for the
+   `${BASE}...HEAD` diff (no reliance on `origin/main` ref resolution).
+   `CLAUDE_PROJECT_DIR=${{ github.workspace }}`.
+4. Exit non-zero (gate's exit 2) fails the job → the PR check goes red.
+
+## Edge Cases
+
+- **Docs/CI-only PR (incl. THIS one)** → no `crates/*/src/**.rs` change → gate
+  PASSES (so this PR is self-consistent; it does not block itself).
+- **`PLAN-EXEMPT:` commit** → gate honours it (≤1 impl file) → PASS.
+- **Plan archived before merge** → gate would BLOCK (no active plan). The
+  current Claude workflow commits plan + code together and archives only
+  AFTER merge, so the plan is present on the PR branch — compatible. Documented
+  so a future archive-before-merge flow knows to use `PLAN-EXEMPT:` or keep the
+  plan until merge.
+
+## Failure Modes
+
+- The job only READS git + runs the hook; it cannot mutate the repo. Worst case
+  is a false RED, recoverable by adding the plan or a `PLAN-EXEMPT:` line.
+- Not yet a REQUIRED check (branch protection is an operator UI setting) — the
+  job runs + reports; the operator marks it required to make it merge-blocking.
+  Stated honestly in the PR.
+
+## Test Plan
+
+- `bash .claude/hooks/plan-gate.sh "$PWD"` locally (this PR = no impl src) → exit 0.
+- `PLAN_GATE_BASE=origin/main bash .claude/hooks/plan-gate.sh "$PWD"` → exit 0.
+- `bash .claude/hooks/plan-gate.selftest.sh` → 11/11 pass (gate logic unchanged).
+- YAML sanity: the job parses (no tab/indent errors).
+
+## Rollback
+
+Delete the `design-first-wall` job from `ci.yml`. No code/schema impact; the
+local pre-push hooks still enforce the wall.
+
+## Observability
+
+The PR Checks tab gains a "Design-First Wall" check — green/red per PR. No new
+metric (CI-native signal).
+
+## Per-Item Guarantee Matrix (cross-reference)
+
+Bound by the 15-row guarantee matrix + 7-row resilience matrix — see
+`.claude/rules/project/per-wave-guarantee-matrix.md`.
+
+**Honest envelope:** "100% inside the tested envelope, with ratcheted regression
+coverage" = the `plan-gate.selftest.sh` 11-case suite (the gate logic this CI
+job invokes). This adds a CI surface for an EXISTING, tested gate; it does not
+change the gate logic. It becomes merge-blocking only once the operator marks
+the check required in branch protection — stated, not assumed.

--- a/crates/storage/tests/operator_boundary_indicator_strategy_guard.rs
+++ b/crates/storage/tests/operator_boundary_indicator_strategy_guard.rs
@@ -1,0 +1,266 @@
+//! §28 operator-boundary guard — `crates/trading/src/indicator/` +
+//! `crates/trading/src/strategy/` are FROZEN.
+//!
+//! Source-scan ratchet promised by
+//! `.claude/rules/project/daily-universe-scope-expansion-2026-05-27.md` §28
+//! (operator verbatim 2026-05-27: "as of now don't even touch indicators and
+//! strategies area dude okay?").
+//!
+//! Every `.rs` file under the two frozen directories is content-pinned by an
+//! FNV-1a 64-bit hash + byte length + line count, captured 2026-06-06. ANY edit
+//! to ANY of those files — even a comment or a whitespace change — flips the pin
+//! and FAILS THE BUILD. That is the §28 mechanism: the boundary holds "until the
+//! boundary is lifted".
+//!
+//! ## Lifting the boundary (the conscious ritual)
+//! When the operator EXPLICITLY lifts §28 with a dated quote:
+//!   1. Edit `.claude/rules/project/daily-universe-scope-expansion-2026-05-27.md`
+//!      §28 to record the lift (dated operator quote).
+//!   2. Re-bless the manifest below: run
+//!      `BLESS_BOUNDARY=1 cargo test -p tickvault-storage \
+//!        --test operator_boundary_indicator_strategy_guard -- --nocapture`
+//!      and paste the printed manifest over `BOUNDARY_FILES`.
+//! Never re-bless without step 1 — the whole point is that touching this area is
+//! a deliberate, recorded operator decision.
+//!
+//! Why FNV-1a and not SHA-256: a new workspace dependency needs operator approval
+//! (CLAUDE.md), and this is regression-evidence, not adversarial crypto. FNV-1a is
+//! deterministic + version-stable across Rust releases (unlike
+//! `std::hash::DefaultHasher`), so it is the correct tool for a persisted pin.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The two frozen directories, relative to repo root.
+const FROZEN_DIRS: &[&str] = &[
+    "crates/trading/src/indicator",
+    "crates/trading/src/strategy",
+];
+
+/// `engine.rs` field §28 names specifically ("the states field unchanged").
+const ENGINE_REL: &str = "crates/trading/src/indicator/engine.rs";
+const ENGINE_STATES_FIELD: &str = "states: Vec<IndicatorState>,";
+
+/// Content pin captured 2026-06-06 (pre-edit tree). Tuple =
+/// (path-relative-to-repo-root, fnv1a64, byte_len, line_count).
+const BOUNDARY_FILES: &[(&str, u64, usize, usize)] = &[
+    (
+        "crates/trading/src/indicator/engine.rs",
+        0xbce7f1b6f74e271d,
+        51785,
+        1436,
+    ),
+    (
+        "crates/trading/src/indicator/mod.rs",
+        0xcd18e8edd8661e9b,
+        351,
+        13,
+    ),
+    (
+        "crates/trading/src/indicator/obi.rs",
+        0xb7cc209c5154456b,
+        19913,
+        576,
+    ),
+    (
+        "crates/trading/src/indicator/tests.rs",
+        0x77678111f6fa34cf,
+        14525,
+        463,
+    ),
+    (
+        "crates/trading/src/indicator/types.rs",
+        0x5ad0c8a7f906943b,
+        32025,
+        968,
+    ),
+    (
+        "crates/trading/src/strategy/config.rs",
+        0x1391a4e2d0fbefb4,
+        41924,
+        1425,
+    ),
+    (
+        "crates/trading/src/strategy/config_tests.rs",
+        0x03c7b91bff066111,
+        11495,
+        459,
+    ),
+    (
+        "crates/trading/src/strategy/evaluator.rs",
+        0xa438888365d4671f,
+        76706,
+        2089,
+    ),
+    (
+        "crates/trading/src/strategy/hot_reload.rs",
+        0x5de2a85fe5a3ddca,
+        36909,
+        1081,
+    ),
+    (
+        "crates/trading/src/strategy/mod.rs",
+        0x6280e89d9fbbe221,
+        609,
+        20,
+    ),
+    (
+        "crates/trading/src/strategy/tests.rs",
+        0xdeb17a1ba308349a,
+        15843,
+        515,
+    ),
+    (
+        "crates/trading/src/strategy/types.rs",
+        0x355d2198678f1676,
+        24398,
+        786,
+    ),
+];
+
+/// FNV-1a 64-bit. Deterministic + stable across Rust versions.
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &byte in bytes {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = .../crates/storage  →  parent().parent() = repo root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repo root is two levels above crates/storage")
+        .to_path_buf()
+}
+
+fn read_rel(rel: &str) -> Vec<u8> {
+    let path = repo_root().join(rel);
+    fs::read(&path).unwrap_or_else(|err| panic!("§28 guard: cannot read frozen file {rel}: {err}"))
+}
+
+/// Every `.rs` file currently on disk under the frozen dirs (repo-relative).
+fn frozen_files_on_disk() -> BTreeSet<String> {
+    let root = repo_root();
+    let mut out = BTreeSet::new();
+    for dir in FROZEN_DIRS {
+        let abs = root.join(dir);
+        let entries = fs::read_dir(&abs)
+            .unwrap_or_else(|err| panic!("§28 guard: cannot read frozen dir {dir}: {err}"));
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .expect("file name is valid UTF-8");
+                out.insert(format!("{dir}/{name}"));
+            }
+        }
+    }
+    out
+}
+
+const LIFT_HINT: &str = "\n\n§28 OPERATOR BOUNDARY VIOLATED — `crates/trading/src/indicator/` and \
+`crates/trading/src/strategy/` are FROZEN by operator lock 2026-05-27 \
+(\"don't even touch indicators and strategies area\").\n\
+If the operator has NOT lifted §28: revert your change to the frozen area.\n\
+If the operator HAS lifted §28 (dated quote): (1) update §28 in \
+.claude/rules/project/daily-universe-scope-expansion-2026-05-27.md, then \
+(2) re-bless with `BLESS_BOUNDARY=1 cargo test -p tickvault-storage \
+--test operator_boundary_indicator_strategy_guard -- --nocapture`.";
+
+/// §28-named test: the `IndicatorEngine::states` field (and the whole engine.rs)
+/// is unchanged since 2026-05-27.
+#[test]
+fn test_indicator_engine_states_field_unchanged_since_2026_05_27() {
+    let bytes = read_rel(ENGINE_REL);
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains(ENGINE_STATES_FIELD),
+        "§28 guard: `engine.rs` no longer contains the exact `{ENGINE_STATES_FIELD}` \
+         field — the indicator engine's state layout changed.{LIFT_HINT}"
+    );
+
+    let (_, want_fnv, want_len, _) = BOUNDARY_FILES
+        .iter()
+        .find(|(p, ..)| *p == ENGINE_REL)
+        .expect("engine.rs is pinned in BOUNDARY_FILES");
+    assert_eq!(
+        bytes.len(),
+        *want_len,
+        "§28 guard: engine.rs byte length changed.{LIFT_HINT}"
+    );
+    assert_eq!(
+        fnv1a64(&bytes),
+        *want_fnv,
+        "§28 guard: engine.rs content hash changed.{LIFT_HINT}"
+    );
+}
+
+/// Every pinned frozen file matches its captured content exactly.
+#[test]
+fn test_indicator_strategy_boundary_files_unchanged() {
+    if std::env::var("BLESS_BOUNDARY").is_ok() {
+        // Re-bless mode: print the current manifest and skip assertions.
+        eprintln!("// re-blessed manifest — paste over BOUNDARY_FILES:");
+        for dir in FROZEN_DIRS {
+            for rel in frozen_files_on_disk().iter().filter(|r| r.starts_with(dir)) {
+                let bytes = read_rel(rel);
+                let lines = bytes.iter().filter(|&&b| b == b'\n').count();
+                eprintln!(
+                    "    (\"{rel}\", 0x{:016x}, {}, {}),",
+                    fnv1a64(&bytes),
+                    bytes.len(),
+                    lines
+                );
+            }
+        }
+        return;
+    }
+
+    for (rel, want_fnv, want_len, want_lines) in BOUNDARY_FILES {
+        let bytes = read_rel(rel);
+        let got_lines = bytes.iter().filter(|&&b| b == b'\n').count();
+        assert_eq!(
+            bytes.len(),
+            *want_len,
+            "§28 guard: {rel} byte length changed ({} → {}).{LIFT_HINT}",
+            want_len,
+            bytes.len()
+        );
+        assert_eq!(
+            got_lines, *want_lines,
+            "§28 guard: {rel} line count changed ({want_lines} → {got_lines}).{LIFT_HINT}"
+        );
+        assert_eq!(
+            fnv1a64(&bytes),
+            *want_fnv,
+            "§28 guard: {rel} content hash changed.{LIFT_HINT}"
+        );
+    }
+}
+
+/// The manifest neither misses a file that exists on disk (a NEW file added to
+/// the frozen area) nor references a file that was deleted.
+#[test]
+fn test_boundary_manifest_covers_every_src_file() {
+    let on_disk = frozen_files_on_disk();
+    let pinned: BTreeSet<String> = BOUNDARY_FILES.iter().map(|(p, ..)| p.to_string()).collect();
+
+    let added: Vec<&String> = on_disk.difference(&pinned).collect();
+    let removed: Vec<&String> = pinned.difference(&on_disk).collect();
+
+    assert!(
+        added.is_empty(),
+        "§28 guard: NEW file(s) appeared in the frozen area but are not pinned: {added:?}.{LIFT_HINT}"
+    );
+    assert!(
+        removed.is_empty(),
+        "§28 guard: pinned file(s) no longer exist on disk (deleted from frozen area): {removed:?}.{LIFT_HINT}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes a real gap found during deep-research verification (2026-06-06): operator
boundary **§28** in `daily-universe-scope-expansion-2026-05-27.md` (verbatim: *"don't
even touch indicators and strategies area"*) **promises** a ratchet test
(`crates/storage/tests/operator_boundary_indicator_strategy_guard.rs::test_indicator_engine_states_field_unchanged_since_2026_05_27`)
— but the file **never existed**. The boundary was enforced only by human discipline.
This PR ships the missing mechanical enforcement.

## What it does

Content-pins **every `.rs` file** under `crates/trading/src/indicator/` and
`crates/trading/src/strategy/` (12 files) via an inline **FNV-1a 64-bit hash + byte
length + line count**. Any edit to the frozen area — even a comment — fails the build
until §28 is consciously lifted (re-bless + rule edit). The lift ritual is documented
in the test header and the failure message.

- **No new dependency** — FNV-1a is inline (new workspace deps need operator approval
  per CLAUDE.md; this is regression-evidence, not adversarial crypto, and FNV-1a is
  deterministic + version-stable for a persisted pin, unlike `std::hash::DefaultHasher`).
- 3 tests: the §28-named states-field pin, the all-file content pin, and add/delete
  drift (a NEW file in the frozen dir or a deletion both fail).

## Verification (real output, not claims)

- `cargo test -p tickvault-storage --test operator_boundary_indicator_strategy_guard`
  → **3 passed; 0 failed**.
- **Negative-verified**: appended 1 byte to `engine.rs` → guard went **RED**
  (`51785 → 51786`); `git checkout` revert → **GREEN** (3/3). Proof it actually fires.
- Pre-commit + pre-push gates green (fmt, banned-pattern, secret-scan, invariants).

## Items completed
- [x] Item 1 — `crates/storage/tests/operator_boundary_indicator_strategy_guard.rs`
  (3 tests) + archive merged design-first-wall plan + set active plan.

## Honest envelope / caveats
- This is a **build-time ratchet**, not a runtime path — no Prometheus/Telegram/audit
  surface applies (correct for a source-scan guard; mirrors `indices4only_scope_lock_guard.rs`).
- It does **not prevent** edits; it **fails the build** on them — that is the §28
  "until the boundary is lifted" mechanism.
- It touches **no production `src/`** (test-only), so it cannot affect the live pipeline.
  Rollback = `git revert` (zero runtime impact).

## Test plan
- [x] `cargo test -p tickvault-storage --test operator_boundary_indicator_strategy_guard` green
- [x] negative test (perturb → RED, revert → GREEN)
- [x] pre-commit + pre-push gates green

https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr)_