### PR TITLE
fix(deploy): unbreak SSM commands quoting that failed every deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,25 @@ jobs:
         run: bash .claude/hooks/plan-gate.sh "${{ github.workspace }}"
 
   # -------------------------------------------------------------------------
+  # Deploy Lint — the SSM `--parameters 'commands=[ ... ]'` block in the deploy
+  # workflows is a SINGLE-QUOTED runner string; a literal apostrophe inside it
+  # closes the quote early and a following `(` then fails the whole deploy with
+  # "syntax error near unexpected token `('" (regression: CI run 27210316913,
+  # 2026-06-09). This guard fails the build if that ever reappears.
+  # -------------------------------------------------------------------------
+  deploy-lint:
+    name: "Deploy Lint (SSM quoting)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+
+      - name: Validate SSM commands[] quoting in deploy workflows
+        shell: bash
+        run: bash scripts/validate-deploy-ssm-quoting.sh "${{ github.workspace }}"
+
+  # -------------------------------------------------------------------------
   # Build & Verify — fmt + clippy + lib tests per crate.
   #
   # Split fmt + clippy (fast, one runner) from per-crate `cargo nextest run

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -570,7 +570,7 @@ jobs:
               "sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc",
               "if [ -f repo/deploy/aws/cloudwatch-agent.json ]; then sudo cp -f repo/deploy/aws/cloudwatch-agent.json /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json; fi",
               "if [ -f repo/deploy/aws/prometheus.yaml ]; then sudo cp -f repo/deploy/aws/prometheus.yaml /opt/aws/amazon-cloudwatch-agent/etc/prometheus.yaml; fi",
-              "sudo timeout 25 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json || echo 'WARN: cloudwatch-agent fetch-config failed (observability only, app unaffected)'",
+              "sudo timeout 25 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json || echo WARN: cloudwatch-agent fetch-config failed - observability only app unaffected",
               "sudo systemctl enable amazon-cloudwatch-agent || true",
               "sudo systemctl start amazon-cloudwatch-agent --no-block || true",
               "echo CWAGENT-CONFIGURED",

--- a/scripts/validate-deploy-ssm-quoting.sh
+++ b/scripts/validate-deploy-ssm-quoting.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# validate-deploy-ssm-quoting.sh
+#
+# Guard against the 2026-06-09 deploy break (CI run 27210316913):
+# the SSM `--parameters 'commands=[ ... ]'` block in the deploy workflows is a
+# SINGLE-QUOTED string on the GitHub Actions runner. A literal apostrophe (')
+# inside that block CLOSES the outer single quote early; any following `(` then
+# parses as an unquoted subshell token →
+#     /home/runner/work/_temp/xxx.sh: line N: syntax error near unexpected token `('
+# and the whole deploy fails before the new binary is ever swapped in.
+#
+# This script fails (exit 2) if any line BETWEEN the opening `'commands=[` and the
+# closing `]'` of a deploy workflow contains a literal apostrophe. The opening and
+# closing lines themselves are the only legal apostrophes.
+#
+# Box-side quoting MUST use escaped double quotes (\") — never raw single quotes.
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+FILES=(
+  "$ROOT/.github/workflows/deploy-aws.yml"
+  "$ROOT/.github/workflows/deploy-aws-after-close.yml"
+)
+
+rc=0
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || continue
+  # awk: track whether we are inside a MULTI-LINE `commands=[ ... ]` block.
+  # A single-line `commands=["..."]'` opener (close `]'` on the same physical
+  # line) is parsed atomically by the runner and is NOT entered as a block.
+  # Inside a multi-line block, flag any interior line carrying an apostrophe.
+  bad=$(awk '
+    # multi-line opener: has commands=[ but NO closing ]'\'' on the same line
+    /--parameters '\''commands=\[/ && $0 !~ /\]'\''/ { inblock=1; next }
+    # closer of a multi-line block
+    inblock && /^[[:space:]]*\]'\''/ { inblock=0; next }
+    # interior line of a multi-line block with a quote-breaking apostrophe
+    inblock && /'\''/ { print FILENAME ":" NR ": " $0 }
+  ' "$f" || true)
+  if [ -n "$bad" ]; then
+    echo "FAIL: apostrophe inside SSM commands=[...] block (breaks the outer single quote):" >&2
+    echo "$bad" >&2
+    echo "  Fix: use escaped double quotes \\\" for box-side strings; never a raw single quote." >&2
+    rc=2
+  fi
+done
+
+if [ "$rc" -eq 0 ]; then
+  echo "OK: no quote-breaking apostrophe inside any deploy SSM commands=[...] block."
+fi
+exit "$rc"


### PR DESCRIPTION
## Summary

**Every deploy was failing on a shell syntax error — fixed.** The instance was `running` but the app stayed `inactive` because the new binary never swapped in.

## Root cause (a regression from #1067)

The CloudWatch fetch-config fallback added in #1067 put a **single-quoted** echo *inside* the outer single-quoted SSM `--parameters 'commands=[ … ]'` string:

```
… || echo 'WARN: cloudwatch-agent fetch-config failed (observability only, app unaffected)'
```

On the GitHub Actions runner that whole block is one single-quoted argument. The first inner `'` **closes** the outer quote, then `(` parses as a bare subshell token:

```
/home/runner/work/_temp/xxx.sh: line 99: syntax error near unexpected token `('
Error: Process completed with exit code 2.
```

The deploy aborted *before* the atomic binary swap, so two `🆘 Deploy FAILED` Telegram alerts fired (07:11 + 07:15 PM IST, CI run `27210316913`) and the live app was left down.

## Fix

Drop the inner single-quotes **and** the parens from the warn echo (box-side strings in this block must use escaped double-quotes, never raw single-quotes — the rest of the 100-line array already follows that):

```
… || echo WARN: cloudwatch-agent fetch-config failed - observability only app unaffected
```

## Guard so it can never silently recur

| Artifact | What it does |
|---|---|
| `scripts/validate-deploy-ssm-quoting.sh` | Fails if any interior line of a multi-line SSM `commands=[…]` block carries an apostrophe |
| `ci.yml` → **Deploy Lint (SSM quoting)** job | Runs the guard on every PR |

Tested both directions: **passes** on the fixed file, **fails (exit 2)** on an injected bad line.

## Verification

- `python3 -c yaml.safe_load` clean on `ci.yml` + `deploy-aws.yml`
- Guard: `OK` on current tree; `FAIL` on injected apostrophe
- No `crates/*/src` change → infra/CI-only

## Honest envelope

This guard covers the exact failure mode (apostrophe inside the multi-line `commands=[…]` block — the only single-quote-breaking construct). The 4 single-line `commands=[…]'` arrays in the same file are atomic and currently clean; extending the guard to them is a cheap follow-up if ever needed.

https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc

---
_Generated by [Claude Code](https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc)_