### PR TITLE
fix(deploy): QuestDB self-heal + correct CloudWatch log path (AWS end-to-end log view)

### DIFF
--- a/.claude/plans/active-plan.md
+++ b/.claude/plans/active-plan.md
@@ -1,82 +1,102 @@
-# Implementation Plan: fill the 3 acknowledged doc gaps (kill-switch runbook + GitHub OIDC runbook + override-log link fix)
+# Implementation Plan: QuestDB self-heal + fix CloudWatch log path (the "IntelliJ view" in AWS)
 
 **Status:** VERIFIED
-**Date:** 2026-06-06
-**Approved by:** Parthiban — "yes dude go ahead" (write the 3 real docs identified in the doc audit).
-**Crate(s) touched:** none (docs + 1 test-file allowlist edit). No production source, no new ErrorCode.
+**Date:** 2026-06-08
+**Approved by:** Parthiban — "Go ahead" (build the QuestDB self-heal + the AWS end-to-end log view).
+**Crate(s) touched:** NONE — deploy + docs only (systemd unit, user-data CloudWatch-agent config,
+operator-control Lambda, new runbook). No production Rust, no new ErrorCode → plan-gate exempt.
 
 ## Context
 
-The doc audit found the codebase's own cross-link guard (`runbook_cross_link_guard.rs`) carries a
-shrinking allowlist of acknowledged-missing docs. Three are real gaps for LIVE functionality:
-1. `docs/runbooks/kill-switch.md` — kill-switch is live OMS code (`activate/deactivate/
-   get_kill_switch_status`) and prod `events.rs` tells the operator "decide go/no-go per kill-switch
-   runbook", but the runbook doesn't exist.
-2. `docs/runbooks/github-oidc-setup.md` — allowlisted TODO; `aws-deploy.md` step 1 points here for the
-   GitHub-Actions→AWS OIDC role (`AWS_ROLE_ARN` secret, `id-token: write`, ap-south-1).
-3. `docs/templates/override_log.md` — allowlisted TODO, BUT the file already exists as
-   `override-log.md` (hyphen); the reference in `daily-operations.md` is a 1-char typo
-   (`override_log` vs `override-log`). Fix the link, don't author a duplicate.
+Root-caused from the live journal: the app crash-loops forever (`BOOT-02: QuestDB not ready`,
+restart counter 26+) because **the QuestDB container is down and nothing on the box recreates it** —
+`user-data` runs once (cloud-init), the app unit only waits for the Docker *daemon* (not the QuestDB
+*container*), and the portal "Restart QuestDB" button uses `compose restart` (which fails if the
+container is gone). Separately, the operator wants the AWS equivalent of IntelliJ's live log view —
+but the CloudWatch agent ships `/opt/tickvault/logs/` while the app actually writes
+`/opt/tickvault/data/logs/` (WorkingDirectory=/opt/tickvault + `ReadWritePaths=/opt/tickvault/data`),
+so **app logs never reach CloudWatch** — a real path-mismatch bug.
 
 ## Design
 
