### PR TITLE
feat(app): turn on real NTM constituent subscription at boot (NTM Sub-PR #10b)

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,136 +1,101 @@
-# Implementation Plan: NTM Sub-PR #10a — core NTM-capable orchestrator + bridge + ErrorCode
+# Implementation Plan: NTM Sub-PR #10b — boot turn-on of real NTM data
 
 **Status:** VERIFIED
 **Date:** 2026-06-06
-**Approved by:** Parthiban — AskUserQuestion 2026-06-06: niftyindices failure policy = **Degrade + alert**
-(proceed on the indices + F&O-underlyings core universe + Critical alert; Dhan CSV stays fail-closed
-§4) + standing "once merged, go ahead with the plan".
-**Crate(s) touched:** `core` (`daily_universe_orchestrator.rs`, new bridge fn; `index_constituency/`
-glue), `app` (`daily_universe_boot.rs`/`main.rs` async niftyindices fetch + degrade wiring),
-`common` (`error_code.rs` new `NtmConstituency01SourceDegraded` + rule-file mention),
-`core/notification` (new `NotificationEvent` variant). Feature: `daily_universe_fetcher`.
+**Approved by:** Parthiban — AskUserQuestion 2026-06-06 (niftyindices failure = **Degrade + alert**) +
+standing "once merged, go ahead with the plan always".
+**Crate(s) touched:** `core` (`instr_fetch_runner.rs` — thread `ntm_map`), `app`
+(`daily_universe_boot.rs` — thread `ntm_map`; `main.rs` — best-effort niftyindices fetch +
+`fetch_ntm_constituency_map` helper). Feature: `daily_universe_fetcher`.
 
 ## Context
 
-This is the **live turn-on** of the §31 NTM subscription. Sub-PRs #2–#5 built every piece behind
-the feature flag, passing `ntm_constituents = Vec::new()` so live boot stayed unchanged. #10 wires
-the real data so the ~750-stock NTM union actually flows on the single main-feed WS.
-
-## The seam (verified against merged code)
-
-```
-boot (app, async)                         orchestrator (core, sync)
-─────────────────                         ─────────────────────────
-csv_downloader::fetch_csv() ── dhan_bytes ─┐
-ConstituencyDownloader::fetch_slug(        │
-  "ind_niftytotalmarket_list")             │
-  → Result<Vec<u8>>  [DEGRADE on Err]──ntm_bytes(Option)
-                                           ▼
-        build_universe_from_bytes(dhan_bytes, ntm_bytes: Option<&[u8]>)
-           parse_detailed_csv(dhan_bytes) → rows
-           extract_indices / extract_fno_underlyings / collect_fno_contracts
-           IF ntm_bytes:
-             parse_constituents(ntm,"Nifty Total Market",today) → ParsedConstituents
-             assemble IndexConstituencyMap
-             resolve_constituents(map, &rows) → ResolveOutcome   [DEGRADE on TooManyDangling]
-             BRIDGE: HashMap<(sid,seg),&CsvRow> over rows; map each resolved → cloned CsvRow
-                     → ntm_constituent_rows: Vec<CsvRow>
-           build_daily_universe(indices, fno, fno_contracts, ntm_constituent_rows)
-```
+#10a (merged) made the orchestrator NTM-capable (`build_universe_from_bytes(bytes, ntm_map)` +
+`resolve_ntm_rows` bridge + `NTM-CONSTITUENCY-01`), with all callers passing `None`. #10b is the
+**turn-on**: fetch the real niftyindices constituents at boot and thread them down so the ~750-stock
+NTM union actually flows on the single main-feed WS.
 
 ## Design
 
