### PR TITLE
feat(mcp): automated CloudWatch prod-log read access for Claude sessions

### DIFF
--- a/scripts/mcp-servers/tickvault-logs/server.py
+++ b/scripts/mcp-servers/tickvault-logs/server.py
@@ -785,6 +785,141 @@ def tool_app_log_tail(
     }
 
 
+# ---------------------------------------------------------------------------
+# CloudWatch Logs (PROD) — fully-automated read access for Claude sessions.
+# ---------------------------------------------------------------------------
+#
+# Goal (operator 2026-06-12): "whenever logs need to be read it must be
+# automatic — no per-read permission, no human effort." This tool gives any
+# Claude session direct, read-only access to the prod CloudWatch log group
+# (/tickvault/prod/app) so the operator never pastes/downloads a CSV again.
+#
+# HONEST one-time setup (the ONLY human step, ever — a security boundary that
+# cannot be coded away): read-only AWS credentials must exist in the session
+# environment so the `aws` CLI can call CloudWatch Logs. Wire ONCE via the
+# Claude Code environment config:
+#   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for a read-only IAM user scoped
+#     to logs:FilterLogEvents + logs:GetLogEvents on
+#     arn:aws:logs:ap-south-1:*:log-group:/tickvault/prod/*
+#   - AWS_REGION (default ap-south-1) + the `aws` CLI on PATH.
+# After that: every session reads prod logs automatically, zero further effort.
+
+
+def _cloudwatch_log_group() -> str:
+    return os.environ.get("TICKVAULT_CLOUDWATCH_LOG_GROUP", "/tickvault/prod/app")
+
+
+def _aws_region() -> str:
+    return os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "ap-south-1"
+
+
+def build_cloudwatch_filter_args(
+    log_group: str,
+    region: str,
+    start_ms: int,
+    limit: int,
+    filter_pattern: str | None,
+) -> list[str]:
+    """Pure builder for the `aws logs filter-log-events` argv (unit-testable
+    without AWS access). `filter_pattern` is a CloudWatch filter pattern, e.g.
+    `"ERROR"` or `"WS-GAP-05"`. Empty/None means no server-side filter.
+    """
+    args = [
+        "aws",
+        "logs",
+        "filter-log-events",
+        "--region",
+        region,
+        "--log-group-name",
+        log_group,
+        "--start-time",
+        str(int(start_ms)),
+        "--limit",
+        str(max(1, min(int(limit), 10000))),
+        "--output",
+        "json",
+    ]
+    if filter_pattern:
+        args += ["--filter-pattern", filter_pattern]
+    return args
+
+
+def parse_cloudwatch_events(stdout: str, limit: int) -> list[dict[str, Any]]:
+    """Pure parser: turn `aws logs filter-log-events` JSON into a compact list
+    of `{ts_ms, stream, message}` (newest last), trimmed to `limit`.
+    """
+    try:
+        payload = json.loads(stdout) if stdout.strip() else {}
+    except json.JSONDecodeError:
+        return []
+    events = payload.get("events", []) if isinstance(payload, dict) else []
+    out: list[dict[str, Any]] = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        out.append(
+            {
+                "ts_ms": ev.get("timestamp"),
+                "stream": ev.get("logStreamName"),
+                "message": (ev.get("message") or "").rstrip("\n"),
+            }
+        )
+    out.sort(key=lambda e: e.get("ts_ms") or 0)
+    return out[-int(limit):] if limit > 0 else out
+
+
+def tool_cloudwatch_logs(
+    minutes: int = 60,
+    filter_pattern: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Read recent events from the prod CloudWatch log group
+    (/tickvault/prod/app) via the read-only `aws` CLI. Looks back `minutes`,
+    optional CloudWatch `filter_pattern` (e.g. `"ERROR"` or `"WS-GAP-05"`),
+    returns up to `limit` newest events. Requires read-only AWS creds in the
+    environment (one-time setup, see note above); fails clearly if absent.
+    """
+    import subprocess
+    import time as _time
+
+    region = _aws_region()
+    group = _cloudwatch_log_group()
+    start_ms = int((_time.time() - max(1, int(minutes)) * 60) * 1000)
+    argv = build_cloudwatch_filter_args(group, region, start_ms, limit, filter_pattern)
+    try:
+        proc = subprocess.run(
+            argv, check=False, capture_output=True, text=True, timeout=30
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "error": "aws CLI not on PATH — wire the read-only AWS credential + aws CLI "
+            "into the session environment once (see CloudWatch setup note in server.py).",
+            "log_group": group,
+        }
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "aws logs filter-log-events timed out after 30s"}
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "exit_code": proc.returncode,
+            "error": "aws logs call failed — most likely no read-only AWS credentials in "
+            "this environment yet (the one-time setup). stderr below.",
+            "stderr": proc.stderr.strip()[:800],
+            "log_group": group,
+        }
+    events = parse_cloudwatch_events(proc.stdout, limit)
+    return {
+        "ok": True,
+        "log_group": group,
+        "region": region,
+        "lookback_minutes": int(minutes),
+        "filter_pattern": filter_pattern or "",
+        "returned": len(events),
+        "events": events,
+    }
+
+
 @dataclass
 class ToolSpec:
     name: str
@@ -1060,6 +1195,41 @@ TOOLS: list[ToolSpec] = [
         handler=lambda args: tool_app_log_tail(
             limit=int(args.get("limit", 100)),
             date=args.get("date"),
+        ),
+    ),
+    ToolSpec(
+        name="cloudwatch_logs",
+        description=(
+            "Read recent PROD logs directly from the CloudWatch log group "
+            "/tickvault/prod/app — fully automated, no human paste/download. "
+            "Args: minutes (lookback, default 60), filter_pattern (optional "
+            "CloudWatch pattern e.g. \"ERROR\" or \"WS-GAP-05\"), limit "
+            "(default 100). Requires read-only AWS creds in the environment "
+            "(one-time setup); returns a clear error if absent."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "minutes": {
+                    "type": "integer",
+                    "description": "Lookback window in minutes (default 60)",
+                    "default": 60,
+                },
+                "filter_pattern": {
+                    "type": "string",
+                    "description": "Optional CloudWatch filter pattern (e.g. ERROR)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max events (default 100)",
+                    "default": 100,
+                },
+            },
+        },
+        handler=lambda args: tool_cloudwatch_logs(
+            minutes=int(args.get("minutes", 60)),
+            filter_pattern=args.get("filter_pattern"),
+            limit=int(args.get("limit", 100)),
         ),
     ),
 ]

--- a/scripts/mcp-servers/tickvault-logs/test_cloudwatch_logs.py
+++ b/scripts/mcp-servers/tickvault-logs/test_cloudwatch_logs.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Standalone tests for the cloudwatch_logs MCP tool's PURE helpers.
+
+Stdlib-only, no AWS access required (mirrors test_placeholder_fallback.py).
+Run: python3 test_cloudwatch_logs.py  (exit 0 = pass, 1 = fail)
+
+Verifies the argv builder + JSON parser + the graceful no-credentials path,
+so the fully-automated CloudWatch read access has ratcheted coverage even
+though the live `aws` call can only be exercised on a credentialed host.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import server
+
+failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        failures.append(msg)
+
+
+# --- build_cloudwatch_filter_args ---
+args = server.build_cloudwatch_filter_args(
+    "/tickvault/prod/app", "ap-south-1", 1_700_000_000_000, 50, "ERROR"
+)
+check(args[:3] == ["aws", "logs", "filter-log-events"], f"argv prefix: {args[:3]}")
+check("/tickvault/prod/app" in args, "log group missing from argv")
+check("ap-south-1" in args, "region missing from argv")
+check("ERROR" in args and "--filter-pattern" in args, "filter pattern missing")
+
+args_no_filter = server.build_cloudwatch_filter_args("/g", "r", 1, 5, None)
+check("--filter-pattern" not in args_no_filter, "filter flag present with no pattern")
+
+args_clamp = server.build_cloudwatch_filter_args("/g", "r", 1, 999_999, None)
+limit_val = args_clamp[args_clamp.index("--limit") + 1]
+check(limit_val == "10000", f"limit not clamped to 10000: {limit_val}")
+
+# --- parse_cloudwatch_events (sorted oldest..newest, trimmed) ---
+sample = json.dumps(
+    {
+        "events": [
+            {"timestamp": 2, "logStreamName": "s", "message": "b\n"},
+            {"timestamp": 1, "logStreamName": "s", "message": "a"},
+        ]
+    }
+)
+evs = server.parse_cloudwatch_events(sample, 100)
+check([e["message"] for e in evs] == ["a", "b"], f"events not sorted oldest..newest: {evs}")
+check(server.parse_cloudwatch_events("not json", 10) == [], "bad json should parse to []")
+check(server.parse_cloudwatch_events("", 10) == [], "empty should parse to []")
+
+trimmed = server.parse_cloudwatch_events(
+    json.dumps({"events": [{"timestamp": i, "message": str(i)} for i in range(5)]}), 2
+)
+check([e["message"] for e in trimmed] == ["3", "4"], f"limit-trim keeps newest: {trimmed}")
+
+# --- graceful failure when no aws CLI / creds (must NOT crash) ---
+result = server.tool_cloudwatch_logs(minutes=5, limit=3)
+check(result.get("ok") is False, f"expected ok=False without creds: {result}")
+check("log_group" in result, "error result should still report the log_group")
+check(bool(result.get("error")), "error result should carry a human-readable message")
+
+if failures:
+    print("FAIL:")
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print("cloudwatch_logs helper tests: ALL PASS")
+sys.exit(0)


### PR DESCRIPTION
## Summary
Operator request (2026-06-12): **log reads must be automatic — no per-read permission, no human effort.** Adds a `cloudwatch_logs` tool to the `tickvault-logs` MCP server so any Claude session reads the prod log group `/tickvault/prod/app` **directly**, instead of the operator pasting/downloading CSVs.

## What it does
- New MCP tool **`cloudwatch_logs`** (args: `minutes` lookback, optional `filter_pattern` e.g. `"ERROR"`/`"WS-GAP-05"`, `limit`) → reads CloudWatch via the read-only `aws logs filter-log-events`, returns compact `{ts_ms, stream, message}` events newest-last.
- Stdlib-only (matches the server's zero-pip-dep design); uses the existing subprocess pattern.
- **Pure, unit-tested helpers:** `build_cloudwatch_filter_args` (argv builder + limit clamp) and `parse_cloudwatch_events` (JSON → sorted/trimmed events) — `test_cloudwatch_logs.py`, no AWS needed.
- **Fails gracefully:** with no `aws` CLI / no creds it returns `ok:false` + a clear "wire the one-time read-only credential" message — never crashes, never fakes success.

## The one HONEST caveat (no hallucination)
Reading **private AWS logs requires a credential to exist** — a security wall that **cannot be coded away**. So:
- **Per-read effort = ZERO** ✅ (no asking the operator each time — the goal)
- **One-time setup = ONE step:** a **read-only** IAM credential scoped to `logs:FilterLogEvents` on `/tickvault/prod/*` wired into the session environment **once** → then every future session auto-reads prod logs, hands-off forever.

This is documented in-code (server.py CloudWatch setup note) + the tool description. **I cannot verify the live AWS call from the dev sandbox** (no creds there — proven by the graceful-failure test); first credentialed use confirms it.

## Scope
Infra/tooling only — `scripts/mcp-servers/tickvault-logs/server.py` (+170) + a new test. No app code, no crates, no hot path.

## Test plan
- [x] `python3 test_cloudwatch_logs.py` → ALL PASS (argv builder, limit clamp, parser sort/trim, bad-JSON → [], graceful no-cred failure)
- [x] `python3 -c "import server"` clean

https://claude.ai/code/session_01VSTGZ288QaQe86m5TTMoys

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSTGZ288QaQe86m5TTMoys)_