### PR TITLE
feat(aws): enrich daily cost digest with per-service table + align to real $25 budget

### DIFF
--- a/deploy/aws/terraform/budget-guards.tf
+++ b/deploy/aws/terraform/budget-guards.tf
@@ -32,11 +32,37 @@ from datetime import datetime, timedelta, timezone
 ce  = boto3.client('ce', region_name='us-east-1')  # Cost Explorer is us-east-1 only
 sns = boto3.client('sns')
 
-INR_PER_USD = 85
+INR_PER_USD = 85    # rupee display rate (what you actually pay incl GST)
 GST_MULT    = 1.18  # India GST 18%
-BUDGET_INR  = 2000  # monthly target per aws-budget.md
+# The REAL ceiling is the AWS Budget that auto-stops the box (budget.tf:20):
+# $25/month measured on UnblendedCost (pre-GST USD). Comparing month-to-date
+# USD against $25 makes the digest "% used" match the kill-switch EXACTLY —
+# previously it compared rupees-with-GST against a separate ₹2000 number, so
+# the percentage you saw did NOT line up with what actually stopped the box.
+BUDGET_USD  = 25.0
 
-def get_cost(start, end):
+# Friendly labels for the Cost Explorer SERVICE dimension (substring match).
+SERVICE_LABELS = [
+    ('Elastic Compute Cloud', 'EC2 compute'),
+    ('EC2 - Other',           'EBS + transfer'),
+    ('Virtual Private Cloud', 'Public IP / VPC'),
+    ('CloudWatch',            'CloudWatch'),
+    ('Simple Storage',        'S3 storage'),
+    ('Simple Notification',   'SNS alerts'),
+    ('Lambda',                'Lambda'),
+    ('Key Management',        'KMS'),
+]
+
+def label_for(svc):
+    for needle, nice in SERVICE_LABELS:
+        if needle in svc:
+            return nice
+    return svc
+
+def inr(usd):
+    return usd * INR_PER_USD * GST_MULT
+
+def get_total(start, end):
     r = ce.get_cost_and_usage(
         TimePeriod={'Start': start, 'End': end},
         Granularity='DAILY',
@@ -44,39 +70,61 @@ def get_cost(start, end):
     )
     return sum(float(d['Total']['UnblendedCost']['Amount']) for d in r['ResultsByTime'])
 
+def get_by_service(start, end):
+    r = ce.get_cost_and_usage(
+        TimePeriod={'Start': start, 'End': end},
+        Granularity='DAILY',
+        Metrics=['UnblendedCost'],
+        GroupBy=[{'Type': 'DIMENSION', 'Key': 'SERVICE'}],
+    )
+    agg = {}
+    for d in r['ResultsByTime']:
+        for g in d['Groups']:
+            usd = float(g['Metrics']['UnblendedCost']['Amount'])
+            if usd <= 0:
+                continue
+            key = label_for(g['Keys'][0])
+            agg[key] = agg.get(key, 0.0) + usd
+    return agg
+
 def handler(event, context):
     today_utc = datetime.now(timezone.utc).date()
     yest_utc  = today_utc - timedelta(days=1)
     mtd_start = today_utc.replace(day=1)
 
     # Cost Explorer "end" is exclusive — yesterday's full day = today as end
-    today_usd = get_cost(str(yest_utc), str(today_utc))
-    mtd_usd   = get_cost(str(mtd_start), str(today_utc))
+    yday_usd = get_total(str(yest_utc), str(today_utc))
+    mtd_usd  = get_total(str(mtd_start), str(today_utc))
+    by_svc   = get_by_service(str(mtd_start), str(today_utc))
 