-- **Bridge fn** (core, e.g. `daily_universe_orchestrator::resolve_ntm_rows(rows: &[CsvRow], ntm_bytes: &[u8], today) -> Result<Vec<CsvRow>, NtmDegradeReason>`):
-  parse → assemble map → `resolve_constituents` → build `HashMap<(security_id,segment), &CsvRow>`
-  (O(N) once) → O(1) lookup per resolved → clone → `Vec<CsvRow>`. Every resolved SID is sourced
-  FROM `rows`, so the lookup never misses; a miss is counted, never panics.
-- **Orchestrator**: `build_universe_from_bytes` gains `ntm_bytes: Option<&[u8]>`. On any NTM-side
-  error (parse / `TooManyDangling` / empty) → **degrade**: log `error!(code=NTM-CONSTITUENCY-01)`,
-  treat NTM as empty, continue building the core universe (NOT an `OrchestratorError`). The Dhan
-  core path stays fail-closed exactly as today.
-- **Boot caller** (app): async `ConstituencyDownloader::fetch_slug("ind_niftytotalmarket_list")`;
-  on `Err` → `None` + degrade alert. Pass `ntm_bytes.as_deref()` to the orchestrator. (Cache-fallback
-  was NOT selected by the operator — pure degrade.)
-- **New `ErrorCode::NtmConstituency01SourceDegraded`** (`NTM-CONSTITUENCY-01`, Severity::Critical,
-  auto-triage NO) + rule-file `.claude/rules/project/ntm-constituency-error-codes.md` (cross-ref test).
-- **New `NotificationEvent::NtmConstituencyDegraded { reason, core_universe_size }`** (Critical) so
-  the operator is paged that today runs without the ~500 cash-only constituents.
+- **`main.rs::fetch_ntm_constituency_map(today)`** (new private async helper) — builds
+  `ConstituencyDownloader` + `build_constituency_map(&dl, NTM_CONSTITUENCY_SLUGS, today)` wrapped in
+  `tokio::time::timeout(NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS = 30s)`. **CRITICAL fix (hostile review):**
+  the SUBSCRIPTION uses the **NTM slug ONLY** (§31 item 4) — NOT the full ~49-index
+  `INDEX_CONSTITUENCY_SLUGS`, whose deduped union ≈ the entire NSE (~1,900 stocks) would breach
+  `MAX_DAILY_UNIVERSE_SIZE` and HALT boot on a *healthy* fetch. **Degrade+alert**: on downloader-init
+  failure OR timeout OR an empty map it logs `error!(code = NTM-CONSTITUENCY-01)` (reason =
+  downloader_init / timeout / fetch_or_parse) and returns `None`; NEVER blocks boot.
+- **Threading:** `cold_build_daily_universe` → `run_daily_universe_boot(.., ntm_map)` (app) →
+  `run_daily_universe_fetch_runner(wrapped, max_attempts, ntm_map.as_ref())` (core) →
+  `build_universe_from_bytes(bytes, ntm_map)`. `Option<&IndexConstituencyMap>` is `Copy`, so the
+  runner's retry closure re-uses it across attempts with no clone.
+- The Dhan CSV path stays **fail-closed §4** (infinite retry); ONLY the niftyindices NTM layer
+  degrades. Subscription set = union of tracked-index constituents (NTM dominates), bounded by the
+  `[100, 1200]` envelope (`INSTR-FETCH-04` halts if exceeded — a data anomaly, not a degrade).
 
 ## Edge Cases
 
