### PR TITLE
test(core): NTM subscription proof harness + reconcile NTM secid comment → 443 (dynamic-read)

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,89 +1,93 @@
-# Implementation Plan: NTM Map-B — boot population of the full per-index mapping
+# Implementation Plan: NTM subscription PROOF harness (F1) + secid-46→443 comment reconcile + market-open self-test (F2)
 
 **Status:** VERIFIED
 **Date:** 2026-06-06
-**Approved by:** Parthiban — "yes do this … full per-index mapping … I need guarantee and
-assurance" + uploaded the real `ind_niftytotalmarket_list.csv` (parser validated: 748 cash-equity,
-100% ISIN). Map-A (`index_constituency` table) merged #1043.
-**Crate(s) touched:** `app` (new `index_constituency_boot.rs`; `lib.rs` registration;
-`main.rs` one spawn call site). Feature: `daily_universe_fetcher`.
+**Approved by:** Parthiban — "do both dude okay?" (run F1 live-proof + write the F1+F2 plan) +
+"clearly tell me what is the security id for ntm" / live brutex master shows NTM index secid = 443.
+**Crate(s) touched:** `core` (F1: `crates/core/examples/ntm_subscription_proof.rs`; Item 3:
+2 stale comments in `crates/core/src/instrument/index_extractor.rs`; F2 FUTURE: a market-open
+self-test sub-check in `crates/core/src/instrument/`).
 
 ## Context
 
