### PR TITLE
fix(storage): gate test-only INDEX_CONSTITUENCY_COLUMNS behind #[cfg(test)] (strict-clippy hygiene)

### DIFF
--- a/crates/storage/src/index_constituency_persistence.rs
+++ b/crates/storage/src/index_constituency_persistence.rs
@@ -64,6 +64,11 @@ pub const DEDUP_KEY_INDEX_CONSTITUENCY: &str = "ts, index_name, security_id, exc
 /// Column list shared by the DDL — one source so the writer + table cannot
 /// drift. (The ILP writer names each column explicitly; this constant pins the
 /// DDL ordering + the `test_ddl_contains_expected_columns` ratchet.)
+///
+/// Test-only: referenced exclusively by the DDL-column ratchet tests, so it is
+/// `#[cfg(test)]`-gated to avoid a dead-code lint on the production lib build
+/// (`cargo clippy --all-targets -- -D warnings`).
+#[cfg(test)]
 const INDEX_CONSTITUENCY_COLUMNS: &[&str] = &[
     "ts",
     "index_name",


### PR DESCRIPTION
## Summary
A full-workspace `verify-build` agent run (the "ensure the whole workspace works" check) found `INDEX_CONSTITUENCY_COLUMNS` is referenced **only inside the test module** (`test_ddl_contains_expected_columns`), so on the production lib build it is dead code under the stricter `cargo clippy --all-targets -- -D warnings`. This gates it with `#[cfg(test)]` — strict clippy is clean and the ratchet test is unchanged.

## Honest scope (no illusion)
- This is **not a CI-blocking fix**: the project's clippy policy is `--workspace -- -D warnings` (no `--all-targets`), which CI runs and `main` already passes (Build & Verify was green on #1061). This is strict-clippy **hygiene**, a small hardening down-payment.
- The other ~20 `--all-targets` lints the agent surfaced in `storage` are **intentional** (e.g. `assertions_on_constants` in ratchet/guard tests, test-only `excessive_precision`) — deliberately **not** changed, since "fixing" intentional const-assertions would weaken the guards.

## Verification
- `cargo check -p tickvault-storage --lib` → clean (rc=0).
- Lib build no longer emits the dead-code lint; the `#[cfg(test)]` ratchet still compiles + runs under test cfg.

## Not in this PR
The TICK-SEQ-01 capture_seq core (the actual index-tick-loss fix) is the next PR — see `.claude/plans/active-plan.md` (merged in #1061).

https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc

---
_Generated by [Claude Code](https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc)_