### PR TITLE
fix(core): correct NTM index symbol to "NIFTY TOTAL MKT" (Dhan-confirmed, secid 46)

### DIFF
--- a/crates/core/src/instrument/index_extractor.rs
+++ b/crates/core/src/instrument/index_extractor.rs
@@ -108,10 +108,11 @@ pub const NSE_INDEX_ALLOWLIST: &[&str] = &[
     "NIFTY SMALLCAP 250",
     "NIFTY MICROCAP250",
     // §31 item 1 (operator 2026-06-06): NIFTY Total Market — the 33rd tracked
-    // index value (32nd NSE entry). Standard NSE name; the `allowlist_misses`
-    // boot telemetry self-verifies it against the live Dhan master and LOUD-warns
-    // if Dhan's exact IDX_I SYMBOL_NAME differs (operator-chosen self-verify path).
-    "NIFTY TOTAL MARKET",
+    // index value (32nd NSE entry). Dhan's exact IDX_I symbol is "NIFTY TOTAL MKT"
+    // (abbreviated; SecurityId 46, exch=IDX seg=I) — confirmed from the operator's
+    // Dhan chart screenshot 2026-06-06, NOT guessed. The `allowlist_misses` boot
+    // telemetry still LOUD-warns if the live master ever differs.
+    "NIFTY TOTAL MKT",
 ];
 
 /// The `SYMBOL_NAME` of GIFT Nifty in the Dhan master (sid 5024,
@@ -495,9 +496,11 @@ mod tests {
 
     #[test]
     fn allowlist_has_exactly_32_nse_indices() {
-        // 31 (§30 lock) + NIFTY TOTAL MARKET (§31 item 1, 2026-06-06) = 32.
+        // 31 (§30 lock) + NIFTY TOTAL MKT (§31 item 1, 2026-06-06) = 32.
         assert_eq!(NSE_INDEX_ALLOWLIST.len(), 32);
-        assert!(NSE_INDEX_ALLOWLIST.contains(&"NIFTY TOTAL MARKET"));
+        // Dhan's exact IDX_I symbol (secid 46) — confirmed from the operator's
+        // Dhan chart, NOT the long-form "NIFTY TOTAL MARKET".
+        assert!(NSE_INDEX_ALLOWLIST.contains(&"NIFTY TOTAL MKT"));
         // Every entry must already be normalized (uppercase, single-spaced)
         // so the runtime match is a direct equality.
         for name in NSE_INDEX_ALLOWLIST {


### PR DESCRIPTION
## Summary

Correct the NIFTY Total Market **index value** symbol from the guessed long-form to the **Dhan-confirmed** value.

#1042 added `"NIFTY TOTAL MARKET"` (operator-chosen "standard name + self-verify"). The operator's **Dhan chart screenshot** (2026-06-06) shows the actual IDX_I symbol is the **abbreviated `"NIFTY TOTAL MKT"`** — **SecurityId 46, exch=IDX seg=I**. Corrected the allowlist entry + 2 test refs to the verbatim Dhan value (§31.1 *resolved, not guessed*). The `allowlist_misses` boot self-verify still guards any future drift.

## Real-file validation (operator-uploaded `ind_niftytotalmarket_list.csv`)
Ran our constituency parser against the actual file — **no hallucination, runtime proof**:
- **748 cash-equity constituents** (755 rows − 7 non-EQ correctly dropped).
- **`missing_isin = 0`** → ISIN-primary resolution covers **100%** of constituents.
- Header columns (`Symbol` / `Series` / `ISIN Code` / `Industry`) **exactly match** the parser constants.

## Verification
- Full **core lib suite: 2348 passed, 0 failed**; `index_extractor` 19.
- No stale `NIFTY TOTAL MARKET` refs remain.

Single-file symbol correction from an authoritative Dhan source, no logic change (`PLAN-EXEMPT`).

https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr)_