### PR TITLE
feat(mcp): direct CloudWatch SigV4 log reader (read-only AWS key, no aws CLI/portal)

### DIFF
--- a/scripts/mcp-servers/tickvault-logs/server.py
+++ b/scripts/mcp-servers/tickvault-logs/server.py
@@ -813,6 +813,183 @@ def _aws_region() -> str:
     return os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "ap-south-1"
 
 
+def _aws_credentials() -> tuple[str, str, str | None]:
+    """(access_key, secret_key, session_token|None) from the standard env vars.
+    Empty strings if absent. This is the ONLY thing needed to read CloudWatch
+    directly — no aws CLI, no portal."""
+    return (
+        os.environ.get("AWS_ACCESS_KEY_ID", ""),
+        os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+        os.environ.get("AWS_SESSION_TOKEN") or None,
+    )
+
+
+def _sigv4_signing_key(secret: str, date_stamp: str, region: str, service: str) -> bytes:
+    """Derive the AWS SigV4 signing key (HMAC chain). Pure — unit-testable
+    against AWS's published test vectors."""
+    import hashlib  # noqa: PLC0415
+    import hmac  # noqa: PLC0415
+
+    def _h(key: bytes, msg: str) -> bytes:
+        return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+    k_date = _h(("AWS4" + secret).encode("utf-8"), date_stamp)
+    k_region = _h(k_date, region)
+    k_service = _h(k_region, service)
+    return _h(k_service, "aws4_request")
+
+
+def build_cloudwatch_sigv4_request(
+    region: str,
+    log_group: str,
+    start_ms: int,
+    limit: int,
+    filter_pattern: str | None,
+    access_key: str,
+    secret_key: str,
+    session_token: str | None,
+    amz_now,
+) -> tuple[str, bytes, dict[str, str]]:
+    """Pure builder for a SigV4-signed CloudWatch Logs `FilterLogEvents` POST.
+    Returns `(url, body_bytes, headers)`. `amz_now` is a `datetime` (UTC) so the
+    signing is deterministic + testable. No network, no aws CLI, no boto3."""
+    import hashlib  # noqa: PLC0415
+    import hmac  # noqa: PLC0415
+
+    service = "logs"
+    host = f"logs.{region}.amazonaws.com"
+    url = f"https://{host}/"
+    amz_date = amz_now.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = amz_now.strftime("%Y%m%d")
+    target = "Logs_20140328.FilterLogEvents"
+    content_type = "application/x-amz-json-1.1"
+
+    body_obj: dict[str, Any] = {
+        "logGroupName": log_group,
+        "startTime": int(start_ms),
+        "limit": max(1, min(int(limit), 10000)),
+    }
+    if filter_pattern:
+        body_obj["filterPattern"] = filter_pattern
+    body = json.dumps(body_obj, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(body).hexdigest()
+
+    # Canonical headers MUST be sorted by lowercase name. Build a list and sort,
+    # so x-amz-security-token slots into the correct position (before x-amz-target,
+    # since "...se" < "...ta") when a session token is present — an out-of-order
+    # canonical header set yields an invalid signature (AWS 403).
+    header_pairs: list[tuple[str, str]] = [
+        ("content-type", content_type),
+        ("host", host),
+        ("x-amz-content-sha256", payload_hash),
+        ("x-amz-date", amz_date),
+        ("x-amz-target", target),
+    ]
+    if session_token:
+        header_pairs.append(("x-amz-security-token", session_token))
+    header_pairs.sort(key=lambda kv: kv[0])
+    canon_headers = "".join(f"{name}:{value}\n" for name, value in header_pairs)
+    signed_headers = ";".join(name for name, _ in header_pairs)
+
+    canonical_request = (
+        f"POST\n/\n\n{canon_headers}\n{signed_headers}\n{payload_hash}"
+    )
+    scope = f"{date_stamp}/{region}/{service}/aws4_request"
+    string_to_sign = (
+        "AWS4-HMAC-SHA256\n"
+        f"{amz_date}\n"
+        f"{scope}\n"
+        f"{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
+    )
+    signing_key = _sigv4_signing_key(secret_key, date_stamp, region, service)
+    signature = hmac.new(
+        signing_key, string_to_sign.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    authorization = (
+        f"AWS4-HMAC-SHA256 Credential={access_key}/{scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+    headers = {
+        "Content-Type": content_type,
+        "X-Amz-Date": amz_date,
+        "X-Amz-Content-Sha256": payload_hash,
+        "X-Amz-Target": target,
+        "Authorization": authorization,
+    }
+    if session_token:
+        headers["X-Amz-Security-Token"] = session_token
+    return url, body, headers
+
+
+def _tool_cloudwatch_logs_via_sigv4(
+    minutes: int, filter_pattern: str | None, limit: int
+) -> dict[str, Any]:
+    """Direct CloudWatch Logs read via SigV4-signed HTTPS — the path the
+    operator wants: drop an AWS read-only key in the env and logs flow, no aws
+    CLI, no portal. Uses stdlib only. Single-page (no nextToken paging): returns
+    up to `limit` (server-capped at 10000, and one response page is ~1 MB), which
+    is ample for a 'recent logs' tail."""
+    import datetime as _dt  # noqa: PLC0415
+    import time as _time  # noqa: PLC0415
+    import urllib.request  # noqa: PLC0415
+
+    import re as _re  # noqa: PLC0415
+
+    region = _aws_region()
+    group = _cloudwatch_log_group()
+    # Validate region charset before it lands in the request host — a region
+    # with `/`, `@`, `:` etc. would build a malformed/attacker-shaped host.
+    # AWS region names are only lowercase letters, digits and hyphens.
+    if not _re.fullmatch(r"[a-z0-9-]+", region):
+        return {
+            "ok": False,
+            "source": "cloudwatch_sigv4",
+            "log_group": group,
+            "error": "invalid AWS region — set AWS_DEFAULT_REGION to a region like "
+            "ap-south-1 (lowercase letters, digits, hyphens only).",
+        }
+    access_key, secret_key, session_token = _aws_credentials()
+    start_ms = int((_time.time() - max(1, int(minutes)) * 60) * 1000)
+    url, body, headers = build_cloudwatch_sigv4_request(
+        region,
+        group,
+        start_ms,
+        limit,
+        filter_pattern,
+        access_key,
+        secret_key,
+        session_token,
+        _dt.datetime.now(_dt.timezone.utc),
+    )
+    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 — signed https to AWS
+            payload = resp.read().decode("utf-8", "replace")
+    except Exception as exc:  # noqa: BLE001 — surface as ok=False, never crash
+        # Bound the exception text and use only the type + a short str — never
+        # the request object — so a future stdlib change can't echo a signed
+        # header (the secret is not in any header, but defence-in-depth).
+        return {
+            "ok": False,
+            "source": "cloudwatch_sigv4",
+            "log_group": group,
+            "region": region,
+            "error": f"CloudWatch FilterLogEvents failed: {type(exc).__name__}: "
+            f"{str(exc)[:300]}",
+        }
+    events = parse_cloudwatch_events(payload, limit)
+    return {
+        "ok": True,
+        "source": "cloudwatch_sigv4",
+        "log_group": group,
+        "region": region,
+        "lookback_minutes": int(minutes),
+        "filter_pattern": filter_pattern or "",
+        "returned": len(events),
+        "events": events,
+    }
+
+
 def build_cloudwatch_filter_args(
     log_group: str,
     region: str,
@@ -998,17 +1175,28 @@ def tool_cloudwatch_logs(
     filter_pattern: str | None = None,
     limit: int = 100,
 ) -> dict[str, Any]:
-    """Read recent prod logs, fully automated. PREFERRED path: the existing
-    operator-control portal's `logs` endpoint (set TICKVAULT_PORTAL_URL +
-    TICKVAULT_PORTAL_TOKEN — no aws CLI, no AWS key; the portal Lambda reads the
-    box with its own role). FALLBACK: the read-only `aws` CLI on the
-    /tickvault/prod/app CloudWatch group. Looks back `minutes` (aws path only),
-    optional `filter_pattern`, up to `limit` newest events. Fails clearly if
-    neither path is configured."""
+    """Read recent prod logs, fully automated. PREFERRED path: direct CloudWatch
+    read via a SigV4-signed HTTPS call — the ONLY input is a read-only AWS key in
+    the env (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY [+ AWS_SESSION_TOKEN];
+    no aws CLI, no portal, no boto3). NEXT: the operator-control portal's `logs`
+    endpoint (set TICKVAULT_PORTAL_URL + TICKVAULT_PORTAL_TOKEN — the portal
+    Lambda reads the box with its own role). FALLBACK: the read-only `aws` CLI on
+    the /tickvault/prod/app CloudWatch group. Looks back `minutes` (SigV4 + aws
+    paths), optional `filter_pattern` (server-side CloudWatch filter on the SigV4
+    + aws paths; substring on the portal path), up to `limit` newest events.
+    Fails clearly (ok=False) if none of the three paths is configured. The AWS
+    secret/token is NEVER logged nor placed in the returned dict."""
     import subprocess
     import time as _time
 
-    # PREFERRED: reuse the operator dashboard's already-working logs endpoint.
+    # PREFERRED (operator goal): direct CloudWatch read with a SigV4-signed
+    # HTTPS request — only a read-only AWS key in the env is needed. Chosen
+    # first whenever both key parts are present (no aws CLI, no portal).
+    access_key, secret_key, _session_token = _aws_credentials()
+    if access_key and secret_key:
+        return _tool_cloudwatch_logs_via_sigv4(minutes, filter_pattern, limit)
+
+    # NEXT: reuse the operator dashboard's already-working logs endpoint.
     if _portal_url() and _portal_token():
         return _tool_cloudwatch_logs_via_portal(filter_pattern, limit)
 
@@ -1023,10 +1211,11 @@ def tool_cloudwatch_logs(
     except FileNotFoundError:
         return {
             "ok": False,
-            "error": "no log reader configured — set TICKVAULT_PORTAL_URL + "
-            "TICKVAULT_PORTAL_TOKEN to read via the existing operator dashboard "
-            "(no aws CLI / no AWS key needed), OR wire a read-only AWS credential "
-            "+ aws CLI. Neither is present in this session.",
+            "error": "no log reader configured — set AWS_ACCESS_KEY_ID + "
+            "AWS_SECRET_ACCESS_KEY (+ AWS_DEFAULT_REGION) for the direct SigV4 "
+            "path (no aws CLI, no portal), OR set TICKVAULT_PORTAL_URL + "
+            "TICKVAULT_PORTAL_TOKEN to read via the operator dashboard, OR wire "
+            "a read-only AWS credential + aws CLI. None is present in this session.",
             "log_group": group,
         }
     except subprocess.TimeoutExpired:
@@ -1036,7 +1225,8 @@ def tool_cloudwatch_logs(
             "ok": False,
             "exit_code": proc.returncode,
             "error": "aws logs call failed — most likely no read-only AWS credentials in "
-            "this environment yet. Prefer the portal path (TICKVAULT_PORTAL_URL + "
+            "this environment yet. Prefer the direct SigV4 path (AWS_ACCESS_KEY_ID + "
+            "AWS_SECRET_ACCESS_KEY) or the portal path (TICKVAULT_PORTAL_URL + "
             "TICKVAULT_PORTAL_TOKEN). stderr below.",
             "stderr": proc.stderr.strip()[:800],
             "log_group": group,
@@ -1335,13 +1525,16 @@ TOOLS: list[ToolSpec] = [
         name="cloudwatch_logs",
         description=(
             "Read recent PROD logs — fully automated, no human paste/download. "
-            "PREFERRED: reuses the existing operator-control dashboard's logs "
-            "endpoint (set TICKVAULT_PORTAL_URL + TICKVAULT_PORTAL_TOKEN — no "
-            "aws CLI, no AWS key; the portal Lambda reads the box with its own "
-            "IAM role). FALLBACK: read-only aws CLI on /tickvault/prod/app. "
-            "Args: minutes (lookback, aws path only), filter_pattern (substring "
-            "on the portal path, e.g. \"ERROR\" or \"WS-GAP-05\"), limit "
-            "(default 100). Returns a clear error if neither path is configured."
+            "PREFERRED: direct CloudWatch read via a SigV4-signed HTTPS request — "
+            "the ONLY input is a read-only AWS key in the env (AWS_ACCESS_KEY_ID + "
+            "AWS_SECRET_ACCESS_KEY [+ AWS_SESSION_TOKEN], AWS_DEFAULT_REGION); no "
+            "aws CLI, no portal, no boto3. NEXT: the operator-control dashboard's "
+            "logs endpoint (TICKVAULT_PORTAL_URL + TICKVAULT_PORTAL_TOKEN). "
+            "FALLBACK: read-only aws CLI on /tickvault/prod/app. Args: minutes "
+            "(lookback; SigV4 + aws paths), filter_pattern (CloudWatch filter on "
+            "SigV4 + aws, substring on portal, e.g. \"ERROR\" or \"WS-GAP-05\"), "
+            "limit (default 100). The AWS secret/token is NEVER logged nor "
+            "returned. Clear ok=false error if no path is configured."
         ),
         input_schema={
             "type": "object",

--- a/scripts/mcp-servers/tickvault-logs/test_cloudwatch_logs.py
+++ b/scripts/mcp-servers/tickvault-logs/test_cloudwatch_logs.py
@@ -59,11 +59,22 @@ trimmed = server.parse_cloudwatch_events(
 )
 check([e["message"] for e in trimmed] == ["3", "4"], f"limit-trim keeps newest: {trimmed}")
 
-# --- graceful failure when no aws CLI / creds (must NOT crash) ---
-result = server.tool_cloudwatch_logs(minutes=5, limit=3)
-check(result.get("ok") is False, f"expected ok=False without creds: {result}")
-check("log_group" in result, "error result should still report the log_group")
-check(bool(result.get("error")), "error result should carry a human-readable message")
+# --- graceful failure when no aws CLI / creds / portal (must NOT crash) ---
+import os as _os
+
+_saved_aws = {
+    k: _os.environ.pop(k, None)
+    for k in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN")
+}
+try:
+    result = server.tool_cloudwatch_logs(minutes=5, limit=3)
+    check(result.get("ok") is False, f"expected ok=False without creds: {result}")
+    check("log_group" in result, "error result should still report the log_group")
+    check(bool(result.get("error")), "error result should carry a human-readable message")
+finally:
+    for _k, _v in _saved_aws.items():
+        if _v is not None:
+            _os.environ[_k] = _v
 
 # --- portal logs parser (reuses the existing dashboard `logs` endpoint) ---
 raw = "\n".join(
@@ -97,9 +108,12 @@ trim = server.filter_and_trim_portal_events(pevs, None, 2)
 check([e["message"] for e in trim] == ["info a", "WS-GAP-05 respawn"], f"trim keeps newest: {trim}")
 check(server.filter_and_trim_portal_events(pevs, "nomatch", 100) == [], "no match -> []")
 
-# --- portal preferred when env set: a failed call is ok=False, source=portal, never crashes ---
-import os as _os
-
+# --- portal preferred when env set (and no AWS key): ok=False, source=portal, never crashes ---
+# AWS creds (if any) are cleared so the SigV4 path does NOT pre-empt the portal here.
+_saved_aws_portal = {
+    k: _os.environ.pop(k, None)
+    for k in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN")
+}
 _os.environ["TICKVAULT_PORTAL_TOKEN"] = "test-token"
 try:
     # https unreachable -> ok=False via the urlopen-failure path (no crash).
@@ -117,6 +131,149 @@ try:
 finally:
     _os.environ.pop("TICKVAULT_PORTAL_URL", None)
     _os.environ.pop("TICKVAULT_PORTAL_TOKEN", None)
+    for _k, _v in _saved_aws_portal.items():
+        if _v is not None:
+            _os.environ[_k] = _v
+
+# --- build_cloudwatch_sigv4_request (pure, deterministic via injected amz_now) ---
+import datetime as _dt
+
+_FIXED_NOW = _dt.datetime(2026, 6, 12, 1, 2, 3, tzinfo=_dt.timezone.utc)
+_ACCESS = "AKIDEXAMPLE"
+# Distinct, easily-greppable sentinels so we can prove the secret never leaks.
+_SECRET = "SECRET-DO-NOT-LEAK-1234567890"
+_TOKEN = "SESSION-TOKEN-DO-NOT-LEAK-abcdef"
+
+
+def _build(filter_pattern=None, limit=50, token=None):
+    return server.build_cloudwatch_sigv4_request(
+        "ap-south-1",
+        "/tickvault/prod/app",
+        1_700_000_000_000,
+        limit,
+        filter_pattern,
+        _ACCESS,
+        _SECRET,
+        token,
+        _FIXED_NOW,
+    )
+
+
+url, body, headers = _build(filter_pattern="ERROR")
+
+# Endpoint + canonical date are deterministic from the injected amz_now.
+check(url == "https://logs.ap-south-1.amazonaws.com/", f"sigv4 url: {url}")
+check(headers.get("X-Amz-Date") == "20260612T010203Z", f"amz_date: {headers.get('X-Amz-Date')}")
+check(
+    headers.get("X-Amz-Target") == "Logs_20140328.FilterLogEvents",
+    f"x-amz-target: {headers.get('X-Amz-Target')}",
+)
+check(
+    headers.get("Content-Type") == "application/x-amz-json-1.1",
+    f"content-type: {headers.get('Content-Type')}",
+)
+
+# Authorization is a well-formed SigV4 header for the right scope.
+auth = headers.get("Authorization", "")
+check(auth.startswith("AWS4-HMAC-SHA256 "), f"auth scheme: {auth[:40]}")
+check(
+    f"Credential={_ACCESS}/20260612/ap-south-1/logs/aws4_request" in auth,
+    f"auth credential scope: {auth}",
+)
+check(
+    "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target" in auth,
+    f"signed headers (no token): {auth}",
+)
+import re as _re
+
+_sig = _re.search(r"Signature=([0-9a-f]+)$", auth)
+check(_sig is not None, f"signature hex tail missing: {auth}")
+check(_sig is not None and len(_sig.group(1)) == 64, "signature must be 64 lowercase-hex chars")
+
+# x-amz-content-sha256 must equal sha256(body) (payload-signed request).
+import hashlib as _hashlib
+
+check(
+    headers.get("X-Amz-Content-Sha256") == _hashlib.sha256(body).hexdigest(),
+    "x-amz-content-sha256 must match sha256(body)",
+)
+
+# Body is compact JSON carrying the filter + clamped limit.
+_obj = json.loads(body.decode("utf-8"))
+check(_obj.get("logGroupName") == "/tickvault/prod/app", f"body log group: {_obj}")
+check(_obj.get("startTime") == 1_700_000_000_000, f"body startTime: {_obj}")
+check(_obj.get("filterPattern") == "ERROR", f"body filter: {_obj}")
+check(b" " not in body, "body must be compact (no spaces)")
+
+# No filter -> no filterPattern key.
+_, body_nf, _ = _build(filter_pattern=None)
+check("filterPattern" not in json.loads(body_nf.decode("utf-8")), "no-filter body must omit filterPattern")
+
+# limit clamped into [1, 10000].
+_, body_hi, _ = _build(limit=999_999)
+check(json.loads(body_hi.decode("utf-8"))["limit"] == 10000, "limit must clamp to 10000")
+_, body_lo, _ = _build(limit=0)
+check(json.loads(body_lo.decode("utf-8"))["limit"] == 1, "limit must floor to 1")
+
+# Determinism: identical inputs -> byte-identical signed request.
+url2, body2, headers2 = _build(filter_pattern="ERROR")
+check((url2, body2, headers2) == (url, body, headers), "sigv4 build must be deterministic")
+
+# Session token: present -> signed + sent as header, and listed in SignedHeaders
+# in the CORRECT alphabetical position (x-amz-security-token BEFORE x-amz-target,
+# else the signature is invalid -> AWS 403).
+_, _, headers_tok = _build(filter_pattern="ERROR", token=_TOKEN)
+check(headers_tok.get("X-Amz-Security-Token") == _TOKEN, "session token must be sent as header")
+check(
+    "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;"
+    "x-amz-security-token;x-amz-target" in headers_tok.get("Authorization", ""),
+    f"signed headers must be alphabetically sorted with token: {headers_tok.get('Authorization')}",
+)
+
+# SECURITY: the AWS SECRET must NEVER appear anywhere in the built request
+# (url, body, or any header value) — it is only used to derive the HMAC.
+for _label, _hdrs, _bdy in (
+    ("no-token", headers, body),
+    ("with-token", headers_tok, body),
+):
+    _blob = url + _bdy.decode("utf-8", "replace") + "".join(f"{k}:{v}" for k, v in _hdrs.items())
+    check(_SECRET not in _blob, f"AWS SECRET leaked into the {_label} request blob")
+
+# SECURITY: the secret/token must NOT appear in the TOOL's returned dict on the
+# unreachable/bad-creds path (an invalid region fails DNS fast, no real call).
+_saved_sig = {
+    k: _os.environ.get(k)
+    for k in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_DEFAULT_REGION", "AWS_REGION")
+}
+try:
+    _os.environ["AWS_ACCESS_KEY_ID"] = _ACCESS
+    _os.environ["AWS_SECRET_ACCESS_KEY"] = _SECRET
+    _os.environ["AWS_SESSION_TOKEN"] = _TOKEN
+    # Invalid region -> logs.<region>.amazonaws.com is NXDOMAIN -> fast failure.
+    _os.environ["AWS_DEFAULT_REGION"] = "invalid-region-zzz9"
+    _os.environ.pop("AWS_REGION", None)
+    sres = server.tool_cloudwatch_logs(minutes=5, limit=3)
+    check(sres.get("source") == "cloudwatch_sigv4", f"sigv4 path preferred when key in env: {sres}")
+    check(sres.get("ok") is False, f"unreachable sigv4 -> ok=False (no crash): {sres}")
+    check(bool(sres.get("error")), "sigv4 failure must carry an error message")
+    _sres_blob = json.dumps(sres)
+    check(_SECRET not in _sres_blob, "AWS SECRET leaked into sigv4 result dict")
+    check(_TOKEN not in _sres_blob, "AWS SESSION TOKEN leaked into sigv4 result dict")
+
+    # SECURITY: a region with host/path-injection chars is refused BEFORE any
+    # network call (and without leaking the secret/token).
+    _os.environ["AWS_DEFAULT_REGION"] = "evil@attacker.com/x"
+    rres = server.tool_cloudwatch_logs(minutes=5, limit=3)
+    check(rres.get("ok") is False, f"injection region must be refused: {rres}")
+    check("region" in (rres.get("error") or "").lower(), f"refusal must cite region: {rres}")
+    _rres_blob = json.dumps(rres)
+    check(_SECRET not in _rres_blob and _TOKEN not in _rres_blob, "creds leaked into region-refusal dict")
+finally:
+    for _k, _v in _saved_sig.items():
+        if _v is None:
+            _os.environ.pop(_k, None)
+        else:
+            _os.environ[_k] = _v
 
 if failures:
     print("FAIL:")


### PR DESCRIPTION
## Summary

Finishes the WIP **direct CloudWatch SigV4 log reader** in the `tickvault-logs` MCP server so prod logs can be read with the **ONLY** input being a read-only AWS key in the environment — **no aws CLI, no portal, no boto3** (stdlib `urllib` + `hmac`/`hashlib` only).

Operator adds `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_DEFAULT_REGION=ap-south-1` (IAM `logs:FilterLogEvents` on `/tickvault/prod/*`) and logs flow directly.

> Supersedes draft #1119 — that branch carried a non-conventional `WIP(...)` commit that Commit Lint rejects and which can't be reworded without a force-push (denied by policy). This branch is `main` (#1118) + one clean `feat(mcp)` commit.

## Items completed
- [x] `tool_cloudwatch_logs` PREFERS the SigV4 direct path when `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` are set — **before** the portal path, **before** the aws-CLI fallback. Fallback error messages + tool description updated to name the key path.
- [x] Tests for `build_cloudwatch_sigv4_request` — structural/deterministic asserts via an injected fixed `amz_now` (endpoint, `X-Amz-Date`, credential scope, 64-hex signature, `x-amz-content-sha256 == sha256(body)`, compact body, filter present/absent, limit clamp `[1,10000]`, byte-for-byte determinism, sorted signed-headers with token) + unreachable/bad-creds **no-crash** + invalid-region refusal tests.
- [x] Updated the `cloudwatch_logs` tool description.

## Bug fixed while finishing the WIP
The WIP appended `x-amz-security-token` **after** `x-amz-target` in the canonical headers. AWS requires canonical headers sorted alphabetically by lowercase name, and `x-amz-se…` sorts **before** `x-amz-ta…` — so the `AWS_SESSION_TOKEN` path produced an **invalid signature (AWS 403)**. Now built from a sorted list. Cross-checked against an independent by-the-book SigV4 implementation: **matches with and without a session token.**

## Adversarial 3-agent review (done)
- **security-reviewer:** secret/token non-leakage **CONFIRMED** (secret only seeds the HMAC; session token only goes on the wire as `x-amz-security-token`; neither is in any returned dict). Findings applied: bound the network-error string to `str(exc)[:300]`; validate region charset `[a-z0-9-]` before it lands in the request host.
- **hostile bug-hunt:** SigV4 verified spec-correct against an independent reimplementation; path priority correct (empty-string creds do not trigger SigV4); shared `parse_cloudwatch_events` handles the FilterLogEvents response shape; crash-safe (`ok=False`, never raises). No CRITICAL/HIGH.
- Pagination caveat noted in the docstring (single-page; ample for a recent-logs tail).

## Security (operator's explicit demand — satisfied)
The AWS secret/token is **NEVER** logged nor placed in any returned dict. Ratchet tests assert the secret never appears in the built request (url/body/headers) and that **neither the secret nor the token** appears in the tool's returned dict on the failure paths.

## Test plan
- [x] `python3 scripts/mcp-servers/tickvault-logs/test_cloudwatch_logs.py` → ALL PASS
- [x] `python3 scripts/mcp-servers/tickvault-logs/test_placeholder_fallback.py` → PASS
- [x] Independent SigV4 cross-check (with + without session token) → both match
- [x] Pre-commit S6 invariant gate (dedup + Bible lockdown) green
- [x] Existing behaviour unchanged when no AWS key is set

## Honest 100% claim
100% inside the tested envelope, with ratcheted regression coverage: the SigV4 request builder is a pure function proven deterministic, correctly-signed (cross-checked against an independent implementation), and secret-non-leaking by unit tests; the network leg is best-effort and fails closed (`ok=False`, never crashes, never leaks credentials). Beyond the envelope (live AWS reachability, real IAM grant) the tool returns a clear `ok=False`.

## Scope note
`scripts/`-only change (Python MCP server) — no `crates/*/src/*.rs` touched, so the design-first plan-gate does not apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyZgMi68H9xBScbg9PRSJ4)_