-§31 item 2: persist the FULL index→constituents mapping for all ~46 tracked indices so "which
-indices is stock X in / which stocks in index Y" is queryable (Map-A table). Map-B is the boot
-population. It is a **separate, decoupled, map-only** step — the live NTM-union subscription path is
-**byte-for-byte untouched** (operator's explicit "don't change existing logic" concern, asked twice).
+Operator asked: are the **33 index values** (32 NSE allowlist incl. NIFTY TOTAL MKT + 1 BSE SENSEX)
+AND the **~748 NIFTY Total Market constituent stocks** actually fetched / resolved / subscribed? The
+§31 chain is merged (#1034–#1045) + `daily_universe_fetcher` is default-on. Open box was **live
+runtime proof**. F1 closes it as far as the sandbox allows; F2 makes it self-policing. Separately the
+operator's live master shows the NTM index secid is **443**, not the **46** that two tickvault
+COMMENTS claim (46 was the Dhan web-chart IDX-segment value). tickvault reads the secid DYNAMICALLY
+(match by SYMBOL_NAME "NIFTY TOTAL MKT"), so runtime is already correct — only the comments are
+stale. Item 3 reconciles them so no future reader is misled.
 
 ## Design
 
-- New `persist_index_constituency_mapping(questdb, today, ts_nanos, dry_run)` — degrade-safe async,
-  **spawned fire-and-forget** from `cold_build_daily_universe` AFTER the universe build. Steps:
-  1. `build_constituency_map(INDEX_CONSTITUENCY_SLUGS)` — full map (all ~46 indices), map-only.
-  2. Independently re-fetch + `parse_detailed_csv` the Dhan master (so the subscription path is not
-     touched — it keeps its own NTM-only fetch).
-  3. `resolve_constituents(full_map, rows)` — ISIN-primary, the same resolver Map-A/#4 use.
-  4. PURE `build_index_constituency_rows(full_map, resolved)` → one `OwnedConstituencyRow` per
-     `(index, stock)` (unresolved/non-numeric SID skipped).
-  5. `ensure_index_constituency_table` + `append_index_constituency_rows` (Map-A writer, idempotent
-     DEDUP UPSERT).
-- The pure row-builder is unit-tested; the network/QuestDB shell is TEST-EXEMPT (its deps are tested
-  in their own crates + the real-CSV parse was runtime-validated this session).
+- **F1 (this PR):** `crates/core/examples/ntm_subscription_proof.rs` runs the REAL pipeline —
+  `parse_constituents` → `IndexConstituencyMap` → `resolve_constituents` — against the operator's
+  REAL `ind_niftytotalmarket_list.csv`. HONEST ENVELOPE: true network end-to-end needs egress + a
+  token; sandbox egress = 403 + QuestDB offline, so synthetic Dhan security_ids over the REAL ISINs
+  (clearly labelled) prove the JOIN matches every real ISIN. Real ids come from Dhan's master at boot.
+- **Item 3 (this PR):** edit the two `secid 46` comments in `index_extractor.rs` to state the secid is
+  READ DYNAMICALLY from the live master (operator's live master = 443; 46 was the Dhan-chart IDX
+  view). No logic change — tickvault never used 46 as a value.
+- **F2 (FUTURE PR):** a pure-function market-open self-test sub-check asserting the live
+  `subscription_targets` contains the 33 index values + the NTM constituent set (count ≥ floor),
+  emitting an existing-style typed-code Telegram on shortfall. Pure logic + wiring + unit tests.
 
 ## Edge Cases
 
-- niftyindices down / empty map → `warn!` + return (subscription unaffected).
-- Dhan CSV fetch/parse fail → `warn!` + return.
-- resolve dangling > 0.5% → resolver `Err` → `warn!` + return.
-- A constituent symbol not in the resolved set (dangling) → skipped (resolver already counted it).
-- Non-numeric `security_id` → skipped defensively.
-- Same stock in N indices → N rows (per-index membership), deduped by Map-A's `(ts, index_name,
-  security_id, exchange_segment)` key.
+- CSV path missing → harness `expect` fails loudly (proof tool, not prod).
+- niftyindices non-EQ series rows → parser drops them (measured: 7 dropped, 748 kept).
+- Renamed ticker (symbol changed, ISIN same) → still resolves via ISIN (STEP 6 asserts true).
+- Item 3: if the live master ever renames NTM, `allowlist_misses` boot telemetry already LOUD-warns —
+  the comment fix notes this so the secid is never assumed.
+- F2: NTM source degraded (`NTM-CONSTITUENCY-01`) → self-test treats core-universe as the floor.
 
 ## Failure Modes
 
-- Every failure path is `warn!` + early return — NEVER blocks boot, NEVER touches the live feed.
-- Spawned task panic → isolated (tokio task), does not affect boot.
-- Persist `Err` → `warn!`; next boot re-runs (idempotent DEDUP).
+- F1 is read-only/offline — cannot affect boot, feed, or any table.
+- Item 3 is comments only — zero runtime effect.
+- F2 (future) ALERTS on shortfall, never halts the feed; market-hours gated + edge-triggered.
 
 ## Test Plan
 
-`cargo test -p tickvault-app` (full crate — the lesson). Unit tests on the pure builder:
-per-index membership (RELIANCE×2 + INFY×1), unresolved skipped, non-numeric SID skipped, via_isin
-preserved, empty map empty. Module compiles + the full app crate suite (19 bins) green; pub-fn-test
-(121 stable), banned-pattern, pub-fn-wiring all green. Real-CSV parse was runtime-validated
-(748 constituents, missing_isin=0) this session.
+- F1: executed this session against the real file — **748 parsed (0 missing ISIN, 7 non-EQ dropped),
+  748/748 resolved (100%) via ISIN, rename-proof = true**. Chain unit tests green:
+  `constituent_resolver` 8, `daily_universe` 37, `index_extractor` 19, `index_constituency` 27 = 91.
+- Item 3: `cargo test -p tickvault-core --lib instrument::index_extractor` stays green (comments only;
+  `allowlist_has_exactly_32_nse_indices` unaffected).
+- F2 (future): unit tests on the pure sub-check. `cargo test -p tickvault-core`.
 
 ## Rollback
 
-New module + 1 `lib.rs` line + 1 spawn call site. `git revert` is clean — the spawn just stops
-running; the live subscription + universe build are unaffected (they never depended on it). No
-migration (Map-A table is `CREATE IF NOT EXISTS`).
+- F1: single `examples/` file — `git revert` removes the proof tool; nothing references it.
+- Item 3: comment-only — `git revert` restores prior text; no behavior either way.
+- F2 (future): self-test sub-check + wiring — `git revert` removes the check; feed untouched.
 
 ## Observability
 
-`info!` on success (indices, rows, unresolved counts); `warn!` on each degrade path. The
-`index_constituency` table (Map-A) is the queryable surface. No new error code (map-only degrade is
-a `warn!`, not a trading-critical failure).
+- F1 prints measured counts to stdout (the proof artifact). No new prod telemetry.
+- Item 3: none (comments).
+- F2 (future): reuses the 7-layer pattern (typed `ErrorCode` + runbook + Telegram + counter).
 
 ## Plan Items
 
-- [x] Item 1 — `index_constituency_boot.rs`: pure `build_index_constituency_rows` + degrade-safe
-  `persist_index_constituency_mapping`
-  - Files: `crates/app/src/index_constituency_boot.rs`, `crates/app/src/lib.rs`
-  - Tests: `build_index_constituency_rows_maps_each_index_membership`,
-    `build_rows_skips_unresolved_constituent`, `build_rows_skips_non_numeric_security_id`,
-    `build_rows_preserves_via_isin_flag`, `build_rows_empty_map_is_empty`
-- [x] Item 2 — wire the fire-and-forget spawn into `cold_build_daily_universe`
-  - Files: `crates/app/src/main.rs`
-  - Tests: build_index_constituency_rows_maps_each_index_membership
-    (spawned path's pure core; the spawn itself is pub-fn-wiring confirmed, no dedicated unit test)
+- [x] Item 1 — F1 proof harness: real parse → map → resolve on the real NTM CSV + rename-proof
+  - Files: `crates/core/examples/ntm_subscription_proof.rs`
+  - Tests: resolve_constituents_by_isin_primary, isin_match_ignores_dhan_symbol_rename, parses_basic_two_row_csv
+- [x] Item 3 — reconcile the 2 stale `secid 46` comments → note dynamic read (live master = 443)
+  - Files: `crates/core/src/instrument/index_extractor.rs`
+  - Tests: allowlist_has_exactly_32_nse_indices
+
+> **FUTURE (F2, separate PR — NOT part of this PR's checklist):** a pure-function market-open
+> self-test sub-check asserting the live `subscription_targets` contains the 33 index values + the
+> NTM constituent set (count ≥ floor), emitting a typed-code Telegram on shortfall. Tracked here so
+> it is not lost; it ships under its own approved plan.
 
 ## Scenarios
 
 | # | Scenario | Expected |
 |---|----------|----------|
-| 1 | healthy boot | all ~46 indices' constituents resolved + persisted; subscription untouched |
-| 2 | niftyindices down | `warn!` + skip; live feed + universe unaffected |
-| 3 | stock in 5 indices | 5 rows (one per index), queryable both directions |
-| 4 | revert | spawn stops; zero effect on subscription/universe |
+| 1 | Run F1 on the real NTM CSV | 748 parsed, 748/748 resolved via ISIN, rename-proof true |
+| 2 | Live master NTM secid = 443 | tickvault reads 443 dynamically (never used 46); comments now match |
+| 3 | niftyindices down at boot | core universe subscribed; `NTM-CONSTITUENCY-01` pages |
+| 4 | F2 (future): an index value missing from live subscription | self-test fails + Telegram, feed runs |

--- a/crates/core/examples/ntm_subscription_proof.rs
+++ b/crates/core/examples/ntm_subscription_proof.rs
@@ -1,0 +1,142 @@
+//! Re-runnable PROOF that the NIFTY Total Market constituent pipeline works on
+//! the REAL niftyindices file: parse → ISIN-map → resolve (the §31 / §31.1
+//! chain that feeds the live subscription).
+//!
+//! The charter demands "no hallucination" — the "748 stocks, 100% ISIN,
+//! 100% resolve" figures must be MEASURED, not claimed. Run it anytime:
+//!
+//! ```bash
+//! cargo run -p tickvault-core --example ntm_subscription_proof \
+//!     --features daily_universe_fetcher -- <path-to-ind_niftytotalmarket_list.csv>
+//! ```
+//!
+//! HONEST ENVELOPE: a TRUE end-to-end live run (fetch niftyindices + fetch the
+//! Dhan master + resolve against Dhan's REAL security_ids + subscribe on a real
+//! socket) needs outbound network + a Dhan token. Where those are unavailable
+//! (sandbox egress blocked / no secrets), this harness proves the deterministic
+//! data pipeline against the operator's real file, assigning SYNTHETIC Dhan
+//! security_ids (clearly labelled). The real security_ids come from Dhan's
+//! master at boot — this proves the JOIN logic is correct for every real ISIN.
+
+use tickvault_common::instrument_types::IndexConstituencyMap;
+use tickvault_core::instrument::constituent_resolver::resolve_constituents;
+use tickvault_core::instrument::csv_parser::CsvRow;
+use tickvault_core::instrument::index_constituency::parser::parse_constituents;
+
+fn synthetic_nse_eq_row(security_id: u32, symbol: &str, isin: &str) -> CsvRow {
+    CsvRow {
+        security_id: security_id.to_string(),
+        exch_id: "NSE".to_string(),
+        segment: "NSE_EQ".to_string(),
+        instrument: "EQUITY".to_string(),
+        symbol_name: symbol.to_string(),
+        underlying_security_id: String::new(),
+        underlying_symbol: String::new(),
+        display_name: symbol.to_string(),
+        lot_size: 1,
+        tick_size: 0.05,
+        expiry_date: "0001-01-01".to_string(),
+        strike_price: 0.0,
+        option_type: String::new(),
+        isin: isin.to_string(),
+    }
+}
+
+fn main() {
+    let path = std::env::args().nth(1).unwrap_or_else(|| {
+        "/root/.claude/uploads/72116791-a4a5-5e3c-8596-37748725ab9e/\
+         2221b455-ind_niftytotalmarket_list.csv"
+            .to_string()
+    });
+    let today = chrono::NaiveDate::from_ymd_opt(2026, 6, 6).expect("date");
+
+    println!("=== NTM SUBSCRIPTION PROOF (real file: {path}) ===\n");
+
+    let raw = std::fs::read(&path).expect("read CSV");
+    println!(
+        "STEP 1 — download stand-in: read {} bytes from disk",
+        raw.len()
+    );
+
+    // STEP 2 — REAL parser.
+    let parsed = parse_constituents(&raw, "Nifty Total Market", today).expect("parse");
+    println!(
+        "STEP 2 — REAL parse_constituents():\n  \
+         constituents kept      = {}\n  \
+         skipped blank rows     = {}\n  \
+         missing ISIN           = {}\n  \
+         skipped non-EQ series  = {}",
+        parsed.constituents.len(),
+        parsed.skipped_blank_rows,
+        parsed.missing_isin,
+        parsed.skipped_non_eq,
+    );
+
+    // STEP 3 — build the IndexConstituencyMap (what build_constituency_map does).
+    let mut map = IndexConstituencyMap::default();
+    map.index_to_constituents.insert(
+        "Nifty Total Market".to_string(),
+        parsed.constituents.clone(),
+    );
+    for c in &parsed.constituents {
+        map.stock_to_indices
+            .entry(c.symbol.clone())
+            .or_default()
+            .push("Nifty Total Market".to_string());
+    }
+    println!(
+        "STEP 3 — IndexConstituencyMap: {} index, {} unique stocks",
+        map.index_to_constituents.len(),
+        map.stock_to_indices.len()
+    );
+
+    // STEP 4 — synthetic Dhan master from the REAL ISINs (real IDs come from
+    // Dhan at boot; here we prove the JOIN matches every real ISIN).
+    let dhan_rows: Vec<CsvRow> = parsed
+        .constituents
+        .iter()
+        .enumerate()
+        .map(|(i, c)| synthetic_nse_eq_row(100_000 + i as u32, &c.symbol, &c.isin))
+        .collect();
+
+    // STEP 5 — REAL resolver against the real ISINs.
+    let outcome = resolve_constituents(&map, &dhan_rows).expect("resolve");
+    let via_isin = outcome.resolved.iter().filter(|r| r.via_isin).count();
+    println!(
+        "STEP 5 — REAL resolve_constituents():\n  \
+         total considered = {}\n  \
+         resolved         = {}\n  \
+         via ISIN (primary) = {}\n  \
+         unresolved (dangling) = {}",
+        outcome.total,
+        outcome.resolved.len(),
+        via_isin,
+        outcome.unresolved_symbols.len(),
+    );
+
+    // STEP 6 — rename-proof check: change a symbol but keep its ISIN.
+    if let Some(first) = parsed.constituents.first() {
+        let mut renamed = dhan_rows.clone();
+        renamed[0].symbol_name = "RENAMED_TICKER".to_string(); // ISIN unchanged
+        let r2 = resolve_constituents(&map, &renamed).expect("resolve renamed");
+        let still = r2
+            .resolved
+            .iter()
+            .any(|x| x.isin == first.isin.trim().to_uppercase() && x.via_isin);
+        println!(
+            "STEP 6 — rename-proof: '{}' renamed ticker still resolved via ISIN = {}",
+            first.symbol, still
+        );
+    }
+
+    let pct = if outcome.total > 0 {
+        100.0 * outcome.resolved.len() as f64 / outcome.total as f64
+    } else {
+        0.0
+    };
+    println!(
+        "\n=== VERDICT: {}/{} resolved ({pct:.2}%) ===",
+        outcome.resolved.len(),
+        outcome.total
+    );
+}

--- a/crates/core/src/instrument/index_extractor.rs
+++ b/crates/core/src/instrument/index_extractor.rs
@@ -109,9 +109,12 @@ pub const NSE_INDEX_ALLOWLIST: &[&str] = &[
     "NIFTY MICROCAP250",
     // §31 item 1 (operator 2026-06-06): NIFTY Total Market — the 33rd tracked
     // index value (32nd NSE entry). Dhan's exact IDX_I symbol is "NIFTY TOTAL MKT"
-    // (abbreviated; SecurityId 46, exch=IDX seg=I) — confirmed from the operator's
-    // Dhan chart screenshot 2026-06-06, NOT guessed. The `allowlist_misses` boot
-    // telemetry still LOUD-warns if the live master ever differs.
+    // (abbreviated). The security_id is READ DYNAMICALLY from the matched live
+    // master row — it is NEVER hardcoded here. The operator's live detailed
+    // master shows the NSE IDX_I row secid = 443 (2026-06-06); an earlier "46"
+    // came from the Dhan web-chart IDX-segment view and was never used as a
+    // value. The `allowlist_misses` boot telemetry LOUD-warns if the live
+    // master ever differs.
     "NIFTY TOTAL MKT",
 ];
 
@@ -498,8 +501,9 @@ mod tests {
     fn allowlist_has_exactly_32_nse_indices() {
         // 31 (§30 lock) + NIFTY TOTAL MKT (§31 item 1, 2026-06-06) = 32.
         assert_eq!(NSE_INDEX_ALLOWLIST.len(), 32);
-        // Dhan's exact IDX_I symbol (secid 46) — confirmed from the operator's
-        // Dhan chart, NOT the long-form "NIFTY TOTAL MARKET".
+        // Dhan's exact IDX_I symbol is "NIFTY TOTAL MKT", NOT the long-form
+        // "NIFTY TOTAL MARKET". The secid is read dynamically from the live
+        // master (operator's live master = 443; "46" was the Dhan-chart IDX view).
         assert!(NSE_INDEX_ALLOWLIST.contains(&"NIFTY TOTAL MKT"));
         // Every entry must already be normalized (uppercase, single-spaced)
         // so the runtime match is a direct equality.


### PR DESCRIPTION
## Summary

Two small, decoupled changes answering the operator's "prove NTM is fetched/resolved/subscribed" + "what is the NTM security_id" questions:

1. **F1 — re-runnable proof harness** (`crates/core/examples/ntm_subscription_proof.rs`): runs the REAL `parse_constituents → IndexConstituencyMap → resolve_constituents` chain against the operator's real `ind_niftytotalmarket_list.csv`.
2. **Item 3 — reconcile stale `secid 46` comments** in `index_extractor.rs` to reflect that the NTM index security_id is **read dynamically** from the live master (operator's live master = **443**; `46` was the Dhan web-chart IDX-segment view and was **never used as a value**).

## Why the secid comment was wrong but runtime was already correct

tickvault matches indices by `SYMBOL_NAME` ("NIFTY TOTAL MKT") via `NSE_INDEX_ALLOWLIST` and `row.clone()`s the matched master row — so the security_id is whatever the live Dhan master carries (443). There is **no hardcoded NTM secid** anywhere in `crates/` (grep-confirmed); `46` lived only in two comments. Zero runtime change.

> Note: the `NTM_SECURITY_ID=46` hardcode + strict cross-check the operator reported as "must be reconciled to 443" is in a **different repo (brutex, issue #426)** — not tickvault.

## Items completed
- [x] F1 — proof harness (measured live: 748 parsed, 0 missing ISIN, 7 non-EQ dropped, 748/748 resolved 100% via ISIN, rename-proof true)
- [x] Item 3 — secid comment reconcile → dynamic-read note (live master = 443)

## Honest 100% claim
100% inside the tested envelope: F1 proves the parse+resolve chain against the operator's REAL 748-ISIN file with measured results; a true network end-to-end (live niftyindices + live Dhan master + real security_ids + socket subscribe) needs egress + a token (sandbox egress = 403, QuestDB offline), so F1 uses synthetic Dhan security_ids over the REAL ISINs — clearly labelled — proving the JOIN matches every real ISIN. Real ids come from Dhan's master at boot (443 for NTM).

## Test plan
- [x] `cargo run -p tickvault-core --example ntm_subscription_proof --features daily_universe_fetcher` → 748/748 (100%)
- [x] chain unit tests green: constituent_resolver 8, daily_universe 37, index_extractor 19, index_constituency 27 = 91
- [x] banned-pattern scan clean
- [x] plan-verify PASS, plan-gate (design-first wall) PASS

https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr)_