-    today_inr = today_usd * INR_PER_USD * GST_MULT
-    mtd_inr   = mtd_usd   * INR_PER_USD * GST_MULT
-    pct       = (mtd_inr / BUDGET_INR) * 100 if BUDGET_INR else 0
-
+    pct = (mtd_usd / BUDGET_USD) * 100 if BUDGET_USD else 0
     emoji = '🟢' if pct < 50 else ('🟡' if pct < 80 else ('🟠' if pct < 100 else '🔴'))
 
     days_in_month  = (today_utc.replace(month=today_utc.month % 12 + 1, day=1) - timedelta(days=1)).day if today_utc.month < 12 else 31
     days_remaining = days_in_month - today_utc.day
-    forecast_inr   = (mtd_inr / today_utc.day) * days_in_month if today_utc.day else mtd_inr
+    forecast_usd   = (mtd_usd / today_utc.day) * days_in_month if today_utc.day else mtd_usd
 
-    msg = (
-        f"{emoji} *Daily Budget Digest*\n"
-        f"_yesterday_: ₹{today_inr:.0f}\n"
-        f"_MTD_:       ₹{mtd_inr:.0f} / ₹{BUDGET_INR} ({pct:.0f}%)\n"
-        f"_forecast_:  ₹{forecast_inr:.0f} EOM\n"
-        f"_days left_: {days_remaining}\n"
-    )
+    lines = [
+        f"{emoji} *AWS Cost — tickvault*",
+        f"_Yesterday_:   ₹{inr(yday_usd):.0f}   (${yday_usd:.2f})",
+        f"_This month_:  ₹{inr(mtd_usd):.0f}   (${mtd_usd:.2f})",
+        f"_Of $25 stop-budget_: {pct:.0f}%",
+        f"_Forecast EOM_: ₹{inr(forecast_usd):.0f}   (${forecast_usd:.2f})",
+        f"_Days left_:   {days_remaining}",
+        "",
+        "*Where it goes (this month):*",
+    ]
+    for nice, usd in sorted(by_svc.items(), key=lambda kv: -kv[1]):
+        lines.append(f"  {nice:<16} ₹{inr(usd):.0f}  (${usd:.2f})")
+    if not by_svc:
+        lines.append("  (no spend yet this month)")
 
     sns.publish(
         TopicArn=os.environ['ALERTS_TOPIC_ARN'],
-        Subject='[BUDGET] daily digest',
-        Message=msg,
+        Subject='[BUDGET] daily AWS cost',
+        Message="\n".join(lines),
     )
-    return {'ok': True, 'mtd_inr': mtd_inr, 'pct': pct}
+    return {'ok': True, 'mtd_usd': mtd_usd, 'pct': pct}
 PYEOF
     filename = "index.py"
   }

--- a/deploy/aws/terraform/budget-guards.tf
+++ b/deploy/aws/terraform/budget-guards.tf
@@ -106,16 +106,16 @@ def handler(event, context):
 
     lines = [
         f"{emoji} *AWS Cost — tickvault*",
-        f"_Yesterday_:   ₹{inr(yday_usd):.0f}   (${yday_usd:.2f})",
-        f"_This month_:  ₹{inr(mtd_usd):.0f}   (${mtd_usd:.2f})",
+        f"_Yesterday_:   ₹{inr(yday_usd):.0f}   ($${yday_usd:.2f})",
+        f"_This month_:  ₹{inr(mtd_usd):.0f}   ($${mtd_usd:.2f})",
         f"_Of $25 stop-budget_: {pct:.0f}%",
-        f"_Forecast EOM_: ₹{inr(forecast_usd):.0f}   (${forecast_usd:.2f})",
+        f"_Forecast EOM_: ₹{inr(forecast_usd):.0f}   ($${forecast_usd:.2f})",
         f"_Days left_:   {days_remaining}",
         "",
         "*Where it goes (this month):*",
     ]
     for nice, usd in sorted(by_svc.items(), key=lambda kv: -kv[1]):
-        lines.append(f"  {nice:<16} ₹{inr(usd):.0f}  (${usd:.2f})")
+        lines.append(f"  {nice:<16} ₹{inr(usd):.0f}  ($${usd:.2f})")
     if not by_svc:
         lines.append("  (no spend yet this month)")
 