-- **kill-switch.md** — operator runbook from the verified facts: endpoints `POST /v2/killswitch?
-  killSwitchStatus=ACTIVATE|DEACTIVATE`, `GET /v2/killswitch`; prerequisite (all positions closed +
-  no pending orders before ACTIVATE → else `exit_all_positions()` first); day-scoped; the OMS client
-  fns that drive it; when to pull it (the OptionChainStaleHalt go/no-go reference); P&L-exit
-  (`/pnlExit`) as the related auto-exit. Ground truth: `docs/dhan-ref/15-traders-control.md`.
-- **github-oidc-setup.md** — steps matching the real workflows: create the GitHub OIDC IAM identity
-  provider (`token.actions.githubusercontent.com`), an IAM role (`tv-github-deploy-role`) with a trust
-  policy scoped to `repo:SJParthi/tickvault:*`, attach least-privilege deploy permissions, set the
-  `AWS_ROLE_ARN` repo secret + `AWS_REGION` var; replaces the long-lived-creds temporary workaround.
-- **daily-operations.md** — change `docs/templates/override_log.md` → `docs/templates/override-log.md`
-  (existing file).
-- **runbook_cross_link_guard.rs** — remove the two now-resolved allowlist entries
-  (`docs/runbooks/github-oidc-setup.md`, `docs/templates/override_log.md`) so the guard ratchets down.
+1. **Self-heal QuestDB at app boot** — `deploy/systemd/tickvault.service`: add
+   `ExecStartPre=-/usr/bin/docker compose -f /opt/tickvault/repo/deploy/docker/docker-compose.yml up -d questdb`.
+   Runs as ec2-user (in the docker group), recreates a missing/stopped QuestDB before the app starts.
+   `-` prefix = a transient compose hiccup doesn't hard-fail the unit; the app's own 60s
+   `wait_for_questdb_ready` remains the real gate. Fixes the "container gone → loop forever" class.
+2. **Restart-QuestDB button → create-or-restart** — `operator-control/handler.py`: change
+   `docker compose restart questdb` → `docker compose up -d questdb` so the portal button works even
+   when the container vanished (not just when it's merely stopped).
+3. **Fix CloudWatch log path (the IntelliJ view)** — `user-data.sh.tftpl` CloudWatch-agent
+   `collect_list`: `/opt/tickvault/logs/{errors.jsonl*,app.*.log}` →
+   `/opt/tickvault/data/logs/...` (where the app actually writes). This makes the full app log +
+   `errors.jsonl` (incl. the `BOOT-02` `error!`) stream to CloudWatch `/tickvault/<env>/app` →
+   CloudWatch **Live Tail** becomes the real-time end-to-end console. Also fix the `mkdir` to create
+   `data/logs`.
+4. **New runbook** `docs/runbooks/aws-docker-daemon-dead.md` — disk-full / QuestDB-down / Docker
+   recovery (referenced by `aws-daily-lifecycle.md`); documents the self-heal + the journald-vs-
+   CloudWatch split (systemd/boot lines = journald/portal Logs tab; app+error logs = CloudWatch).
+
+**Honest scope note:** journald (the raw systemd `Failed to start` + the final anyhow `Error:` line)
+is NOT shipped to CloudWatch by the agent (it tails files, not the journal). But the *root-cause*
+`BOOT-02` line IS emitted via `error!` → `errors.jsonl` → reaches CloudWatch after fix #3, so the
+operator sees WHY boot failed in CloudWatch. Raw systemd lines stay in journald (portal Logs tab).
+A journald→CloudWatch source is deliberately out of scope (fragile; the path fix covers the need).
+
+**Deploy caveat (documented in the runbook):** the systemd-unit + user-data changes take effect on
+the next deploy / instance refresh — the existing down box must first be recovered manually
+(free disk / `docker compose up -d`).
 
 ## Edge Cases
 
-- Removing allowlist entries makes the guard ENFORCE resolution: kill-switch.md + github-oidc-setup.md
-  now exist; the override_log reference is fixed to the existing override-log.md → all resolve.
-- kill-switch.md is referenced from a phase doc (not a runbook) so it was never allowlisted; creating
-  it is purely additive.
+- ExecStartPre under `ProtectSystem=strict` — only reads the compose file (/opt readable) + talks to
+  `/run/docker.sock` (/run not locked by strict); ec2-user is in the docker group. Works.
+- Disk genuinely full → ExecStartPre `up -d` still can't start QuestDB → app still waits/fails
+  (correct — can't conjure space); the runbook covers freeing disk / growing EBS.
+- `up -d questdb` is idempotent — a healthy running QuestDB is untouched.
 
 ## Failure Modes
 
-- Docs + one test-file edit; zero production-behavior impact. The only failure surface is the
-  cross-link guard, which I run locally to confirm green after the allowlist shrink.
+- All changes are deploy/docs. ExecStartPre uses `-` so it never blocks boot worse than today.
+  Lambda change is a one-word command swap. user-data change is a path string.
 
 ## Test Plan
 
-- `cargo test -p tickvault-common --test runbook_cross_link_guard` — green after the 2 new docs + the
-  link fix + the allowlist shrink.
-- `bash .claude/hooks/plan-verify.sh` + plan-gate green.
+- `python3 -c "import json; ..."` validate the embedded CloudWatch-agent JSON still parses.
+- `python3 -m py_compile deploy/aws/lambda/operator-control/handler.py` — Lambda still compiles.
+- `cargo test -p tickvault-common --test runbook_cross_link_guard` — new runbook has no dangling links.
+- Manual review of the systemd unit (no syntax tool; matches existing directive style).
 
 ## Rollback
 
-- `git revert` removes the 2 docs, restores the typo + the 2 allowlist entries. Pure docs revert.
+- `git revert` restores the old systemd unit, the `compose restart`, and the old CW path. Pure
+  deploy/docs revert; no runtime code affected.
 
 ## Observability
 
-- N/A — documentation. The guard test is the mechanical proof the links resolve.
+- After deploy: CloudWatch `/tickvault/<env>/app` Live Tail shows the full app log + errors (incl.
+  BOOT-02). `tv_disk_*` gauges + the existing 75%-full alarm already cover disk.
 
 ## Plan Items
 
-- [x] Item 1 — write `docs/runbooks/kill-switch.md` (live OMS kill-switch operator runbook)
-  - Files: `docs/runbooks/kill-switch.md`
-  - Tests: every_repo_path_referenced_in_runbooks_resolves
-- [x] Item 2 — write `docs/runbooks/github-oidc-setup.md` + remove its allowlist entry
-  - Files: `docs/runbooks/github-oidc-setup.md`, `crates/common/tests/runbook_cross_link_guard.rs`
-  - Tests: every_repo_path_referenced_in_runbooks_resolves
-- [x] Item 3 — fix `daily-operations.md` override-log link + remove its allowlist entry
-  - Files: `docs/runbooks/daily-operations.md`, `crates/common/tests/runbook_cross_link_guard.rs`
+- [x] Item 1 — systemd `ExecStartPre` self-heals QuestDB
+  - Files: `deploy/systemd/tickvault.service`
+  - Tests: N/A (TEST-EXEMPT systemd unit — no Rust)
+- [x] Item 2 — Restart-QuestDB button → `compose up -d`
+  - Files: `deploy/aws/lambda/operator-control/handler.py`
+  - Tests: N/A (TEST-EXEMPT Lambda — py_compile verified)
+- [x] Item 3 — fix CloudWatch agent log path → `/opt/tickvault/data/logs/`
+  - Files: `deploy/aws/terraform/user-data.sh.tftpl`
+  - Tests: N/A (TEST-EXEMPT Terraform template — JSON validated)
+- [x] Item 4 — new `aws-docker-daemon-dead.md` runbook
+  - Files: `docs/runbooks/aws-docker-daemon-dead.md`
   - Tests: every_repo_path_referenced_in_runbooks_resolves
 
 ## Scenarios
 
 | # | Scenario | Expected |
 |---|----------|----------|
-| 1 | Operator hits OptionChainStaleHalt Telegram | kill-switch.md tells them go/no-go + how to pull the switch |
-| 2 | New deployer sets up CI→AWS | github-oidc-setup.md gives the exact IAM OIDC steps |
-| 3 | Operator logs a manual override | daily-operations.md links to the real override-log.md template |
-| 4 | Cross-link guard runs | all referenced paths resolve; allowlist shrank by 2 |
+| 1 | QuestDB container removed, app starts | ExecStartPre `up -d` recreates it → app boots (no more loop) |
+| 2 | Operator presses Restart QuestDB with container gone | `up -d` recreates it (old `restart` would fail) |
+| 3 | App running, operator opens CloudWatch Live Tail | full app log + BOOT/errors stream live (IntelliJ-style) |
+| 4 | Disk full | self-heal can't help; runbook → free disk / grow EBS |

--- a/deploy/aws/lambda/operator-control/handler.py
+++ b/deploy/aws/lambda/operator-control/handler.py
@@ -484,7 +484,13 @@ def lambda_handler(event, _context):
             cid = _ssm_shell(["systemctl stop tickvault || true", "systemctl disable tickvault || true"])
             return _resp(200, {"ok": True, "action": action, "command_id": cid})
         if action == "restart-questdb":
-            cid = _ssm_shell(["cd /opt/tickvault/repo/deploy/docker && docker compose restart questdb"])
+            # `up -d` (create-or-restart), NOT `restart`: `restart` fails if the
+            # container was removed (down/wipe/reset), leaving QuestDB down + the
+            # app crash-looping on BOOT-02. `up -d` recreates it when gone and
+            # restarts it when merely stopped. Idempotent on a healthy container.
+            # (Does NOT fix QuestDB CRASHING on start — disk-full / volume
+            # corruption: see docs/runbooks/aws-docker-daemon-dead.md.)
+            cid = _ssm_shell(["cd /opt/tickvault/repo/deploy/docker && docker compose up -d questdb"])
             return _resp(200, {"ok": True, "action": action, "command_id": cid})
         if action == "command-status":
             # READ-ONLY (not in _DESTRUCTIVE, allowed off-hours, no force). Lets

--- a/deploy/aws/terraform/user-data.sh.tftpl
+++ b/deploy/aws/terraform/user-data.sh.tftpl
@@ -107,13 +107,13 @@ cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<CWCFG
             "log_stream_name": "{instance_id}"
           },
           {
-            "file_path": "/opt/tickvault/logs/errors.jsonl*",
+            "file_path": "/opt/tickvault/data/logs/errors.jsonl*",
             "log_group_name": "/tickvault/$${ENVIRONMENT}/app",
             "log_stream_name": "{instance_id}/errors-jsonl",
             "timezone": "UTC"
           },
           {
-            "file_path": "/opt/tickvault/logs/app.*.log",
+            "file_path": "/opt/tickvault/data/logs/app.*.log",
             "log_group_name": "/tickvault/$${ENVIRONMENT}/app",
             "log_stream_name": "{instance_id}/app",
             "timezone": "UTC"
@@ -133,7 +133,10 @@ CWCFG
     -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 
 # ---- Step 4: Create application directories ----
-mkdir -p /opt/tickvault/{config,data/spill,logs,bin}
+# NOTE: the app writes its logs to data/logs (WorkingDirectory=/opt/tickvault +
+# ReadWritePaths=/opt/tickvault/data), which is where the CloudWatch agent now
+# tails app.*.log + errors.jsonl from (NOT the old /opt/tickvault/logs).
+mkdir -p /opt/tickvault/{config,data/spill,data/logs,bin}
 chown -R ec2-user:ec2-user /opt/tickvault
 
 # ---- Step 5: Clone the repo (shallow, main branch) ----

--- a/deploy/systemd/tickvault.service
+++ b/deploy/systemd/tickvault.service
@@ -30,6 +30,20 @@ Group=ec2-user
 ExecStart=/opt/tickvault/bin/tickvault
 WorkingDirectory=/opt/tickvault
 
+# Self-heal: ensure the QuestDB container EXISTS + is started before the app
+# boots. user-data's `docker compose up -d` runs only once (cloud-init), and
+# Docker's `restart: unless-stopped` cannot recreate a container that was
+# removed (down/wipe/reset). Without this, a missing QuestDB makes the app
+# crash-loop forever on BOOT-02. `up -d questdb` is idempotent (no-op if already
+# healthy) and recreates it if gone. Leading `-` = a transient compose hiccup
+# does NOT hard-fail the unit; the app's own 60s `wait_for_questdb_ready` is the
+# real gate.
+# NOTE: this fixes the "container removed" class. It does NOT fix QuestDB
+# CRASHING on start (disk-full / volume corruption) — `up` creates it but it
+# exits. For that, see docs/runbooks/aws-docker-daemon-dead.md (`docker logs
+# tv-questdb` + `df -h`).
+ExecStartPre=-/usr/bin/docker compose -f /opt/tickvault/repo/deploy/docker/docker-compose.yml up -d questdb
+
 # Auto-restart on ANY failure. RestartSec prevents tight restart loops.
 Restart=always
 RestartSec=3

--- a/docs/runbooks/aws-docker-daemon-dead.md
+++ b/docs/runbooks/aws-docker-daemon-dead.md
@@ -1,0 +1,103 @@
+# Runbook — QuestDB / Docker down → app crash-loops (BOOT-02)
+
+> **Symptom:** the tickvault app sits in `activating` with **0 ticks**, the journal
+> repeats `Failed to start tickvault.service` + `BOOT-02: QuestDB not ready`, and the
+> AWS-autopilot Telegram says **"QuestDB container not running after docker compose up"**.
+> **One-line cause:** the app is fail-closed — it refuses to run without QuestDB, and
+> **QuestDB is not up**. Get QuestDB up and the app self-recovers on its next restart.
+> **Referenced by:** `docs/architecture/aws-daily-lifecycle.md`.
+
+---
+
+## Why the app can't "just start"
+
+| Fact | Consequence |
+|---|---|
+| App is `Type=notify`, fail-closed at boot step 6c | No QuestDB → exits with **BOOT-02** → `Restart=always` loops forever |
+| `user-data` (`docker compose up -d`) runs **once** (cloud-init) | A stop/start does NOT recreate a removed QuestDB container |
+| App unit waits for the Docker **daemon**, not the QuestDB **container** | App boots before/without QuestDB and loops |
+
+The systemd unit now has `ExecStartPre=… docker compose up -d questdb` (self-heal for the
+**removed-container** case) and the portal **Restart QuestDB** button now uses `up -d` (create-or-restart).
+
+---
+
+## The decision tree (run on the box: SSM, or the portal AWS/Logs tab)
+
+```
+df -h                              # 1) DISK
+docker ps -a                       # 2) container state
+docker logs tv-questdb --tail 80   # 3) why QuestDB exits
+```
+
+| What you see | Cause | Fix |
+|---|---|---|
+| `/` at ~100% **or** `docker logs` shows **"No space left on device"** | **Disk full (EBS)** — the #1 cause | Free space + (optionally) grow EBS — see below |
+| `docker ps -a` shows `tv-questdb` **missing** | Container removed (down/wipe/reset) | `cd /opt/tickvault/repo/deploy/docker && docker compose up -d questdb` |
+| `tv-questdb` **Exited / Restarting**, logs show a **corruption / WAL / table open** error | **Volume corruption** (unclean stop mid-write) | repair / restore — see below |
+| `systemctl status docker` not `active` | Docker daemon down (often disk-full too) | `sudo systemctl restart docker` then `compose up -d` |
+
+> **"QuestDB not running after `docker compose up`"** (the autopilot's exact words) means the
+> container was created but **exited immediately** → it's **crashing on start**, i.e. the
+> **disk-full** or **volume-corruption** row above. `compose up` cannot fix either.
+
+---
+
+## Fix: disk full (the usual case)
+
+QuestDB writes to `tv-questdb-data` (`/var/lib/questdb`) on the 30 GB gp3 root volume. Within the
+90-day retention window the disk only grows (there's a CloudWatch **>75% full** alarm for this).
+
+1. **See what's big:** `sudo du -xh --max-depth=2 / | sort -rh | head -20` — usual culprits:
+   `/var/lib/docker/volumes/tv-questdb-data` (QuestDB data), `/opt/tickvault/data/spill`, `/opt/tickvault/data/logs`.
+2. **Free space (safe):** clear spill/DLQ + old logs first —
+   `rm -f /opt/tickvault/data/spill/* /opt/tickvault/data/dlq/* ; find /opt/tickvault/data/logs -name 'app.*' -mtime +2 -delete`.
+3. **If still full:** drop old QuestDB partitions (data >90d should already be in S3), or **grow the volume online** (no downtime):
+   - bump `ebs_gp3_size_gb` (e.g. `30 → 50`) in `deploy/aws/terraform/variables.tf` + `terraform apply`,
+   - on the box: `sudo growpart /dev/nvme0n1 1 && sudo xfs_growfs /`.
+4. **Bring it up:** `cd /opt/tickvault/repo/deploy/docker && docker compose up -d questdb` → the app's
+   `Restart=always` loop succeeds on its next attempt (≤60s). Watch `journalctl -u tickvault -f`.
+
+## Fix: volume corruption
+
+1. `docker logs tv-questdb --tail 120` → identify the offending table / WAL.
+2. If a single table is corrupt, QuestDB may start with it quarantined; otherwise restore the
+   `tv-questdb-data` volume from the most recent backup/snapshot.
+3. Worst case (data is reproducible — ticks are re-fetchable): the portal **"Wipe ALL data → fresh
+   start"** recreates an empty volume + restarts. Audit tables are preserved by that action.
+
+---
+
+## After recovery — confirm
+
+- `systemctl is-active tickvault` → `active`
+- portal app tile → `running`, **ticks captured today** climbing
+- `journalctl -u tickvault -f` → no more `BOOT-02`
+
+---
+
+## Where to watch logs (AWS, end-to-end)
+
+| Layer | Where | What |
+|---|---|---|
+| App log + `errors.jsonl` (incl. the `BOOT-02` `error!`) | **CloudWatch → Logs → Live tail → `/tickvault/<env>/app`** (ap-south-1) | the IntelliJ-style live app stream |
+| systemd / `Failed to start` / raw boot lines | **journald** — portal **Logs tab**, or `journalctl -u tickvault` via SSM | unit + crash-loop |
+| QuestDB's own crash reason | `docker logs tv-questdb` (box) | why the container exits — **not yet shipped to CloudWatch** (future enhancement) |
+
+---
+
+## Prevention (shipped / planned)
+
+- **Shipped:** `ExecStartPre … up -d questdb` self-heal; portal Restart-QuestDB uses `up -d`; the
+  CloudWatch agent now tails `/opt/tickvault/data/logs/` (the real path) so app+error logs reach
+  CloudWatch; the **>75% disk** CloudWatch alarm warns before full.
+- **Planned:** ship QuestDB container logs to CloudWatch (via the `awslogs` driver, with a
+  pre-created log group so a bad driver config can never block the container).
+
+---
+
+## Cross-references
+
+- `docs/runbooks/aws-capacity-error.md` — EC2 won't start (capacity).
+- `docs/runbooks/aws-startinstances-failed.md` — start-instances failures.
+- `docs/architecture/aws-daily-lifecycle.md` — the daily start/stop lifecycle.


### PR DESCRIPTION
## Summary

Prevents the multi-day outage seen on Jun 01→08: a **down QuestDB makes the app crash-loop forever** (`BOOT-02: QuestDB not ready`, restart counter 26+) with **no auto-heal**, and the AWS logs you actually need weren't reaching CloudWatch. Deploy + docs only — no Rust, no ErrorCode.

## What it fixes

| # | Change | Why |
|---|---|---|
| 1 | `tickvault.service`: `ExecStartPre=-… docker compose up -d questdb` | `user-data` runs once (cloud-init) + `restart:unless-stopped` can't recreate a **removed** container → the app now brings QuestDB up itself before boot. `-` keeps the app's own 60s QuestDB wait as the real gate. |
| 2 | `operator-control` **Restart QuestDB** button: `compose restart` → `compose up -d` | `restart` fails when the container is gone; `up -d` create-or-restarts. |
| 3 | CloudWatch agent log path: `/opt/tickvault/logs/` → `/opt/tickvault/data/logs/` | **Real bug** — the app writes `data/logs/` (WorkingDirectory + `ReadWritePaths`), so app logs never reached CloudWatch. Now `app.*.log` + `errors.jsonl` (incl. the `BOOT-02` `error!`) stream to `/tickvault/<env>/app` → **CloudWatch Live Tail = the IntelliJ-style end-to-end view**. |
| 4 | New `docs/runbooks/aws-docker-daemon-dead.md` | disk-full / QuestDB-crash / Docker recovery decision tree + where to watch logs in AWS. |

## Honest scope
- This fixes the **container-removed** class. It does **not** fix QuestDB **crashing on start** (disk-full / volume corruption — the runbook covers `docker logs tv-questdb` + `df -h` + freeing/growing EBS).
- Raw systemd lines stay in journald (portal Logs tab); the **root-cause** `BOOT-02` line reaches CloudWatch via `errors.jsonl` after fix #3.
- Takes effect on the **next deploy** (can't apply to a down box).

## Test plan
- [x] `cargo test -p tickvault-common --test runbook_cross_link_guard` → 4 passed (no dangling links)
- [x] `python3 -m py_compile` operator-control handler → OK
- [x] user-data edit = only the 2 log paths + mkdir (Terraform template; structurally safe)
- [x] plan-verify PASS, plan-gate PASS (deploy/docs only)

https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZcZEQdxzYwtm6FJP9uAsr)_