### PR TITLE
feat(core,storage): TICK-SEQ-01 threading — replay-stable capture_seq from read-loop frame_seq

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -422,7 +422,10 @@ async fn main() -> Result<()> {
     let ws_wal_path = std::path::PathBuf::from(&ws_wal_dir);
     // Replay first — this MUST happen before any WS connection opens so we
     // never race a fresh append against a stale segment rotation.
-    let mut ws_wal_replay_live_feed: Vec<bytes::Bytes> = Vec::new();
+    // TICK-SEQ-01: carry each replayed frame's `frame_seq` so re-injected
+    // frames reuse the SAME capture sequence as their original live write
+    // (replay-stable). v1 records replay with frame_seq=0.
+    let mut ws_wal_replay_live_feed: Vec<(u64, bytes::Bytes)> = Vec::new();
     let mut ws_wal_replay_order_update: Vec<Vec<u8>> = Vec::new();
     match tickvault_storage::ws_frame_spill::replay_all(&ws_wal_path) {
         Ok(recovered) => {
@@ -435,7 +438,8 @@ async fn main() -> Result<()> {
                     match rec.ws_type {
                         tickvault_storage::ws_frame_spill::WsType::LiveFeed => {
                             live += 1;
-                            ws_wal_replay_live_feed.push(bytes::Bytes::from(rec.frame));
+                            ws_wal_replay_live_feed
+                                .push((rec.frame_seq, bytes::Bytes::from(rec.frame)));
                         }
                         tickvault_storage::ws_frame_spill::WsType::OrderUpdate => {
                             ord += 1;
@@ -5467,7 +5471,7 @@ fn create_websocket_pool(
     notifier: Option<std::sync::Arc<NotificationService>>,
     wal_spill: Option<std::sync::Arc<tickvault_storage::ws_frame_spill::WsFrameSpill>>,
 ) -> Option<(
-    tokio::sync::mpsc::Receiver<bytes::Bytes>,
+    tokio::sync::mpsc::Receiver<(u64, bytes::Bytes)>,
     WebSocketConnectionPool,
 )> {
     let plan = match subscription_plan {

--- a/crates/core/src/pipeline/tick_processor.rs
+++ b/crates/core/src/pipeline/tick_processor.rs
@@ -673,7 +673,7 @@ mod conservation_tests {
 // APPROVED: indices-only hot-loop entry point — params wire distinct tick/depth/broadcast/greeks/enricher/heartbeat collaborators; a struct would only relocate the count.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_tick_processor<G: GreeksEnricher>(
-    mut frame_receiver: mpsc::Receiver<bytes::Bytes>,
+    mut frame_receiver: mpsc::Receiver<(u64, bytes::Bytes)>,
     mut tick_writer: Option<TickPersistenceWriter>,
     tick_broadcast: Option<broadcast::Sender<ParsedTick>>,
     mut greeks_enricher: Option<G>,
@@ -922,7 +922,13 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
     // PR #4 (2026-05-19): `depth_seq_tracker` retired alongside the
     // deleted depth_sequence_tracker module. Depth feeds are gone.
 
-    while let Some(raw_frame) = frame_receiver.recv().await {
+    while let Some((frame_seq, raw_frame)) = frame_receiver.recv().await {
+        // TICK-SEQ-01: the read-loop `frame_seq` IS this frame's capture
+        // sequence (1 frame = 1 tick — review CRITICAL #1). It is replay-stable:
+        // WAL replay re-delivers the SAME frame_seq, so the persisted
+        // `capture_seq` matches the original. u64→i64 is safe (wall-nanos-seeded,
+        // always positive, « i64::MAX; keeps `ORDER BY capture_seq` correct).
+        let capture_seq = i64::try_from(frame_seq).unwrap_or(i64::MAX);
         let tick_start = Instant::now();
         frames_processed = frames_processed.saturating_add(1);
         m_frames.increment(1);
@@ -1215,9 +1221,9 @@ pub async fn run_tick_processor<G: GreeksEnricher>(
                 // QuestDB write errors (connection down, buffer full, etc.).
                 if let Some(ref mut writer) = tick_writer {
                     let result = if let Some((_, _, life)) = lifecycle_for_tick {
-                        writer.append_tick_enriched(&tick, life)
+                        writer.append_tick_enriched_with_seq(&tick, life, capture_seq)
                     } else {
-                        writer.append_tick(&tick)
+                        writer.append_tick_with_seq(&tick, capture_seq)
                     };
                     match result {
                         Ok(()) => {
@@ -1965,12 +1971,24 @@ mod tests {
     // PR #2 (2026-05-18): movers tracker params removed from
     // `run_test_tick_processor` alongside the deleted modules.
     async fn run_test_tick_processor(
-        frame_receiver: mpsc::Receiver<bytes::Bytes>,
+        mut frame_receiver: mpsc::Receiver<bytes::Bytes>,
         tick_writer: Option<TickPersistenceWriter>,
         tick_broadcast: Option<broadcast::Sender<ParsedTick>>,
     ) {
+        // TICK-SEQ-01: bridge the test's `Bytes` channel to the production
+        // `(frame_seq, frame)` channel so the existing Bytes-sending test sites
+        // stay unchanged. frame_seq=0 is fine here — `capture_seq` is a non-key
+        // column in this slice (production stamps the real read-loop seq).
+        let (seq_tx, seq_rx) = mpsc::channel::<(u64, bytes::Bytes)>(256);
+        tokio::spawn(async move {
+            while let Some(frame) = frame_receiver.recv().await {
+                if seq_tx.send((0u64, frame)).await.is_err() {
+                    break;
+                }
+            }
+        });
         run_tick_processor::<tickvault_common::tick_types::NoopGreeksEnricher>(
-            frame_receiver,
+            seq_rx,
             tick_writer,
             tick_broadcast,
             None,                                                  // greeks_enricher

--- a/crates/core/src/websocket/connection.rs
+++ b/crates/core/src/websocket/connection.rs
@@ -240,7 +240,9 @@ pub struct WebSocketConnection {
     instruments: Vec<InstrumentSubscription>,
 
     /// Channel sender for forwarding raw binary frames to downstream.
-    frame_sender: mpsc::Sender<bytes::Bytes>,
+    /// TICK-SEQ-01: sends `(frame_seq, frame)` — the read-loop capture sequence
+    /// stamped once and shared with the WAL so `capture_seq` is replay-stable.
+    frame_sender: mpsc::Sender<(u64, bytes::Bytes)>,
 
     /// Current connection state (tracked for health reporting).
     state: std::sync::Mutex<ConnectionState>,
@@ -389,7 +391,7 @@ impl WebSocketConnection {
         ws_config: WebSocketConfig,
         instruments: Vec<InstrumentSubscription>,
         feed_mode: FeedMode,
-        frame_sender: mpsc::Sender<bytes::Bytes>,
+        frame_sender: mpsc::Sender<(u64, bytes::Bytes)>,
         notifier: Option<Arc<crate::notification::NotificationService>>,
     ) -> Self {
         let websocket_base_url = dhan_config.websocket_url.clone(); // O(1) EXEMPT: constructor — once
@@ -1277,13 +1279,19 @@ impl WebSocketConnection {
                     //     the CRITICAL metric — that is the single "real loss"
                     //     path and it requires both the disk writer thread
                     //     AND the downstream consumer to be stuck simultaneously.
+                    // TICK-SEQ-01: stamp the capture sequence ONCE per frame, then
+                    // share the SAME value with BOTH the durable WAL and the live
+                    // broadcast so the persisted `capture_seq` is replay-stable.
+                    // O(1) atomic, zero heap alloc.
+                    let frame_seq = tickvault_storage::ws_frame_spill::next_frame_seq();
                     if let Some(spill) = self.wal_spill.as_ref() {
                         // Zero-tick-loss PR-8a (H1): hand the WAL spill an O(1)
                         // `Bytes` Arc-refcount clone instead of a per-frame
                         // `Vec<u8>` malloc. `data` is already `Bytes` (the live
                         // forward below also moves it zero-copy), so `data.clone()`
                         // is a refcount bump — no heap allocation on the read loop.
-                        let outcome = spill.append(WsType::LiveFeed, data.clone());
+                        let outcome =
+                            spill.append_with_seq(WsType::LiveFeed, data.clone(), frame_seq);
                         if outcome == tickvault_storage::ws_frame_spill::AppendOutcome::Dropped {
                             error!(
                                 connection_id = self.connection_id,
@@ -1292,7 +1300,7 @@ impl WebSocketConnection {
                             // CRITICAL metric already incremented inside spill.append().
                         }
                     }
-                    match self.frame_sender.try_send(data) {
+                    match self.frame_sender.try_send((frame_seq, data)) {
                         Ok(()) => {}
                         Err(mpsc::error::TrySendError::Full(_dropped)) => {
                             let wal_attached = self.wal_spill.is_some();
@@ -3603,7 +3611,7 @@ mod tests {
 
     /// Helper: creates a `WebSocketConnection` with tiny timeouts for fast tests.
     fn make_test_conn_for_read_loop(
-        frame_sender: mpsc::Sender<bytes::Bytes>,
+        frame_sender: mpsc::Sender<(u64, bytes::Bytes)>,
     ) -> WebSocketConnection {
         WebSocketConnection::new(
             0,
@@ -3652,7 +3660,7 @@ mod tests {
         assert!(result.is_ok(), "read loop should return Ok on close");
 
         // Verify the binary payload was forwarded.
-        let received = rx.recv().await.expect("should receive frame"); // APPROVED: test
+        let (_seq, received) = rx.recv().await.expect("should receive frame"); // APPROVED: test
         assert_eq!(received, payload);
     }
 
@@ -3680,7 +3688,7 @@ mod tests {
 
         // All 3 frames should be received.
         for i in 0u8..3 {
-            let frame = rx.recv().await.expect("should receive frame"); // APPROVED: test
+            let (_seq, frame) = rx.recv().await.expect("should receive frame"); // APPROVED: test
             assert_eq!(frame, vec![i, i + 1, i + 2]);
         }
     }
@@ -4072,9 +4080,9 @@ mod tests {
         assert!(result.is_ok());
 
         // Check that both binary frames were forwarded.
-        let frame1 = rx.recv().await.expect("should get frame 1"); // APPROVED: test
+        let (_seq, frame1) = rx.recv().await.expect("should get frame 1"); // APPROVED: test
         assert_eq!(frame1, vec![0xAA]);
-        let frame2 = rx.recv().await.expect("should get frame 2"); // APPROVED: test
+        let (_seq2, frame2) = rx.recv().await.expect("should get frame 2"); // APPROVED: test
         assert_eq!(frame2, vec![0xBB]);
     }
 
@@ -4185,7 +4193,7 @@ mod tests {
         let result = read_handle.await.expect("task panicked"); // APPROVED: test
         assert!(result.is_ok());
 
-        let received = rx.recv().await.expect("should receive large frame"); // APPROVED: test
+        let (_seq, received) = rx.recv().await.expect("should receive large frame"); // APPROVED: test
         assert_eq!(received.len(), 4096);
         assert_eq!(received, expected);
     }
@@ -4210,7 +4218,7 @@ mod tests {
         let result = read_handle.await.expect("task panicked"); // APPROVED: test
         assert!(result.is_ok());
 
-        let received = rx.recv().await.expect("should receive empty frame"); // APPROVED: test
+        let (_seq, received) = rx.recv().await.expect("should receive empty frame"); // APPROVED: test
         assert!(received.is_empty());
     }
 
@@ -4267,7 +4275,7 @@ mod tests {
         let result = read_handle.await.expect("task panicked"); // APPROVED: test
         assert!(result.is_ok());
 
-        let frame = rx.recv().await.expect("should receive binary frame"); // APPROVED: test
+        let (_seq, frame) = rx.recv().await.expect("should receive binary frame"); // APPROVED: test
         assert_eq!(frame, vec![0xFF]);
     }
 

--- a/crates/core/src/websocket/connection_pool.rs
+++ b/crates/core/src/websocket/connection_pool.rs
@@ -61,14 +61,16 @@ pub struct WebSocketConnectionPool {
     connections: Vec<Arc<WebSocketConnection>>,
 
     /// Receiver for raw binary frames from all connections.
-    frame_receiver: mpsc::Receiver<bytes::Bytes>,
+    /// TICK-SEQ-01: each item is `(frame_seq, frame)` — the read-loop capture
+    /// sequence rides alongside the frame so `capture_seq` is replay-stable.
+    frame_receiver: mpsc::Receiver<(u64, bytes::Bytes)>,
 
     /// STAGE-C.2b: Retained clone of the shared frame sender. Held on the
     /// pool so boot-time WAL replay can inject recovered LiveFeed frames
     /// into the downstream consumer through the same mpsc the live
     /// connections write to. Without this, replayed frames would only be
     /// archived, never re-played into the live pipeline.
-    frame_sender: mpsc::Sender<bytes::Bytes>,
+    frame_sender: mpsc::Sender<(u64, bytes::Bytes)>,
 
     /// Stagger delay between connection spawns (milliseconds). 0 = no stagger.
     connection_stagger_ms: u64,
@@ -276,7 +278,7 @@ impl WebSocketConnectionPool {
     /// cleanly when the caller is done injecting. Covered end-to-end by
     /// the STAGE-C.2b replay-injection integration flow in main.rs.
     // TEST-EXEMPT: trivial Arc-bump clone accessor — `mpsc::Sender::clone` is tokio-tested; integration covered by main.rs replay-injection path
-    pub fn frame_sender_clone(&self) -> mpsc::Sender<bytes::Bytes> {
+    pub fn frame_sender_clone(&self) -> mpsc::Sender<(u64, bytes::Bytes)> {
         self.frame_sender.clone() // APPROVED: cold path — Arc bump for boot-time WAL replay, not per-tick
     }
 
@@ -332,7 +334,7 @@ impl WebSocketConnectionPool {
     ///
     /// The caller owns this receiver and reads raw binary frames from
     /// all active connections. Each frame is a complete Dhan binary packet.
-    pub fn take_frame_receiver(&mut self) -> mpsc::Receiver<bytes::Bytes> {
+    pub fn take_frame_receiver(&mut self) -> mpsc::Receiver<(u64, bytes::Bytes)> {
         // Replace with a dummy channel — receiver can only be taken once.
         let (_, dummy) = mpsc::channel(1);
         std::mem::replace(&mut self.frame_receiver, dummy)

--- a/crates/core/src/websocket/order_update_connection.rs
+++ b/crates/core/src/websocket/order_update_connection.rs
@@ -439,7 +439,14 @@ async fn connect_and_listen(
                     // O(1) EXEMPT: one allocation per frame on a cold path
                     // (orders are sparse — ~1-100/day).
                     let frame_vec = text.as_bytes().to_vec();
-                    let outcome = spill.append(WsType::OrderUpdate, frame_vec);
+                    // TICK-SEQ-01: order-update frames are JSON (not ticks) and are
+                    // not broadcast to the tick processor, but they still get a
+                    // monotonic frame_seq for WAL replay-ordering parity.
+                    let outcome = spill.append_with_seq(
+                        WsType::OrderUpdate,
+                        frame_vec,
+                        tickvault_storage::ws_frame_spill::next_frame_seq(),
+                    );
                     if outcome == AppendOutcome::Dropped {
                         error!(
                             "CRITICAL: WAL spill dropped OrderUpdate frame — disk writer stalled"

--- a/crates/storage/src/tick_persistence.rs
+++ b/crates/storage/src/tick_persistence.rs
@@ -360,6 +360,16 @@ impl TickPersistenceWriter {
     /// O(1) — single ILP row append + conditional flush.
     /// Ring buffer and reconnect logic (cold path) only run on error.
     pub fn append_tick(&mut self, tick: &ParsedTick) -> Result<()> {
+        self.append_tick_with_seq(tick, next_capture_seq())
+    }
+
+    /// Like [`append_tick`] but threads a replay-stable `capture_seq` (sourced
+    /// from the WS read-loop `frame_seq`) into the persisted row. TICK-SEQ-01
+    /// threading slice: the tick processor calls this with the frame's seq so
+    /// the live row's `capture_seq` matches the WAL-replayed row's. Ring-buffered
+    /// (QuestDB-down) ticks fall back to a drain-time seq, which PR-2b makes
+    /// ring-stable.
+    pub fn append_tick_with_seq(&mut self, tick: &ParsedTick, capture_seq: i64) -> Result<()> {
         // If sender is None (previous failure), attempt reconnect before writing.
         if self.sender.is_none() {
             match self.try_reconnect_on_error() {
@@ -375,7 +385,7 @@ impl TickPersistenceWriter {
             }
         }
 
-        build_tick_row(&mut self.buffer, tick)?;
+        build_tick_row_seq(&mut self.buffer, tick, capture_seq)?;
 
         // Track in-flight: save a copy so we can rescue on flush failure.
         // ParsedTick is Copy (112 bytes) — this is a memcpy, not a heap alloc.
@@ -413,7 +423,18 @@ impl TickPersistenceWriter {
     ///
     /// O(1) — same characteristics as `append_tick`. The `TickLifecycle`
     /// carrier is `Copy`, no heap allocation.
-    pub fn append_tick_enriched(&mut self, tick: &ParsedTick, _life: TickLifecycle) -> Result<()> {
+    pub fn append_tick_enriched(&mut self, tick: &ParsedTick, life: TickLifecycle) -> Result<()> {
+        self.append_tick_enriched_with_seq(tick, life, next_capture_seq())
+    }
+
+    /// Like [`append_tick_enriched`] but threads a replay-stable `capture_seq`
+    /// (from the WS read-loop `frame_seq`). TICK-SEQ-01 threading slice.
+    pub fn append_tick_enriched_with_seq(
+        &mut self,
+        tick: &ParsedTick,
+        _life: TickLifecycle,
+        capture_seq: i64,
+    ) -> Result<()> {
         if self.sender.is_none() {
             match self.try_reconnect_on_error() {
                 Ok(()) => {
@@ -426,7 +447,7 @@ impl TickPersistenceWriter {
             }
         }
 
-        build_tick_row(&mut self.buffer, tick)?;
+        build_tick_row_seq(&mut self.buffer, tick, capture_seq)?;
 
         self.in_flight.push(*tick);
         self.pending_count = self.pending_count.saturating_add(1);
@@ -1352,6 +1373,15 @@ fn next_capture_seq() -> i64 {
 /// Price fields use `f32_to_f64_clean` to preserve the original Dhan f32
 /// precision without f32→f64 widening artifacts.
 fn build_tick_row(buffer: &mut Buffer, tick: &ParsedTick) -> Result<()> {
+    build_tick_row_seq(buffer, tick, next_capture_seq())
+}
+
+/// Like [`build_tick_row`] but writes the caller-supplied, replay-stable
+/// `capture_seq` (sourced from the WAL `frame_seq` via the tick processor)
+/// instead of generating one at persist time. TICK-SEQ-01 threading slice:
+/// this is what makes the live row's `capture_seq` match the WAL-replayed
+/// row's `capture_seq` for the same frame (closes review HIGH #5 / CRITICAL #2).
+fn build_tick_row_seq(buffer: &mut Buffer, tick: &ParsedTick, capture_seq: i64) -> Result<()> {
     // Dhan WebSocket exchange_timestamp is already IST epoch seconds.
     // Store directly — no offset needed.
     let ts_nanos =
@@ -1406,11 +1436,12 @@ fn build_tick_row(buffer: &mut Buffer, tick: &ParsedTick) -> Result<()> {
         // collapse. See `tick_payload_hash` + the `DEDUP_KEY_TICKS` doc.
         .column_i64("payload_hash", tick_payload_hash(tick))
         .context("payload_hash")?
-        // TICK-SEQ-01 step 1: strictly-monotonic per-row capture sequence,
-        // stored as a column. NOT yet in the DEDUP key (still `payload_hash`) —
-        // it becomes the replay-stable key tiebreaker once sourced from the WAL
-        // frame (step 2). See `next_capture_seq` + `.claude/plans/active-plan.md`.
-        .column_i64("capture_seq", next_capture_seq())
+        // TICK-SEQ-01: replay-stable capture sequence. On the live path this is
+        // the WS read-loop `frame_seq`; on WAL replay it is the SAME value read
+        // back from the v2 record — so a true duplicate collapses and distinct
+        // ticks are kept. Still a stored column only in this slice; the DEDUP key
+        // flip to capture_seq lands in PR-2b. See `.claude/plans/active-plan.md`.
+        .column_i64("capture_seq", capture_seq)
         .context("capture_seq")?
         .at(ts_nanos)
         .context("designated timestamp")?;

--- a/crates/storage/src/ws_frame_spill.rs
+++ b/crates/storage/src/ws_frame_spill.rs
@@ -252,9 +252,23 @@ impl WsFrameSpill {
     /// (also zero-copy), so existing callers keep working unchanged.
     // TEST-EXEMPT: covered by test_append_spill_and_replay_roundtrip + test_drop_counter_increments_when_channel_full; the Bytes-clone hand-off is proven zero-alloc by crates/core/tests/dhat_ws_reader_zero_alloc.rs::dhat_ws_reader_tail_zero_alloc
     pub fn append(&self, ws_type: WsType, frame: impl Into<Bytes>) -> AppendOutcome {
+        self.append_with_seq(ws_type, frame, next_frame_seq())
+    }
+
+    /// Like [`WsFrameSpill::append`] but stamps the caller-provided `frame_seq`
+    /// (the WS read loop's value) so the SAME sequence is persisted in the WAL
+    /// AND shared with the live broadcast → `ticks.capture_seq` (replay-stable).
+    /// TICK-SEQ-01 threading slice. Hot path, O(1), zero-alloc.
+    // TEST-EXEMPT: identical try_send path as `append` (covered by test_append_spill_and_replay_roundtrip + test_wal_v2_roundtrip_preserves_frame_seq); frame_seq plumbing covered by chaos_ws_frame_wal_replay + the read-loop integration.
+    pub fn append_with_seq(
+        &self,
+        ws_type: WsType,
+        frame: impl Into<Bytes>,
+        frame_seq: u64,
+    ) -> AppendOutcome {
         let record = WalRecord {
             ws_type,
-            frame_seq: next_frame_seq(),
+            frame_seq,
             frame: frame.into(),
         };
         match self.spill_tx.try_send(record) {
@@ -482,12 +496,13 @@ fn maybe_test_panic(r: &WalRecord) {
 }
 
 /// Process-wide strictly-monotonic frame sequence: `max(prev+1, wall_nanos)`.
-/// Lock-free CAS, O(1), zero heap alloc. TICK-SEQ-01 PR-2a stamps this at
-/// `append` time; a later slice hoists it to the WS read loop (passed in) so
-/// it equals the per-tick `capture_seq` written to `ticks.capture_seq`.
+/// Lock-free CAS, O(1), zero heap alloc. The WS read loop calls this ONCE per
+/// frame and passes the value to BOTH [`WsFrameSpill::append_with_seq`] and the
+/// live broadcast, so the WAL record and the `ticks.capture_seq` column carry
+/// the identical replay-stable value.
 static WAL_FRAME_SEQ: AtomicU64 = AtomicU64::new(0);
 
-fn next_frame_seq() -> u64 {
+pub fn next_frame_seq() -> u64 {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))


### PR DESCRIPTION
## Summary
TICK-SEQ-01 **threading slice** (PR-2a, second half). Makes the `capture_seq` column **replay-stable** by sourcing it from a `frame_seq` stamped once in the WS read loop and threaded through the broadcast to the persist path. **Additive, zero behaviour change** — the `ticks` DEDUP key is UNCHANGED (`payload_hash`); the key flip is PR-2b.

## What changed (the thread)
- **Read loop** (`connection.rs`): stamps `frame_seq = ws_frame_spill::next_frame_seq()` ONCE per frame, shares the SAME value with BOTH the WAL (`append_with_seq`) and the live broadcast `(frame_seq, frame)`.
- **Broadcast** (`connection.rs`/`connection_pool.rs`): channel `Bytes` → `(u64, Bytes)`.
- **Tick processor** (`tick_processor.rs`): binds `capture_seq = frame_seq` (1 frame = 1 tick) and threads it into `append_tick_with_seq` / `build_tick_row_seq`.
- **Persist** (`tick_persistence.rs`): new `*_with_seq` paths write the threaded `capture_seq`; the **persist-time stamp is deleted on the live path**.
- **WAL replay** (`main.rs`): re-injects `(rec.frame_seq, frame)` so replayed rows reuse the SAME `capture_seq` → true duplicates collapse (idempotent), distinct ticks survive.
- Order-update frames stamped for WAL-ordering parity.

## Review severities closed by this PR
| Sev | Finding | Status |
|---|---|---|
| 🔴 CRITICAL #1 | `capture_seq = frame_seq` 1:1 (no phantom packet_index) | ✅ |
| 🔴 CRITICAL #2 | delete persist-time re-stamp (replay would duplicate) | ✅ |
| 🟠 HIGH #5 | live `capture_seq` == WAL-replayed (single read-loop source) | ✅ |

Combined with #1064 (TVW2 WAL), **8 of the review's 12 severities are now closed.** Remaining: CRITICAL #4 (never auto-DROP `ticks`) + HIGH (verify in-place dedup) land in **PR-2b** with the `45→75→45` chaos test — the fix is NOT complete until that test is green.

## Verification (real output)
- `cargo build -p tickvault-storage -p tickvault-core -p tickvault-app` → green.
- `cargo test -p tickvault-storage --lib` → **542 passed; 0 failed**.
- `cargo test -p tickvault-core --lib` → **2035 passed; 0 failed** (incl. read-loop + tick_processor).
- WAL integration (`chaos_ws_frame_wal_replay`, `ws_frame_order_preservation_guard`) → green.
- 5 core integration test targets + app `shutdown_sequence_guard` compile clean.
- `cargo clippy -p tickvault-storage -p tickvault-core --lib -- -D warnings` → clean.

## Test-side note
`run_test_tick_processor` bridges the tests' `Bytes` channel to the production `(u64, Bytes)` channel (frame_seq=0) so the 111 existing Bytes-sending test sites stay unchanged; read-loop tests destructure the `(seq, frame)` tuple.

## Rollback
Additive; key unchanged. `git revert <sha>`.

https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc

---
_Generated by [Claude Code](https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc)_