-- niftyindices 5xx / timeout / DNS fail → degrade, core universe lives, Critical alert.
-- niftyindices 200 but malformed / non-UTF-8 / missing column → degrade (parse error).
-- `> 0.5%` constituents dangling vs Dhan rows → `resolve_constituents` `TooManyDangling` → degrade.
-- All constituents already F&O underlyings → universe size unchanged; both-flags set (no dup).
-- NTM pushes universe past `MAX_DAILY_UNIVERSE_SIZE = 1200` → `build_daily_universe` envelope reject
-  (fail-closed — this is a Dhan/NTM data anomaly worth halting on, NOT a degrade).
-- Weekend/holiday boot → existing holiday gate; niftyindices fetch best-effort.
+- niftyindices fully down / DNS / 5xx → empty map → `None` + Critical alert → core universe.
+- Some slugs fail, NTM ok → map non-empty → resolve over what's present (best-effort).
+- `>0.5%` constituents dangling vs Dhan rows → `resolve_ntm_rows` degrades to empty (#10a) + alert.
+- All constituents are F&O underlyings → both-flags set, no dup (#5 fold).
+- Union > 1200 → `INSTR-FETCH-04` fail-closed HALT.
+- Weekend/holiday → existing daily orchestrator gate; fetch best-effort.
 
 ## Failure Modes
 
-- NTM source down → DEGRADE + `NTM-CONSTITUENCY-01` Critical (operator-chosen). Core trading continues.
-- Bridge lookup miss (should be impossible) → counted, skipped, never panics.
-- Envelope breach after fold → `INSTR-FETCH-04` fail-closed HALT (unchanged).
-- Dhan CSV failure → §4 infinite-retry fail-closed (unchanged — NTM policy does NOT relax this).
+- NTM source down → DEGRADE + `NTM-CONSTITUENCY-01` Critical (operator-chosen); core trades.
+- Dhan CSV down → §4 infinite-retry fail-closed (UNCHANGED — NTM policy does not relax this).
+- niftyindices slow → bounded by the downloader's connect/read timeouts (#3 §18 hardening); cold path.
 
 ## Test Plan
 
-`cargo test -p tickvault-core --features daily_universe_fetcher` + scoped app + workspace test-compile
-(disk: scoped only — full workspace link exceeds the container; CI is the full-workspace gate).
-
-- bridge: resolved→CsvRow mapping correct; both-case dedup; pure-constituent added; lookup-miss skip.
-- orchestrator degrade: malformed ntm_bytes → core universe built, NTM empty, code emitted (not Err).
-- orchestrator success: valid ntm_bytes → universe grows by the resolved count; counts correct.
-- envelope: NTM over-MAX → `INSTR-FETCH-04` (still fail-closed).
-- ErrorCode: variant + `code_str` + rule-file cross-ref + tag-guard.
-- NotificationEvent severity Critical.
+`cargo test -p tickvault-core --features daily_universe_fetcher` + `-p tickvault-app` (scoped; full
+workspace = CI). Threading is param-only — covered by recompiling the existing runner (8) + boot (11)
+suites with the new arg (all callers updated). The resolve+bridge + degrade behaviour is already
+unit-tested in #10a (`resolve_ntm_rows_*`, `build_universe_with_ntm_map_threads_through`).
+`fetch_ntm_constituency_map` is a thin best-effort wrapper over already-tested `build_constituency_map`
+(network I/O — TEST-EXEMPT by integration boundary; degrade branches are straight-line + logged).
 
 ## Rollback
 
-NTM is degrade-by-design: passing `ntm_bytes = None` (or feature off) restores the exact pre-#10
-core universe. `git revert` clean; no migration. The live turn-on is gated by the niftyindices fetch
-succeeding — a revert or a source outage both fall back to the proven core universe.
+Degrade-by-design: a niftyindices outage OR `git revert` both fall back to the proven core universe
+(the new fetch returns `None` ⇒ identical to pre-#10b boot). No migration, no schema change.
 
 ## Observability
 
-`NTM-CONSTITUENCY-01` Critical → Telegram + `errors.jsonl`; boot `info!` adds the resolved NTM count
-+ `tv_universe_size{kind="index_constituent"}` (already added in #5) now non-zero on success. Audit
-table additions deferred to a follow-up (the lifecycle master already records roles via #9/#5).
+`NTM-CONSTITUENCY-01` Critical → Telegram via the 5-sink error pipeline on degrade; boot `info!`
+logs `indices` + `unique_stocks` on success and the per-phase build log (#5) shows
+`index_constituent_count` non-zero. `tv_universe_size{kind="index_constituent"}` (gauge, #5) becomes
+non-zero on a healthy NTM boot.
 
 ## Plan Items
 
-> **Scoped to Sub-PR #10a (core).** This PR ships the NTM-capable orchestrator + bridge + ErrorCode
-> (param threaded, all callers pass `None`). The niftyindices async fetch + degrade wiring at boot is
-> **Sub-PR #10b** (the repo already references "#10b boot orchestrator") — a separate PR.
-
-- [x] Item 1 — `ErrorCode::NtmConstituency01SourceDegraded` + rule file (cross-ref + tag-guard) +
-  catalogue-size (102→103) + prefix-pattern updated
-  - Files: `crates/common/src/error_code.rs`, `.claude/rules/project/ntm-constituency-error-codes.md`
-  - Tests: `test_all_list_length_matches_catalogue_size`, `test_code_str_follows_expected_prefix_pattern`
-- [x] Item 2 — degrade ALERT via `error!(code = NTM-CONSTITUENCY-01)` (routes to Telegram via the
-  5-sink error pipeline per observability-architecture.md sink 5). A dedicated typed
-  `NotificationEvent::NtmConstituencyDegraded` is DEFERRED to a polish follow-up — the Critical
-  alert already fires through the error-code pipeline, which is the operator-paging path.
-  - Files: `crates/core/src/instrument/daily_universe_orchestrator.rs`
-- [x] Item 3 — `resolve_ntm_rows` bridge fn + `build_universe_from_bytes(bytes, ntm_map: Option<&IndexConstituencyMap>)` + degrade; runner caller passes `None`
-  - Files: `crates/core/src/instrument/daily_universe_orchestrator.rs`,
-    `crates/core/src/instrument/instr_fetch_runner.rs`
-  - Tests: `resolve_ntm_rows_bridges_resolved_to_dhan_rows`,
-    `resolve_ntm_rows_degrades_to_empty_on_dangling`, `build_universe_with_ntm_map_threads_through`
-- [x] Item 4 — adversarial review: §31 end-to-end chain reviewed earlier this session
-  (hot-path CLEAN / security 0 / hostile 0 CRITICAL-HIGH; #10b bridge flagged + now built here).
-  This #10a diff is a contained cold-path extension of that reviewed chain.
-
-> **Deferred to Sub-PR #10b:** boot async niftyindices fetch (`build_constituency_map`) +
-> `cold_build_daily_universe` wiring to pass `Some(&map)` + the fetch/parse degrade-alert site +
-> the boot-path source-scan guard. Turning on real ~750-stock data is #10b.
+- [x] Item 1 — `run_daily_universe_fetch_runner` gains `ntm_map: Option<&IndexConstituencyMap>`;
+  retry closure threads it into `build_universe_from_bytes`
+  - Files: `crates/core/src/instrument/instr_fetch_runner.rs`
+  - Tests: `runner_wires_build_universe_from_bytes`, `runner_wires_tokio_time_sleep`
+- [x] Item 2 — `run_daily_universe_boot` gains `ntm_map: Option<IndexConstituencyMap>`; passes
+  `.as_ref()` to the runner
+  - Files: `crates/app/src/daily_universe_boot.rs`
+  - Tests: `test_run_daily_universe_boot_no_universe_bails`,
+    `test_run_daily_universe_boot_valid_csv_reaches_reconcile_then_fails_closed`
+- [x] Item 3 — `main.rs::fetch_ntm_constituency_map` best-effort fetch + degrade alert; wired into
+  `cold_build_daily_universe`
+  - Files: `crates/app/src/main.rs`
+  - Tests: `test_run_daily_universe_boot_valid_csv_reaches_reconcile_then_fails_closed` (boot path recompiles + green; helper is a network-boundary best-effort wrapper)
+- [x] Item 4 — adversarial review on the #10b diff (hot-path CLEAN; hostile found **1 CRITICAL + 1
+  MEDIUM**, BOTH fixed inline): CRITICAL = subscribe NTM-slug-only (was full ~49-index list →
+  envelope breach → boot HALT on healthy fetch); MEDIUM = added `NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS`
+  total-fetch timeout so a stalled niftyindices degrades instead of delaying boot. New constants
+  `NTM_CONSTITUENCY_SLUGS` + `NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS`.
+  - Files: `crates/common/src/constants.rs`
 
 ## Scenarios
 
 | # | Scenario | Expected |
 |---|----------|----------|
-| 1 | niftyindices healthy | universe = indices + F&O underlyings + ~500 cash NTM; both-flags on overlap |
-| 2 | niftyindices down | core universe only + `NTM-CONSTITUENCY-01` Critical; trading continues |
-| 3 | malformed NTM CSV | degrade (not a boot halt); Dhan core unaffected |
-| 4 | NTM over MAX=1200 | `INSTR-FETCH-04` fail-closed HALT |
-| 5 | revert / feature off | exact pre-#10 core universe |
+| 1 | niftyindices healthy | universe = core + ~750 NTM; both-flags on overlap; `index_constituent_count` > 0 |
+| 2 | niftyindices down | core universe + `NTM-CONSTITUENCY-01` Critical; trading continues |
+| 3 | union > 1200 | `INSTR-FETCH-04` fail-closed HALT |
+| 4 | revert / source outage | exact pre-#10b core universe |

--- a/crates/app/src/daily_universe_boot.rs
+++ b/crates/app/src/daily_universe_boot.rs
@@ -49,6 +49,7 @@ use std::time::Instant;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use tickvault_common::config::QuestDbConfig;
+use tickvault_common::instrument_types::IndexConstituencyMap;
 use tickvault_core::instrument::csv_downloader::CsvDownloadError;
 use tickvault_core::instrument::daily_universe::{DailyUniverse, InstrumentRole};
 use tickvault_core::instrument::instr_fetch_loop::LoopOutcome;
@@ -181,6 +182,7 @@ pub async fn run_daily_universe_boot<Fetch, FetchFut>(
     today_ist_nanos: i64,
     dry_run: bool,
     max_attempts: Option<u32>,
+    ntm_map: Option<IndexConstituencyMap>,
 ) -> Result<(DailyUniverseBootOutcome, Arc<DailyUniverse>)>
 where
     Fetch: FnMut(u32) -> FetchFut,
@@ -216,7 +218,8 @@ where
         }
     };
 
-    let (outcome, universe) = run_daily_universe_fetch_runner(wrapped, max_attempts).await;
+    let (outcome, universe) =
+        run_daily_universe_fetch_runner(wrapped, max_attempts, ntm_map.as_ref()).await;
 
     let Some(universe) = universe else {
         anyhow::bail!(
@@ -472,7 +475,7 @@ mod tests {
                 b"SECURITY_ID,EXCH_ID,SEGMENT,INSTRUMENT,SYMBOL_NAME,UNDERLYING_SECURITY_ID\n51,BSE,IDX_I,INDEX,SENSEX,\n".to_vec(),
             )
         };
-        let result = run_daily_universe_boot(&cfg, fetch, 1, 1, false, Some(1)).await;
+        let result = run_daily_universe_boot(&cfg, fetch, 1, 1, false, Some(1), None).await;
         assert!(result.is_err(), "no universe built → boot must bail");
     }
 
@@ -486,7 +489,7 @@ mod tests {
         // wrapper capture → runner Success → universe → counts → reconcile.
         let cfg = cfg_unreachable();
         let fetch = |_attempt: u32| async { Ok::<_, CsvDownloadError>(valid_csv()) };
-        let result = run_daily_universe_boot(&cfg, fetch, 1, 1, false, Some(1)).await;
+        let result = run_daily_universe_boot(&cfg, fetch, 1, 1, false, Some(1), None).await;
         let msg = format!("{:#}", result.expect_err("reconcile must fail-closed"));
         assert!(
             msg.contains("reconcile"),

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5301,6 +5301,13 @@ async fn cold_build_daily_universe(
         let downloader = Arc::clone(&downloader);
         async move { downloader.fetch_csv().await }
     };
+    // §31 NTM (Sub-PR #10b): best-effort fetch of the NIFTY Total Market
+    // constituents. DEGRADE+ALERT (operator 2026-06-06): a None here means the
+    // niftyindices source failed — the universe builds on the indices +
+    // F&O-underlyings core set and `NTM-CONSTITUENCY-01` already paged. The
+    // Dhan CSV path below stays fail-closed (§4) regardless.
+    let ntm_map = fetch_ntm_constituency_map(now_ist.date_naive()).await;
+
     // §4: infinite retry (None) — boot blocks until a fresh CSV is in hand.
     let (outcome, universe) = tickvault_app::daily_universe_boot::run_daily_universe_boot(
         questdb,
@@ -5309,6 +5316,7 @@ async fn cold_build_daily_universe(
         today_ist_nanos,
         dry_run,
         None,
+        ntm_map,
     )
     .await
     .context("daily-universe boot failed (fail-closed §4)")?;
@@ -5331,6 +5339,80 @@ async fn cold_build_daily_universe(
     tickvault_app::prev_day_ohlcv_boot::stash_universe(std::sync::Arc::clone(&universe));
 
     Ok((outcome, universe))
+}
+
+/// §31 NTM (Sub-PR #10b): best-effort fetch of the NIFTY Total Market (and the
+/// other tracked-index) constituents from niftyindices.com, assembled into an
+/// [`IndexConstituencyMap`] for the universe builder's resolve+bridge step.
+///
+/// **DEGRADE+ALERT (operator AskUserQuestion 2026-06-06):** this NEVER blocks
+/// boot. On any failure (downloader init, all slugs failed → empty map) it logs
+/// `error!(code = NTM-CONSTITUENCY-01)` (→ Telegram via the 5-sink pipeline) and
+/// returns `None`, so the universe builds on the indices + F&O-underlyings core
+/// set. The Dhan CSV path stays fail-closed (§4) independently. Per-slug
+/// download/parse failures are already logged inside `build_constituency_map`.
+///
+/// Cold path — runs once at boot.
+async fn fetch_ntm_constituency_map(
+    today: chrono::NaiveDate,
+) -> Option<tickvault_common::instrument_types::IndexConstituencyMap> {
+    use std::time::Duration;
+    use tickvault_common::constants::{
+        NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS, NTM_CONSTITUENCY_SLUGS,
+    };
+    use tickvault_common::error_code::ErrorCode;
+    use tickvault_core::instrument::index_constituency::build_constituency_map;
+    use tickvault_core::instrument::index_constituency::downloader::ConstituencyDownloader;
+
+    let downloader = match ConstituencyDownloader::new() {
+        Ok(d) => d,
+        Err(err) => {
+            error!(
+                code = ErrorCode::NtmConstituency01SourceDegraded.code_str(),
+                reason = "downloader_init",
+                %err,
+                "NTM constituency downloader init failed — degrading to core universe"
+            );
+            return None;
+        }
+    };
+    // §31 item 4: subscribe the NTM union ONLY (NTM_CONSTITUENCY_SLUGS), NOT the
+    // full ~49-index list (whose union ~= the entire NSE → would breach the
+    // [100,1200] envelope and HALT boot). Total-fetch timeout bounds a stalled
+    // niftyindices before the 09:00 open → degrade.
+    let map = match tokio::time::timeout(
+        Duration::from_secs(NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS),
+        build_constituency_map(&downloader, NTM_CONSTITUENCY_SLUGS, today),
+    )
+    .await
+    {
+        Ok(map) => map,
+        Err(_elapsed) => {
+            error!(
+                code = ErrorCode::NtmConstituency01SourceDegraded.code_str(),
+                reason = "timeout",
+                timeout_secs = NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS,
+                "NTM constituency fetch exceeded its boot budget — degrading to core universe"
+            );
+            return None;
+        }
+    };
+    if map.index_to_constituents.is_empty() {
+        error!(
+            code = ErrorCode::NtmConstituency01SourceDegraded.code_str(),
+            reason = "fetch_or_parse",
+            indices_failed = map.build_metadata.indices_failed,
+            "NTM constituency fetch returned no indices — degrading to core universe \
+             (today runs without the cash-only NTM constituents)"
+        );
+        return None;
+    }
+    info!(
+        indices = map.index_to_constituents.len(),
+        unique_stocks = map.stock_to_indices.len(),
+        "NTM constituency map fetched for the daily-universe build"
+    );
+    Some(map)
 }
 
 // create_log_file_writer is now in boot_helpers module (lib.rs).

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -2379,6 +2379,24 @@ pub const INDEX_CONSTITUENCY_SLUGS: &[(&str, &str)] = &[
 /// Number of slugs in `INDEX_CONSTITUENCY_SLUGS`.
 pub const INDEX_CONSTITUENCY_SLUG_COUNT: usize = INDEX_CONSTITUENCY_SLUGS.len();
 
+/// The SUBSCRIPTION constituent source (§31 item 4, operator lock 2026-06-06):
+/// the live main-feed subscription is the **NIFTY Total Market union ONLY**
+/// (NTM is the broadest basket and already contains the other indices' members).
+/// The boot turn-on (NTM Sub-PR #10b) fetches THIS slug — NOT the full
+/// `INDEX_CONSTITUENCY_SLUGS` — because the deduped union of all ~49 indices is
+/// ~the entire NSE (~1,900 stocks), which would breach `MAX_DAILY_UNIVERSE_SIZE`
+/// and HALT boot. The full list above is for the (map-only, not-subscribed)
+/// §31-item-2 index→constituents mapping, a separate concern.
+pub const NTM_CONSTITUENCY_SLUGS: &[(&str, &str)] =
+    &[("Nifty Total Market", "ind_niftytotalmarket_list")];
+
+/// Total wall-clock budget for the boot-time NTM constituency fetch (§31 Sub-PR
+/// #10b). niftyindices.com can accept a connection then stall the body (the
+/// per-GET 60s read timeout doesn't bound a slow-loris before the 09:00 open),
+/// so the boot caller wraps the fetch in `tokio::time::timeout(this)` and
+/// DEGRADES to the core universe on expiry (operator policy 2026-06-06).
+pub const NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS: u64 = 30;
+
 /// Slugs known to return 404/HTML from niftyindices.com — skipped by the
 /// CSV downloader so we don't log 14 WARNs + fire an aggregated ERROR every
 /// boot for URLs we already know are wrong. The underlying CSVs almost

--- a/crates/core/src/instrument/instr_fetch_runner.rs
+++ b/crates/core/src/instrument/instr_fetch_runner.rs
@@ -42,6 +42,8 @@ use core::future::Future;
 use tickvault_common::error_code::{ErrorCode, Severity};
 use tracing::{error, info, warn};
 
+use tickvault_common::instrument_types::IndexConstituencyMap;
+
 use super::csv_downloader::CsvDownloadError;
 use super::daily_universe::DailyUniverse;
 use super::daily_universe_orchestrator::{OrchestratorError, build_universe_from_bytes};
@@ -75,6 +77,7 @@ use super::instr_fetch_retry_adapter::TelegramEmit;
 pub async fn run_daily_universe_fetch_runner<Fetch, FetchFut>(
     fetch_fn: Fetch,
     max_attempts: Option<u32>,
+    ntm_map: Option<&IndexConstituencyMap>,
 ) -> (LoopOutcome, Option<DailyUniverse>)
 where
     Fetch: FnMut(u32) -> FetchFut,
@@ -86,9 +89,10 @@ where
     // without this the operator would see "boot BLOCKED" with no clue WHICH
     // underlyings failed to resolve.
     let build_with_diagnostics = |bytes: &[u8]| -> Result<DailyUniverse, OrchestratorError> {
-        // NTM constituents (§31) are passed `None` here — the niftyindices async
-        // fetch + degrade wiring is Sub-PR #10b (this runner stays CSV-bytes-pure).
-        build_universe_from_bytes(bytes, None).inspect_err(|e| {
+        // §31 NTM (Sub-PR #10b): `ntm_map` is the best-effort niftyindices
+        // constituency fetched once by the boot caller; `None` means the source
+        // degraded (caller already emitted NTM-CONSTITUENCY-01) → core universe.
+        build_universe_from_bytes(bytes, ntm_map).inspect_err(|e| {
             let code = e.error_code().code_str();
             warn!(
                 code = code,
@@ -242,7 +246,7 @@ mod tests {
             let next = outcomes.borrow_mut().remove(0);
             async move { next }
         };
-        let (outcome, universe) = run_daily_universe_fetch_runner(fetch, Some(1)).await;
+        let (outcome, universe) = run_daily_universe_fetch_runner(fetch, Some(1), None).await;
         assert_eq!(outcome, LoopOutcome::Exhausted { attempts_used: 1 });
         assert!(universe.is_none());
     }
@@ -260,7 +264,7 @@ mod tests {
             let next = outcomes.borrow_mut().remove(0);
             async move { next }
         };
-        let (outcome, universe) = run_daily_universe_fetch_runner(fetch, Some(1)).await;
+        let (outcome, universe) = run_daily_universe_fetch_runner(fetch, Some(1), None).await;
         assert_eq!(outcome, LoopOutcome::Exhausted { attempts_used: 1 });
         assert!(universe.is_none());
     }
@@ -276,7 +280,7 @@ mod tests {
             let next = outcomes.borrow_mut().pop();
             async move { next.unwrap_or(Err(CsvDownloadError::BodyTooLarge)) }
         };
-        let (outcome, universe) = run_daily_universe_fetch_runner(fetch, Some(0)).await;
+        let (outcome, universe) = run_daily_universe_fetch_runner(fetch, Some(0), None).await;
         assert_eq!(outcome, LoopOutcome::Exhausted { attempts_used: 0 });
         assert!(universe.is_none());
         assert!(!fetch_called, "max_attempts=0 must not invoke fetcher");


### PR DESCRIPTION
## Summary

**NTM Sub-PR #10b — the live turn-on.** Fetches the niftyindices constituents once at boot and
threads them through the §4 fetch runner into `build_universe_from_bytes`, so the **NTM union actually
flows** on the single main-feed WS. **Degrade-by-design** (operator 2026-06-06): niftyindices failure
→ core universe + `NTM-CONSTITUENCY-01`; the **Dhan CSV path stays fail-closed §4 (unchanged)**.

## What it does
- **`main.rs::fetch_ntm_constituency_map(today)`** — best-effort niftyindices fetch (NTM slug only),
  total-fetch timeout, returns `Option<IndexConstituencyMap>`; never blocks boot.
- **Threading** — `cold_build_daily_universe` → `run_daily_universe_boot(.., ntm_map)` →
  `run_daily_universe_fetch_runner(.., ntm_map.as_ref())` → `build_universe_from_bytes(bytes, ntm_map)`
  (Copy ref, no clone across retries).

## Adversarial 3-agent review (boot path = full Z+) — caught a real boot-bricking bug
- **hot-path:** CLEAN (cold-path only, allocation-free ref threading).
- **hostile:** **1 CRITICAL + 1 MEDIUM, both fixed inline BEFORE commit:**
  - **CRITICAL** — original code passed the **full ~49-index `INDEX_CONSTITUENCY_SLUGS`**; the deduped
    union ≈ the entire NSE (~1,900 stocks) → would breach `MAX_DAILY_UNIVERSE_SIZE` → **HALT boot on a
    healthy fetch** (`INSTR-FETCH-04`). Fixed: subscribe the **NTM slug ONLY** (`NTM_CONSTITUENCY_SLUGS`,
    §31 item 4).
  - **MEDIUM** — no total-fetch timeout → a stalled niftyindices could delay boot before 09:00. Fixed:
    `NTM_CONSTITUENCY_FETCH_TIMEOUT_SECS = 30` `tokio::time::timeout` → degrade on expiry.

## Verification (real output)
- common **105 pass** (incl. new constants), app boot **11 pass**, core runner **8 pass**; app compiles (lib+tests).
- pub-fn-test stable (121); plan-verify PASS; banned-pattern clean. (Full workspace = CI.)

## Honest envelope / rollback
Degrade-safe: a niftyindices outage OR `git revert` both fall back to the proven core universe (no migration). Dhan §4 fail-closed is untouched. The healthy path now subscribes the ~750-stock NTM union, bounded by the `[100,1200]` envelope.

https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr)_