--- a/docs/operator/aws-cost-truth-2026-06-09.md
+++ b/docs/operator/aws-cost-truth-2026-06-09.md
@@ -1,0 +1,112 @@
+# AWS Cost — The Real Truth (2026-06-09)
+
+> Operator asked: *"is this AWS budget cost correct or wrong? Who is tracking
+> it, how is it calculated? Every day should give the precise AWS cost. I need
+> guarantee + assurance, as an easy comparison table."*
+>
+> This document answers all four — every number is anchored to a `file:line` in
+> the repo or a cited AWS price. Where I cannot confirm a number from this
+> sandbox (no `aws` CLI), I say so plainly. **The ONLY ground-truth for actual
+> spend is your AWS Cost Explorer — which a Lambda already reads daily.**
+
+---
+
+## 1. Who is tracking the cost, and how? (you DO have a tracker — two, in fact)
+
+| # | Tracker | What it does | Source of the number | Where you see it | file:line |
+|---|---|---|---|---|---|
+| A | **AWS Budgets** `tv-prod-monthly-budget` | A hard **$25/month** budget on everything tagged `Project=tickvault`. At **80% forecast** → emails you. At **100% actual** → SNS → **kill-switch Lambda STOPS the EC2 box** + Telegram page. | AWS's own billing engine (authoritative) | AWS console → Billing → Budgets; Telegram on breach | `budget.tf:20,43-49` |
+| B | **Daily Budget Digest** Lambda `tv-prod-daily-budget-digest` | Every **weekday 17:30 IST** reads **real Cost Explorer** spend, converts to ₹ (×85 ×1.18 GST), posts to Telegram: *yesterday ₹X / MTD ₹Y / forecast / days-left*. | **Cost Explorer `get_cost_and_usage`** (real, not an estimate) | Telegram, weekday evenings | `budget-guards.tf:40-78,146` |
+
+**So the cost IS tracked from real AWS billing data — not a guess.** If you are
+not seeing the daily Telegram digest, the likely reason is that **Terraform/deploy
+has been failing** (the same syntax bug I just fixed in PR #1070), so this Lambda
+may not be deployed yet — OR the SNS→Telegram route isn't wired to your chat.
+That is the thing to verify, not the math.
+
+---
+
+## 2. Is the cost "correct or wrong"? — The honest verdict
+
+**The digest's method is correct (real Cost Explorer data). After verifying the
+Terraform, the bill is ROUGHLY RIGHT — my first pass wrongly flagged the Elastic
+IP as a leak; it is actually mandatory + operator-approved. The two remaining
+items are small:**
+
+| # | Item | Finding after verification | Cost impact | Action |
+|---|---|---|---|---|
+| ✅ 1 | Elastic IP | **NOT a leak.** You enabled it on 2026-05-31 (`variables.tf:60-63`) because after the t4g→m8g manual upgrade the instance ENI has auto-assign-public-IP **OFF** — without the EIP the box has **no internet at all** (can't reach Dhan or SSM). Mandatory. | ~₹300/mo (necessary) | **keep** — it's load-bearing. (Stale subnet comment `main.tf:62-66` should be updated to match.) |
+| 🟠 2 | CloudWatch alarms | **25 alarms deployed** (10 free) — real, but removing monitoring on a live trading box to save ₹150 is a bad trade. | +~₹150/mo | keep, or prune only clearly-redundant ones |
+| 🟡 3 | Digest vs budget mismatch | Digest target = **₹2,000** (`budget-guards.tf` `BUDGET_INR`) but the AWS Budget that actually stops the box = **$25** (≈ ₹2,508 w/GST). The "% of target" you see ≠ the kill-switch trigger. | confusing, not costly | align the digest to $25 |
+
+**The one number I still cannot confirm from here:** the m8g.large Mumbai hourly
+rate. The rule file says **$0.06416/hr** (you console-confirmed); public
+aggregators show m8g.large ≈ **$0.0898/hr** (us-east-1; Mumbai usually equal or
+higher). **The daily digest shows the true number — trust that over any estimate.**
+
+---
+
+## 3. The precise per-day cost (verified prices, m8g.large + 30GB + EIP, weekday 08:30–16:30 IST)
+
+Two columns because the instance hourly rate is unconfirmed (see §2). Pick the
+column your digest matches.
+
+| Cost item | Rate (cited) | Per **trading day** (box ON 8h) | Per **off day** (box OFF) |
+|---|---|---|---|
+| EC2 m8g.large | A: $0.06416/h · B: $0.0898/h | **A $0.51 · B $0.72** | $0 (auto-stopped) |
+| EBS gp3 30 GB | $0.0912/GB-mo ⁽¹⁾ | $0.09 | $0.09 (24/7) |
+| Public IPv4 (EIP) | $0.005/hr since Feb-2024 ⁽²⁾ | $0.12 | $0.12 (24/7) |
+| CloudWatch (15 billable alarms) | $0.10/alarm-mo | $0.05 | $0.05 |
+| S3 + SNS + data + Lambdas | free-tier / tiny | $0.02 | $0.02 |
+| **TOTAL / day (pre-GST)** | | **A ≈ $0.79 · B ≈ $1.00** | **≈ $0.28** |
+| **TOTAL / day (₹, +18% GST)** | ×85 ×1.18 | **A ≈ ₹79 · B ≈ ₹100** | **≈ ₹28** |
+
+⁽¹⁾ AWS EBS pricing (base gp3 $0.08, Mumbai ~$0.0912). ⁽²⁾ AWS Public IPv4 charge blog (Feb 1 2024).
+
+### Month roll-up (≈22 trading days + ≈8 off days)
+
+| Scenario | EC2 | EIP | EBS | CW | misc | **Pre-GST/mo** | **₹/mo (+GST)** | vs $25 budget |
+|---|---|---|---|---|---|---|---|---|
+| **A** (rate $0.06416) | $11.3 | $3.65 | $2.74 | $1.50 | $0.50 | **$19.7** | **≈ ₹1,975** | ✅ safe |
+| **B** (rate $0.0898) | $15.8 | $3.65 | $2.74 | $1.50 | $0.50 | **$24.2** | **≈ ₹2,430** | 🟠 near ceiling |
+| **B + heavy manual runs (270h)** | $24.2 | $3.65 | $2.74 | $1.50 | $0.50 | **$32.6** | **≈ ₹3,270** | 🔴 **kill-switch fires** |
+
+**The risk that matters:** with EIP on + 25 alarms + the higher instance rate, a
+month with a lot of manual out-of-window runs can cross **$25 → the kill-switch
+auto-stops your trading box mid-month.** Plugging the EIP + alarm leaks buys back
+the headroom the original plan assumed.
+
+---
+
+## 4. What I recommend (corrected after verifying Terraform)
+
+1. **Keep the EIP.** It is mandatory (no EIP → no internet → dead box). My first
+   pass was wrong to call it a leak; I verified and corrected it. Update the stale
+   subnet comment (`main.tf:62-66`) that still says "no EIP needed".
+2. **Reconcile the digest ceiling:** make the digest's `BUDGET_INR` = the real $25
+   AWS Budget (≈ ₹2,508 w/GST), so "MTD vs target %" matches what actually stops
+   the box. (Safe 1-line change.)
+3. **Enrich the digest** into a per-service table (EC2 / EBS / Elastic IP /
+   CloudWatch split + forecast) so the daily Telegram reads like the §3 table —
+   the "easy comparison anyone understands" you asked for.
+4. **Confirm the digest is live + reaching Telegram** — it depends on a successful
+   Terraform apply (deploy was broken until PR #1070; now fixed).
+5. **CloudWatch alarms (₹150/mo):** leave them — monitoring on a trading box is
+   worth more than the saving. Only prune if you find genuinely duplicate alarms.
+
+**Net:** after verification there is **no safe money to cut** — the ~₹2,000–2,400/mo
+bill is roughly correct. The real win is making the daily digest TRUSTWORTHY and
+READABLE (items 2–4), not cutting cost.
+
+---
+
+## 5. Honest envelope (no hallucination)
+
+- Every repo number here is `file:line`-cited; every AWS price is from an AWS page
+  cited in the chat. **I could not run `aws` from this sandbox**, so I did not read
+  your live bill — the daily digest does that and is the authority.
+- The m8g.large Mumbai hourly rate is the one unconfirmed input; both scenarios are
+  shown so you can match whichever your digest reports.
+- "Guarantee" here = *the tracking mechanism exists and reads real billing data*;
+  the precise rupee number is whatever Cost Explorer reports each evening — not a
+  figure I can promise blind.


### PR DESCRIPTION
## Summary

Makes the **daily AWS-cost Telegram digest** trustworthy + readable — the "automated easy table anyone understands, every day" the operator asked for — and fixes a real correctness gap: the digest's "% used" did **not** match the budget that actually stops the box.

## What the digest looked like before vs after

**Before:** one MTD total vs a hardcoded `₹2000` (≠ the real `$25` AWS Budget → the % was meaningless).

**After** (verified output from a mocked dry-run):
```
🟢 AWS Cost — tickvault
Yesterday:   ₹160   ($1.60)
This month:  ₹160   ($1.60)
Of $25 stop-budget: 6%
Forecast EOM: ₹535   ($5.33)
Days left:   21

Where it goes (this month):
  EC2 compute      ₹1133  ($11.30)
  Public IP / VPC  ₹366   ($3.65)
  EBS + transfer   ₹275   ($2.74)
  CloudWatch       ₹150   ($1.50)
```

## Changes (`deploy/aws/terraform/budget-guards.tf`, Lambda body)

| Change | Why |
|---|---|
| Compare MTD **UnblendedCost (pre-GST USD)** against `BUDGET_USD = 25.0` | The kill-switch fires at the `$25` AWS Budget (`budget.tf:20`); now the digest's "% of stop-budget" matches it **exactly** (was rupees-with-GST vs a separate ₹2000) |
| **Per-service breakdown** via Cost Explorer `GroupBy=SERVICE` | EC2 / EBS / Public IP / CloudWatch / S3 / SNS / Lambda / KMS — each in ₹ (w/GST) **and** $, sorted by spend |
| Show yesterday + MTD + forecast in **both ₹ and $** | ₹ = wallet (incl GST); $ = budget (pre-GST) |

## Also: `docs/operator/aws-cost-truth-2026-06-09.md`

Full file:line-cited cost audit. **Honest correction included:** my first pass flagged the Elastic IP as a leak — I verified the Terraform and it is **mandatory + operator-approved (2026-05-31)**: after the t4g→m8g upgrade the ENI has auto-assign-public-IP OFF, so without the EIP the box has no internet (no Dhan, no SSM). The bill is roughly right (~₹2,000–2,400/mo); the real win is this readable digest, not a cost cut.

## Verification

- Extracted the heredoc Python, `compile()`-checked it, and **dry-ran `handler()`** with a mocked Cost Explorer + SNS → produces the message above (no AWS needed for this check).
- No other file references the removed fields (`BUDGET_INR`, `today_inr`, `mtd_inr`, old subject).
- `terraform fmt`/`plan` run in CI; the live Lambda deploys on the next `terraform apply`.

## Honest envelope

I have no `aws` CLI here, so I did **not** run the real Lambda against your live account — the dry-run proves the logic + message; the real numbers appear when it runs at 17:30 IST. The Cost Explorer `SERVICE` names are mapped by substring; any unmapped service falls through with its raw AWS name (still shown, never dropped).

https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc

---
_Generated by [Claude Code](https://claude.ai/code/session_013Dcrz5od4DQT131vLKJFPc)_