### PR TITLE
chore(hooks): auto-repair a broken cargo toolchain on session start

### DIFF
--- a/.claude/hooks/session-auto-health.sh
+++ b/.claude/hooks/session-auto-health.sh
@@ -46,6 +46,32 @@ SUMMARY="$LOG_DIR/session-auto-health.latest.txt"
 
   STATUS="ok"
 
+  # Toolchain self-heal: the pinned toolchain occasionally ships without the
+  # `cargo` proxy binary (the rustup component is "installed" but the binary is
+  # absent), which breaks every build until manually repaired. Detect + repair
+  # automatically so no session needs the manual `rustup component add cargo`.
+  ensure_cargo() {
+    echo "--- stage: cargo-self-heal ---"
+    if cargo --version >/dev/null 2>&1; then
+      echo "[cargo-self-heal] cargo OK"
+      return 0
+    fi
+    local channel
+    channel="$(awk -F'"' '/^channel/{print $2}' "$PROJECT_DIR/rust-toolchain.toml" 2>/dev/null)"
+    channel="${channel:-stable}"
+    echo "[cargo-self-heal] cargo binary missing — repairing toolchain $channel"
+    rustup component remove cargo --toolchain "$channel" >/dev/null 2>&1 || true
+    rustup component add cargo --toolchain "$channel" >/dev/null 2>&1 \
+      || rustup component add cargo >/dev/null 2>&1 || true
+    if cargo --version >/dev/null 2>&1; then
+      echo "[cargo-self-heal] repaired: $(cargo --version)"
+    else
+      echo "[cargo-self-heal] STILL BROKEN — manual rustup needed"
+      STATUS="fail"
+    fi
+  }
+  ensure_cargo
+
   run_stage() {
     local name="$1"
     local cmd="$2"


### PR DESCRIPTION
## Summary

Removes the one **manual** step I hit this session: the pinned toolchain shipped without the `cargo` proxy binary (rustup reported the component "installed" but the binary was absent), which broke every build until I ran `rustup component add cargo` by hand.

`session-auto-health.sh` (a SessionStart hook that already runs every session) now **self-heals** it: detect a missing `cargo` → remove+re-add the cargo component for the `rust-toolchain.toml` channel → verify. No-ops when cargo is present.

## Why
Directly answers "make it entirely automated" for the build-setup gap — no future session needs the manual toolchain repair.

## Evidence
- `bash -n` syntax OK.
- Channel parses correctly (`1.95.0` from `rust-toolchain.toml`).
- With cargo present, the stage no-ops (verified) — zero overhead on healthy sessions.
- Hooks-only change (no `crates/src`) → design-first-wall exempt; 1 file.

## Honest scope
This closes the toolchain gap. The two gaps I **cannot** close myself remain by design: (1) the read-only AWS log credential must be set in the environment config (agents can't mint cloud keys), and (2) the full integration/chaos battery needs live QuestDB/Docker.

https://claude.ai/code/session_01KkMLdT2S5eUwB8gviJcTRE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkMLdT2S5eUwB8gviJcTRE)_