### PR TITLE
fix(ci): unbreak chronic Coverage-and-Perf red + Claude workflow inputs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,6 +28,9 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
+    # claude-code-action v1 dropped the `timeout_minutes` input — the
+    # job-level timeout below bounds the run instead.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -43,4 +46,3 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
-          timeout_minutes: 30

--- a/.github/workflows/claude-mobile-command.yml
+++ b/.github/workflows/claude-mobile-command.yml
@@ -83,13 +83,16 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          timeout_minutes: 25
           # Inherit the universal .mcp.json at repo root — attaches
           # github, postgres, and tickvault-logs MCP servers so the
           # mobile command can query logs, metrics, QuestDB, Grafana
           # without extra setup.
-          mcp_config: .mcp.json
-          direct_prompt: |
+          # (claude-code-action v1 dropped the `mcp_config`,
+          # `direct_prompt` and `timeout_minutes` inputs — config now
+          # flows through `claude_args`/`prompt`; the 30-minute
+          # job-level timeout-minutes bounds the run.)
+          claude_args: "--mcp-config .mcp.json"
+          prompt: |
             # Mobile Command — Run ${{ github.run_id }}
 
             ## Operator instruction (verbatim)

--- a/.github/workflows/claude-triage-loop.yml
+++ b/.github/workflows/claude-triage-loop.yml
@@ -72,15 +72,36 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Fail-soft when the ANTHROPIC_API_KEY secret is absent/empty:
+      # without this guard the schedule fires every 10 minutes and every
+      # run goes RED (observed 2026-06-09/10 — chronic failure noise on
+      # main). A missing key is an operator-setup state, not a code
+      # failure, so we annotate loudly and skip instead of failing.
+      - name: Check ANTHROPIC_API_KEY is configured
+        id: keycheck
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning title=Triage loop skipped::ANTHROPIC_API_KEY repo secret is empty — add it in Settings > Secrets and variables > Actions to enable the zero-touch triage loop."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Claude Co-work triage pass
+        if: steps.keycheck.outputs.present == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          timeout_minutes: 9
           # Inherit the repo's universal .mcp.json — attaches github,
           # postgres, and tickvault-logs MCP servers automatically.
-          mcp_config: .mcp.json
-          direct_prompt: |
+          # (claude-code-action v1 dropped the `mcp_config`,
+          # `direct_prompt` and `timeout_minutes` inputs — config now
+          # flows through `claude_args`/`prompt`; the 10-minute
+          # job-level timeout-minutes bounds the pass.)
+          claude_args: "--mcp-config .mcp.json"
+          prompt: |
             You are the tickvault 24/7 zero-touch operator. Follow the
             runbook at `.claude/triage/claude-loop-prompt.md` EXACTLY —
             do not re-implement its logic.

--- a/crates/api/src/handlers/debug.rs
+++ b/crates/api/src/handlers/debug.rs
@@ -241,7 +241,27 @@ async fn read_text_file(
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Process-global env-var lock. Plain `cargo test` runs every `#[test]`
+    /// in this binary as a parallel THREAD of ONE process, and
+    /// `LOGS_DIR_ENV` / `SPILL_DIR_ENV` are process-global state — two
+    /// tests mutating them concurrently race. Reproduced locally at 3/60
+    /// runs (`spill_status_reports_real_counts_when_dir_populated` reads
+    /// `"exists":false` after its sibling swaps the var); on CI this was
+    /// the chronic "Coverage & Perf" red, because that job runs plain
+    /// `cargo test` under llvm-cov while the green Test (api) job uses
+    /// nextest, whose process-per-test isolation masks the race.
+    /// Every test that sets/removes/depends-on these vars takes this lock
+    /// first. Poison is swallowed so one failing test doesn't cascade.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 
     /// Minimal tempdir helper — avoids pulling in the `tempfile` crate
     /// (which isn't in the workspace deps). Returns a unique
@@ -271,9 +291,9 @@ mod tests {
 
     #[test]
     fn resolve_logs_dir_respects_env_override() {
-        // Safety: tests run serially per #[test] and read env vars.
-        // SAFETY: set_var/remove_var require a mutable environment which
-        // is safe within a single-threaded test execution.
+        let _env = env_guard();
+        // SAFETY: set_var/remove_var mutate the process environment; the
+        // ENV_LOCK guard above serializes every test that touches it.
         unsafe {
             std::env::set_var(LOGS_DIR_ENV, "/tmp/tickvault-debug-test");
         }
@@ -286,6 +306,7 @@ mod tests {
 
     #[test]
     fn resolve_logs_dir_default_when_env_unset() {
+        let _env = env_guard();
         unsafe {
             std::env::remove_var(LOGS_DIR_ENV);
         }
@@ -295,6 +316,7 @@ mod tests {
 
     #[test]
     fn resolve_logs_dir_ignores_whitespace_env() {
+        let _env = env_guard();
         unsafe {
             std::env::set_var(LOGS_DIR_ENV, "   ");
         }
@@ -365,6 +387,7 @@ mod tests {
 
     #[tokio::test]
     async fn logs_summary_returns_404_when_file_missing() {
+        let _env = env_guard();
         unsafe {
             std::env::set_var(LOGS_DIR_ENV, "/nonexistent-tickvault-logs-test");
         }
@@ -377,6 +400,7 @@ mod tests {
 
     #[tokio::test]
     async fn logs_jsonl_latest_returns_404_when_dir_empty() {
+        let _env = env_guard();
         let tmp = mktemp("test");
         unsafe {
             std::env::set_var(LOGS_DIR_ENV, tmp.path().to_str().unwrap());
@@ -390,6 +414,7 @@ mod tests {
 
     #[test]
     fn resolve_spill_dir_default_when_env_unset() {
+        let _env = env_guard();
         unsafe {
             std::env::remove_var(SPILL_DIR_ENV);
         }
@@ -398,6 +423,7 @@ mod tests {
 
     #[test]
     fn resolve_spill_dir_respects_env_override() {
+        let _env = env_guard();
         unsafe {
             std::env::set_var(SPILL_DIR_ENV, "/tmp/tv-spill-test");
         }
@@ -438,6 +464,7 @@ mod tests {
 
     #[tokio::test]
     async fn spill_status_returns_200_with_categories_even_when_dir_missing() {
+        let _env = env_guard();
         unsafe {
             std::env::set_var(SPILL_DIR_ENV, "/nonexistent/spill-test-dir-xyz");
         }
@@ -459,6 +486,7 @@ mod tests {
 
     #[tokio::test]
     async fn spill_status_reports_real_counts_when_dir_populated() {
+        let _env = env_guard();
         let tmp = mktemp("spill_status");
         // Create category subdirs with one bin each
         for kind in ["ticks", "candles", "depth"] {


### PR DESCRIPTION
## Summary

Every `main` push since at least 2026-06-08 has shown a red ✗, and the scheduled triage loop has failed every 10-minute cycle. This PR removes both chronic red signals at their root cause:

1. **`Coverage & Perf` (post-merge CI job) — red on every main push since 2026-06-08.**
   Root cause: 9 tests in `crates/api/src/handlers/debug.rs` mutate the process-global env vars `TICKVAULT_LOGS_DIR` / `TICKVAULT_SPILL_DIR` with `set_var`/`remove_var` and **no serialization**. The green `Test (api)` job uses **nextest** (process-per-test isolation → race invisible). The Coverage job runs **plain `cargo test` under cargo-llvm-cov** (all tests = parallel threads of ONE process → race fires). The in-code comment claiming "tests run serially per #[test]" was factually wrong.
   Fix: a `static ENV_LOCK: Mutex<()>` in the test module; all 9 env-touching tests take the guard first (poison-tolerant so one failure can't cascade).

2. **`Claude Triage Loop` — red every 10 minutes, 24/7.** Two stacked causes:
   - `anthropics/claude-code-action@v1` **removed** the `direct_prompt`, `mcp_config`, and `timeout_minutes` inputs (run logs show "Unexpected input(s)" warnings — the prompt was being silently ignored). Migrated to the supported `prompt:` + `claude_args: "--mcp-config .mcp.json"`; timeouts ride the job-level `timeout-minutes`. Same migration applied to `claude-mobile-command.yml` and `claude-code-review.yml`.
   - The **`ANTHROPIC_API_KEY` repo secret is empty** (visible in the run-log env dump). A missing key is an operator-setup state, not a code failure, so the triage loop now fail-softs: a guard step emits a loud `::warning` annotation and skips instead of going red 144×/day. **Operator action still required:** add `ANTHROPIC_API_KEY` in Settings → Secrets and variables → Actions to actually enable the loop.

## Root-cause evidence (real, reproduced — no hallucination)

- CI run [27214748019](https://github.com/SJParthi/tickvault/actions/runs/27214748019) (main @ 7da2348): 10 jobs green, ONLY `Coverage & Perf` red. Failure line from run 27211623963 logs: `error: 1 target failed: -p tickvault-api --lib` (exit 101), while the same commit's nextest `Test (api)` job passed.
- **Race reproduced locally pre-fix:** `cargo test -p tickvault-api --lib handlers::debug` in a 60× loop → **3/60 runs FAILED**, failing test captured verbatim:
  `handlers::debug::tests::spill_status_reports_real_counts_when_dir_populated panicked at crates/api/src/handlers/debug.rs:478: assertion failed: body_str.contains("\"exists\":true")` — its sibling test had concurrently swapped `SPILL_DIR_ENV`.
- **Post-fix:** same 60× loop → **0/60 failures**; full `tickvault-api --lib` green under `-C instrument-coverage` (the coverage job's instrumentation): `test result: ok. 182 passed; 0 failed`.
- Triage-loop log (run 27246643970): `ANTHROPIC_API_KEY:` empty in env dump + `Unexpected input(s) 'timeout_minutes', 'mcp_config', 'direct_prompt'`.

## Zero-Loss Guarantee Charter check (`.claude/rules/project/zero-loss-guarantee-charter.md`)

### Coverage (§2) — proof, not claim
- [x] Code coverage: no test deleted; 9 tests hardened; this PR is what lets the 100% coverage gate RUN again (it has produced no coverage.json for days)
- [x] Audit coverage: N/A — no new event class; no schema change
- [x] Testing coverage: unit (the 9 hardened tests) + concurrency (the race itself; 60×-loop evidence above)
- [x] Security: no secret exposure — the key-guard step does an empty-string check only, never prints the key
- [x] Monitoring: N/A — no runtime code path changed
- [x] Logging: N/A — no `error!` sites changed
- [x] Alerting: the `::warning` annotation replaces 144 red runs/day of noise with one loud actionable signal
- [x] Scenarios/edge: race scenario pinned by the ENV_LOCK pattern + doc comment explaining the nextest-vs-cargo-test divergence
- [x] Performance: N/A — not hot path (test-only + CI YAML)
- [x] Recovery: N/A — rescue→spill→DLQ untouched
- [x] Functionalities: `env_guard()` is test-internal and called by all 9 tests
- [x] Extreme check: the Coverage & Perf job itself is the regression ratchet — it re-runs plain `cargo test` under llvm-cov on every future main push

### Zero-loss / resilience (§1 envelope) — honest, bounded
- [x] No new tick-drop path (no production code touched)
- [x] WS SubscribeRxGuard + pool watchdog unchanged
- [x] No new hot-path allocation — zero production-code changes
- [x] No inflated O(1) claims
- [x] QuestDB schema self-heal preserved (untouched)
- [x] Composite (security_id, exchange_segment) uniqueness untouched

### Evidence (§4 — NO HALLUCINATION)
- [x] Real test output pasted above (3/60 pre-fix FAIL, 0/60 post-fix, `test result: ok. 182 passed; 0 failed`)
- [x] Real CI run links + verbatim log lines above
- [x] "100%" wording carries the envelope qualifier below

### Review
- [x] Adversarial multi-agent pass: hot-path-reviewer (CLEAN on the recent TICK-SEQ-01 chain — `next_frame_seq`/`append_with_seq`/`build_tick_row_seq` verified zero-alloc O(1)), targeted security checks (WAL file naming = internal counter, no traversal; ILP symbols via typed questdb-rs API from fixed internal mappings; SSM quoting covered by the green "Deploy Lint" CI gate), hostile root-cause hunt (this investigation)

## Honest 100% claim

100% inside the tested envelope, with ratcheted regression coverage: the env race is eliminated by construction (one process-wide mutex serializes all 9 env-mutating tests — reproduced 3/60 pre-fix, 0/60 post-fix across 60 randomized-interleaving runs); the Coverage & Perf job re-validates on every future main push. Beyond the envelope: the triage loop stays SKIPPED (with a loud warning) until the operator adds the `ANTHROPIC_API_KEY` secret — code cannot conjure a missing credential.

## Test plan
- [x] `cargo fmt -p tickvault-api -- --check` clean
- [x] `cargo test -p tickvault-api --lib` green (182/182), including under `-C instrument-coverage`
- [x] 60× post-fix race loop: 0 failures
- [ ] CI on this PR fully green before merge (auto-merge armed; monitored to completion)

## Operator action needed (cannot be done from code)
1. Add `ANTHROPIC_API_KEY` in repo Settings → Secrets and variables → Actions (re-enables triage loop + mobile command + @claude review).
2. Optional: the `TICKVAULT_TUNNEL_*` secrets are also empty — triage MCP stays OFFLINE-graceful until set.

https://claude.ai/code/session_016tFBc4wN6D4bXBi1kZRZEo

---
_Generated by [Claude Code](https://claude.ai/code/session_016tFBc4wN6D4bXBi1kZRZEo)_