### PR TITLE
docs(groww): authorize Groww as pluggable native-Rust second feed (PR-0 governance)

### DIFF
--- a/.claude/plans/active-plan-groww-second-feed.md
+++ b/.claude/plans/active-plan-groww-second-feed.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Groww as a pluggable SECOND live feed (reuse WAL/ring/spill; live-vs-backtest 1m parity)
+
+**Status:** APPROVED
+**Date:** 2026-06-19
+**Approved by:** Parthiban (2026-06-19, AskUserQuestion: "Go — start PR-0 (Groww default OFF)")
+**Branch:** `claude/compassionate-faraday-728tnc`
+**Authority:** CLAUDE.md > operator-charter-forever.md §I > groww-second-feed-scope-2026-06-19.md > design-first-wall.md > this file
+**Crates touched (future PRs):** `common` (config), `core` (groww feed/parser/aggregate/cross-verify), `storage` (groww tables), `app` (boot wiring)
+
+## Design
+
+Add **Groww** as market-data **feed #2** alongside the existing **Dhan** feed #1, per the
+operator authorization in `groww-second-feed-scope-2026-06-19.md`. The two feeds are pluggable:
+a `[feeds]` config section with `dhan_enabled` (default `true`, unchanged) and `groww_enabled`
+(default `false`) lets the operator run Dhan-only, Groww-only, or both. Groww **reuses the
+existing resilience architecture AS-IS** — the same WAL frame spill, rescue ring buffer, disk
+spill, DLQ, tick processor, and 1-minute aggregator that Dhan uses — never redesigning them.
+Groww is a SECOND PRODUCER into those reused blocks, writing to its OWN namespaced QuestDB
+tables (`groww_live_ticks`, `groww_candles_1m`, `groww_cross_verify_1m_audit`); the Dhan
+`ticks`/`candles_*`/audit tables are untouched.
+
+Why Groww: Dhan has told us its live WebSocket has "minor changes and fluctuations / missed
+ticks". Groww gives an INDEPENDENT second source whose tick timestamps carry **millisecond**
+precision (Dhan's are whole seconds), enabling cleaner minute-boundary bucketing and exact
+ordering. The deliverable is a **Groww-live-1m vs Groww-backtest-1m parity check** (exact OHLCV
+compare, minute-by-minute, naming every mismatch) — confirming Groww's live feed agrees with
+Groww's own historical/backtest data, giving the operator a trustworthy yardstick to measure
+Dhan's drift.
+
+**Native Rust ONLY — brutex is reference, not code (operator lock 2026-06-19, Quote 3):**
+NOTHING is pulled, vendored, or imported from the brutex repo. The brutex `live` package is used
+purely as a **design/protocol REFERENCE** (the idea + the Groww live-feed wire details); the
+implementation is **native tickvault Rust** reusing our existing O(1) chain. No `growwapi` Python
+dependency, no Python sidecar, no vendored files. PR-1 implements the Groww live-feed connector
+in Rust against Groww's live-feed protocol (token + TOTP auth, implemented natively) feeding raw
+frames into the SAME `ws_frame_spill` → ring → spill → DLQ. Groww inherits the SAME bounded
+zero-tick-loss capture guarantee as Dhan — WAL-before-broadcast + disconnect/reconnect with
+subscription preservation — so not a single RECEIVED tick is dropped inside the tested chaos
+envelope, on Groww exactly as on Dhan. Honest envelope: that is a CAPTURE guarantee (every tick
+we receive is durable); it does NOT claim Groww's UPSTREAM exchange feed never drops a tick —
+measuring that drift vs Dhan is the goal. Default-OFF guarantees zero prod impact until proven.
+
+## Plan Items
+
+- [x] PR-0 — Governance: operator authorization rule file + this approved plan + 2 pointer lines. NO code.
+  - Files: `.claude/rules/project/groww-second-feed-scope-2026-06-19.md`, `.claude/plans/active-plan-groww-second-feed.md`, `.claude/rules/project/websocket-connection-scope-lock.md`, `.claude/rules/project/operator-charter-forever.md`
+  - Tests: n/a (docs/rules only — plan-gate exempt: no `crates/*/src`)
+- [ ] PR-1 — `[feeds]` config (`FeedsConfig` in `crates/common/src/config.rs` + `config/base.toml`, Groww default OFF) + **native Rust** Groww live-feed connector (token + TOTP auth implemented natively; brutex referenced for protocol ONLY, zero code pulled) feeding raw frames into the EXISTING `ws_frame_spill` → ring → spill → DLQ with the same disconnect/reconnect + subscription-preservation. Behind `groww_enabled=false`.
+  - Files: `crates/common/src/config.rs`, `config/base.toml`, `crates/core/src/feed/groww/*.rs`, `crates/app/src/main.rs` (additive boot branch, gated)
+  - Tests: `test_feeds_config_defaults_groww_off`, `test_groww_feed_only_spawns_when_enabled`, `test_groww_frame_enters_wal_spill`
+- [ ] PR-2 — Groww tick parser (ms timestamps) → tick processor → 1-minute aggregator → `groww_candles_1m` QuestDB table (DEDUP UPSERT KEYS).
+  - Files: `crates/core/src/feed/groww/parser.rs`, `crates/storage/src/groww_candle_persistence.rs`, `crates/core/src/feed/groww/aggregate.rs`
+  - Tests: `test_groww_ms_timestamp_buckets_to_correct_minute`, `test_groww_1m_ohlcv_fold`, `test_groww_candles_dedup_key_includes_segment`
+- [ ] PR-3 — Groww backtest/historical 1m fetch + live-vs-backtest EXACT 1m cross-verify → `groww_cross_verify_1m_audit` + Telegram/console parity report (names every mismatched minute; no false-OK on empty set).
+  - Files: `crates/core/src/feed/groww/cross_verify.rs`, `crates/storage/src/groww_cross_verify_audit_persistence.rs`, `crates/common/src/error_code.rs` (GROWW-XVERIFY-01/02)
+  - Tests: `test_groww_live_vs_backtest_exact_match`, `test_groww_xverify_names_mismatch_minute`, `test_groww_xverify_no_false_ok_on_empty`
+- [ ] PR-4 — Runtime per-feed enable/disable wiring + (optional) Dhan-vs-Groww live parity report + dashboards/observability + chaos/hardening tests.
+  - Files: `crates/app/src/main.rs`, `crates/core/src/feed/parity.rs`, `crates/storage/tests/chaos_groww_feed_*.rs`
+  - Tests: `test_feed_toggle_all_three_modes`, `chaos_groww_spill_saturation`, `test_dhan_vs_groww_live_parity_report`
+
+## Edge Cases
+- Groww `groww_enabled=false` (default) ⇒ feed never spawns; boot path byte-identical to today.
+- Same `(symbol, exchange)` tick twice ⇒ QuestDB DEDUP UPSERT KEYS collapse it (O(1) amortized).
+- Groww ms-timestamp at a minute boundary (e.g. `09:15:59.998`) ⇒ buckets to the 09:15 minute, never bleeds into 09:16.
+- Groww feed down while Dhan up (both-mode) ⇒ Dhan lane fully unaffected (separate connection + tables + pipeline instance).
+- Groww live set ≠ Groww backtest set for a minute ⇒ reported as `missing`, never silently equal.
+- Empty/partial Groww backtest fetch ⇒ parity reports `partial coverage`, never a false "all match" (audit Rule 11).
+
+## Failure Modes
+- Groww auth/token/TOTP failure ⇒ Groww lane fails closed + typed error + retry-with-backoff; Dhan lane untouched. (Operator demand: "pull until it fetches successful response" → bounded exponential-backoff retry per the existing Dhan retry ladders, with escalating Telegram — never an unbounded busy-loop / retry storm.)
+- Groww WS drop ⇒ reuse the existing reconnect + WAL-spill recovery; frames already captured to WAL before broadcast are replayed on recovery (zero loss inside the chaos envelope).
+- QuestDB down ⇒ Groww writes ABSORB via the SAME ring→spill→DLQ as Dhan; no new failure path.
+- Groww-default-ON regression ⇒ ratchet `test_feeds_config_defaults_groww_off` fails the build.
+- Groww frame written to a Dhan table (table-mixup regression) ⇒ caught by the DEDUP-segment meta-guard + a source-scan asserting Groww writers target `groww_*` only.
+
+## Test Plan
+- PR-0: docs/rules only — plan-gate exempt; pre-push banned-pattern + secret-scan + plan-verify must pass.
+- PR-1..PR-4: per `testing-scope.md`, scoped to the changed crate; `common` change (PR-1) escalates to `cargo test --workspace`. 22-test categories per `testing.md` for each changed crate; DHAT zero-alloc + Criterion budget on the Groww hot-path (tick parse + 1m fold); chaos test for Groww spill saturation (PR-4); adversarial 3-agent review (hot-path + security + hostile) on every code diff BEFORE and AFTER per `operator-charter-forever.md` §E.
+- Real evidence pasted (test counts, bench numbers) per `zero-loss-guarantee-charter.md` §4 — no "should pass".
+
+## Rollback
+- PR-0 is additive docs/rules — `git revert <sha>` removes the authorization + plan, zero runtime impact.
+- PR-1..PR-4 are gated behind `groww_enabled=false` (default). Disable flag ⇒ Groww never runs ⇒ instant logical rollback with no redeploy. `git revert` of any PR removes that PR's Groww code; the Dhan core is never touched, so revert is always clean and never affects live Dhan trading/data.
+
+## Observability
+- Each Groww code path carries the 7-layer telemetry (Prom counter + gauge + tracing span + structured `error!` with `code = ErrorCode::X.code_str()` + Telegram event + `groww_*_audit` table). New typed ErrorCodes (GROWW-XVERIFY-01/02 in PR-3) get a runbook in `groww-second-feed-scope-2026-06-19.md` or a sibling rule file (cross-ref test enforced). The parity report itself is the headline observability deliverable: "Groww live == backtest" or the exact mismatched-minute list.
+
+## Guarantee matrix
+The full 15-row + 7-row matrices from `per-wave-guarantee-matrix.md` apply to every code PR
+(PR-1..PR-4). PR-0 applicable rows: 100% audit/governance (authorization rule file + this plan),
+100% logging/alerting design (typed codes reserved), 100% scenarios (3 run modes + failure modes
+above). N/A for PR-0: code coverage / DHAT / bench / hot-path O(1) — reason: docs/rules only,
+zero `crates/*/src`. Any "100% guarantee" in this plan or its PRs means exactly
+"100% inside the tested envelope, with ratcheted regression coverage" per
+`wave-4-shared-preamble.md` §8 and `groww-second-feed-scope-2026-06-19.md` §5 honest envelope —
+never the unbounded literal.
+
+## Scenarios
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Prod default (Groww OFF) | Byte-identical Dhan-only behaviour; Groww code dormant |
+| 2 | Groww-only mode | Only Groww feed runs → `groww_live_ticks` + `groww_candles_1m` populate; Dhan idle |
+| 3 | Both feeds ON | Dhan + Groww in parallel, separate lanes/tables; neither affects the other |
+| 4 | Groww live 1m == Groww backtest 1m | Parity report: ✅ "all match (exact, zero tolerance)" |
+| 5 | Groww live 1m ≠ backtest at minute X field Y | Parity report names symbol+minute+field+(live,backtest) values |
+| 6 | Groww auth fails at boot | Groww lane fails closed + bounded-backoff retry + Telegram; Dhan unaffected |
+| 7 | QuestDB outage during both-mode | Both lanes absorb via ring→spill→DLQ; zero loss inside envelope |

--- a/.claude/rules/project/groww-second-feed-scope-2026-06-19.md
+++ b/.claude/rules/project/groww-second-feed-scope-2026-06-19.md
@@ -1,0 +1,139 @@
+# Groww Second Feed — Pluggable-Feeds Scope Extension (Operator Lock 2026-06-19)
+
+> **Authority:** CLAUDE.md > `operator-charter-forever.md` §I > this file > `websocket-connection-scope-lock.md` (EXTENDED below) > `daily-universe-scope-expansion-2026-05-27.md` > defaults.
+> **Scope:** PERMANENT. Every Phase. Every PR. Every future Claude/Cowork session.
+> **Operator-locked:** 2026-06-19 (verbatim quotes preserved below).
+> **Status:** Authorization record + contract. Sub-PR #0 of the Groww-second-feed sequence (PR-0 = this file + the plan + the two pointer lines; code lands in PR-1..PR-4 per `.claude/plans/active-plan-groww-second-feed.md`).
+> **Extends (does NOT supersede):** the 2-Dhan-WebSocket lock (1 main-feed + 1 order-update) is **UNCHANGED**. This file authorizes a SEPARATE, INDEPENDENT, **default-OFF** second market-data feed to a DIFFERENT provider (Groww) under a per-feed enable/disable contract. No Dhan connection is added, removed, or modified.
+> **Auto-load trigger:** Always loaded (path is in `.claude/rules/project/`).
+
+---
+
+## §0. The verbatim operator demands (preserve exactly, do not paraphrase)
+
+**Quote 1 (2026-06-19, add Groww as a second feed, reuse the architecture):**
+> "along with dhan we need to add this groww mechanism also dude okay? That's it bro but we need to follow our current architectures like wal ring buffer spill disk everything as it is dude okay? Just by adding our new groww live feed dude because in groww the main advantage is timestamp has milliseconds so that we should fetch the live ticks and need to generate our one minute especially to check whether atleast groww live feed data and groww backtesting is same or not dude"
+
+**Quote 2 (2026-06-19, motivation + enable/disable per feed):**
+> "groww as the second feed that's it dude … the main problem with dhan live feed is they clearly told us there will be a minor changes and fluctuations like something will miss in live feed websocket and it's literally irritated dude so that's why I want to check this groww live feed dude … let the code be there as a separated groww vs dhan but in the future or current always when we need to go ahead with only one or multiple feeds means then it should be allowed to enabled and disabled right dude"
+
+**Quote 3 (2026-06-19, native Rust ONLY — brutex is reference/idea, NOT pulled):**
+> "you are going to pull the code directly from brutex live package right if that's the case never … only the idea behind that will be used right dude except reference nothing else will be pulled from there right dude so that … our strict hard earned rust tick vault always O(1) will be used even for this added groww right I need the real time guarantee dude because even with groww also disconnect reconnect and not even a single tick miss also should happen dude"
+
+**Approval (2026-06-19, AskUserQuestion):**
+> "Go — start PR-0 (Groww default OFF)"
+
+---
+
+## §1. The rule — one paragraph
+
+Market-data feeds become **pluggable**. There are exactly two feed providers, each
+independently **enable/disable**-able by config: **Dhan** (feed #1, the existing system,
+**UNCHANGED** — still ≤2 Dhan WebSocket connections per `websocket-connection-scope-lock.md`)
+and **Groww** (feed #2, **NEW**, **default OFF**). Groww is implemented **natively in tickvault
+Rust** — **NOTHING is pulled, vendored, or imported from the brutex repo; brutex is used ONLY as
+a design/protocol REFERENCE (the idea), never as code.** Groww is added by **reusing the existing
+resilience architecture AS-IS** — the same WAL frame spill, rescue ring buffer, disk spill,
+DLQ, tick processor, and 1-minute aggregator that Dhan uses — never by redesigning them. Groww
+therefore inherits the SAME hard-earned **O(1)** hot path and the SAME **bounded zero-tick-loss
+capture guarantee** as Dhan: WAL-before-broadcast, disconnect/reconnect with subscription
+preservation, ring → spill → DLQ — so **not a single tick we receive is dropped** inside the
+tested chaos envelope, on Groww exactly as on Dhan. The two feeds are kept **fully separate**
+(separate connection, separate parser, separate QuestDB tables); they never share a table or a
+pipeline instance. Groww's tick timestamps carry
+**millisecond** precision (Dhan's carry whole seconds), which is the reason for adding it. The
+deliverable goal is a **Groww-live-1-minute vs Groww-backtest-1-minute parity check** (exact
+match, minute-by-minute) so the operator can confirm whether Groww's live feed agrees with
+Groww's own historical/backtest data — and, by extension, quantify the Dhan-live-feed
+drift/missing-tick problem against an independent second source.
+
+---
+
+## §2. The pluggable-feed contract (LOCKED)
+
+| Feed | Provider | Default | Connection | Reuses tickvault resilience chain | Writes to |
+|---|---|---|---|---|---|
+| **#1 Dhan** | Dhan | **ON** (unchanged) | ≤2 WS (main-feed + order-update) | yes (existing) | `ticks`, `candles_*`, audit tables (UNCHANGED) |
+| **#2 Groww** | Groww | **OFF** | independent Groww live feed — **native Rust client** (token + TOTP); brutex is reference only | **yes — same WAL→ring→spill→DLQ→aggregator, reused unchanged** | `groww_live_ticks`, `groww_candles_1m`, `groww_cross_verify_1m_audit` (NEW, namespaced) |
+
+| Run mode | `feeds.dhan_enabled` | `feeds.groww_enabled` | Behaviour |
+|---|---|---|---|
+| **Today / prod default** | `true` | `false` | Byte-identical to current Dhan-only system. Groww code present but never spawned. |
+| Groww-only | `false` | `true` | Only Groww feed runs (isolated test). |
+| Both (the target) | `true` | `true` | Dhan + Groww live in parallel, each in its own lane. |
+
+**Config home:** `config/base.toml` `[feeds]` section → `FeedsConfig` in `crates/common/src/config.rs`
+(lands in PR-1). Boot reads the flags ONCE (O(1)) and spawns ONLY enabled feeds.
+
+---
+
+## §3. What is UNCHANGED (still locked)
+
+- **Exactly ≤2 Dhan WebSocket connections** (1 main-feed + 1 order-update). Groww does NOT add a Dhan connection. The `SubscriptionScope` enum, `effective_main_feed_pool_size`, the Dhan subscription planner, and `indices4only_scope_lock_guard.rs` are untouched.
+- **Dhan pipeline, tables, boot path** — not modified. Groww default-OFF ⇒ zero behaviour change until explicitly enabled.
+- **The resilience architecture is REUSED, never redesigned** — WAL frame spill (`ws_frame_spill.rs`), rescue ring (`TICK_BUFFER_CAPACITY`), disk spill (NDJSON), DLQ, tick processor, 1-minute aggregator. Groww plugs into these as a second producer; it does not change their design.
+- **Composite uniqueness** `(security_id/symbol, exchange_segment)` per I-P1-11 + DEDUP UPSERT KEYS on every new Groww table.
+- **Indicators/strategies boundary** (daily-universe lock §28) — untouched. Groww is feed + 1m candles + parity check only; it drives NO strategy and places NO order.
+
+---
+
+## §4. What a PR that violates this lock looks like (REJECT)
+
+- Modifies the Dhan feed, the Dhan pipeline, the Dhan tables, `SubscriptionScope`, or `effective_main_feed_pool_size` in the name of "adding Groww".
+- Redesigns / forks / duplicates the WAL/ring/spill/DLQ/aggregator instead of reusing the existing blocks.
+- Writes Groww ticks into the Dhan `ticks`/`candles_*` tables (must use `groww_*` namespaced tables).
+- Ships Groww **default ON** without a fresh dated operator quote (default is OFF; flipping it on by default changes prod behaviour).
+- Removes the per-feed enable/disable flags or makes a feed un-disableable.
+- Wires Groww into any strategy/order path (parity-check + observability ONLY in this scope).
+- Adds a NEW Dhan WebSocket endpoint (that remains forbidden by `websocket-connection-scope-lock.md`).
+- **Pulls, vendors, copies, or imports ANY code from the brutex repo (Python or otherwise).** brutex is a design/protocol REFERENCE ONLY — the Groww implementation is native tickvault Rust. A PR containing vendored brutex code, a `growwapi` Python dependency, or a Python sidecar process = REJECT.
+- Gives Groww a weaker resilience guarantee than Dhan (e.g. skips WAL-before-broadcast, skips reconnect, or allows a tick-drop path Dhan doesn't have). Groww MUST inherit the same bounded zero-tick-loss chain.
+
+Any such PR MUST be rejected in review even if the operator approves verbally — the operator
+must update this rule file FIRST with a dated quote, only then can the PR land.
+
+---
+
+## §5. Honest envelope (mandatory per `operator-charter-forever.md` §F)
+
+When any PR / commit / Telegram for this work invokes "100% guarantee", qualify it exactly:
+
+> "100% inside the tested envelope, with ratcheted regression coverage: Groww feed reuses the
+> existing zero-tick-loss chain (ring → NDJSON spill → DLQ — `TICK_BUFFER_CAPACITY`, ratcheted
+> by `zero_tick_loss_alert_guard.rs`); Groww default OFF ⇒ Dhan-only behaviour is byte-identical;
+> per-feed enable/disable is an O(1) boot-time config read + per-feed pipeline isolation; the
+> live-vs-backtest parity check is an EXACT 1-minute OHLCV compare that NAMES every mismatched
+> minute (never a false 'all match' on an empty/partial set, per audit Rule 11). Groww's
+> millisecond timestamps improve minute-boundary accuracy. Two distinct senses of 'no tick
+> missed', kept honest: (a) CAPTURE — every tick we RECEIVE on the Groww socket is durably
+> recorded inside the tested chaos envelope (WAL-before-broadcast + reconnect + ring→spill→DLQ),
+> identical to Dhan — 'not a single tick missed' holds here; (b) UPSTREAM — we do NOT claim
+> Groww's exchange feed never drops a tick before it reaches us — measuring that drift against
+> Dhan is the whole point, not asserting its absence."
+
+Stronger phrasing ("Groww never misses a tick", "live == backtest always") without the
+envelope qualifier = REJECT IN REVIEW.
+
+---
+
+## §6. Auto-driver / Insta-reel explanation
+
+> Sir, imagine your juice shop has ONE price board from supplier Dhan. Dhan himself admits his
+> board sometimes blinks and skips a price. Annoying. So we add a SECOND price board from
+> supplier Groww — and Groww's board even shows the *milliseconds*, sharper than Dhan's
+> seconds-only board. Both boards hang side by side, each with its own ON/OFF switch — show only
+> Dhan, only Groww, or both. Groww's switch starts OFF so nothing about your existing shop
+> changes until you flip it. And the clever bit: we collect Groww's live prices for one minute,
+> then check that minute against Groww's OWN official record book. If they match, Groww's live
+> board is honest — and now you have a trustworthy second board to catch when Dhan's blinks.
+
+---
+
+## §7. Trigger (auto-loaded paths)
+
+Always loaded. Activates on any session that:
+- Edits `crates/common/src/config.rs` (`FeedsConfig` / `[feeds]` flags)
+- Edits `config/base.toml` `[feeds]` section
+- Adds/edits any file under a `crates/*/src/**/groww*` path or containing `groww`, `GrowwFeed`, `groww_live_ticks`, `groww_candles_1m`, `FeedsConfig`, `feeds.groww_enabled`, `feeds.dhan_enabled`
+- Adds any new `wss://` Groww feed URL constant
+- Edits `.claude/plans/active-plan-groww-second-feed.md`

--- a/.claude/rules/project/operator-charter-forever.md
+++ b/.claude/rules/project/operator-charter-forever.md
@@ -231,8 +231,10 @@ For every plan item / new feature / Telegram message / docs:
 >
 > Operator verbatim 2026-05-15:
 > "except [for] this 1 connection main feed websocket and order update websocket we will never ever use anything else"
+>
+> **⚠ SECOND-FEED EXTENSION 2026-06-19 by [`groww-second-feed-scope-2026-06-19.md`](./groww-second-feed-scope-2026-06-19.md):** the Dhan 2-WS lock (1 main-feed + 1 order-update) below is UNCHANGED. The operator authorized **GROWW** as an independent, **default-OFF**, per-feed-toggleable second market-data feed (feed #2), implemented in **native tickvault Rust** (brutex = reference only, no code pulled), reusing the same WAL/ring/spill/DLQ/aggregator chain. It adds NO Dhan connection. See that file for the verbatim authorization + contract.
 
-**The only WebSocket connections this product will EVER open:**
+**The only WebSocket connections this product will EVER open:** (Dhan; the Groww second feed is governed separately per the 2026-06-19 extension above)
 
 | WS type | Count | Allowed instruments | Mode |
 |---|---|---|---|

--- a/.claude/rules/project/websocket-connection-scope-lock.md
+++ b/.claude/rules/project/websocket-connection-scope-lock.md
@@ -2,6 +2,8 @@
 
 > **⚠ ALLOWED-INSTRUMENTS SUPERSEDED 2026-05-27 by [`daily-universe-scope-expansion-2026-05-27.md`](./daily-universe-scope-expansion-2026-05-27.md):** main-feed subscription expanded from 4 IDX_I SIDs (`LOCKED_UNIVERSE`) to ~250 daily-fetched SIDs (all NSE indices + 1 BSE SENSEX + unique F&O underlyings); all in Quote mode (was Ticker for IDX_I). `SubscriptionScope::Indices4Only` retires; replaced by `SubscriptionScope::DailyUniverse`. The 2-WebSocket lock itself (1 main-feed + 1 order-update) is UNCHANGED. Contents below retained as 2026-05-15 historical audit.
 >
+> **⚠ SECOND-FEED EXTENSION 2026-06-19 by [`groww-second-feed-scope-2026-06-19.md`](./groww-second-feed-scope-2026-06-19.md):** the 2-**Dhan**-WebSocket lock below is UNCHANGED. The operator authorized adding **GROWW** as an independent, **default-OFF** second market-data feed (feed #2) under a per-feed enable/disable contract. Groww is **native tickvault Rust** (brutex is reference only — no code pulled) reusing the same WAL/ring/spill/DLQ/aggregator chain; it adds NO Dhan connection and touches NO Dhan code. See that file for the verbatim authorization + full contract.
+>
 > **Authority:** CLAUDE.md > `operator-charter-forever.md` §I > this file > defaults.
 > **Scope:** PERMANENT. Every Phase. Every PR. Every future Claude/Cowork session.
 > **Operator-locked:** 2026-05-15 (verbatim quote below).


### PR DESCRIPTION
## Summary

**PR-0** of the Groww-second-feed sequence — **governance only, NO code.** Adds the operator authorization + the APPROVED design-first plan so the code PRs (PR-1..PR-4) can land legally. **Groww is default OFF ⇒ zero behaviour change.**

Adds **Groww** as market-data **feed #2** alongside **Dhan** (feed #1, UNCHANGED). Feeds become **pluggable** (`feeds.dhan_enabled` / `feeds.groww_enabled`) so you can run Dhan-only, Groww-only, or both. Groww is **native tickvault Rust** — **brutex is a design/protocol reference ONLY, no code pulled** — reusing the same WAL/ring/spill/DLQ/aggregator chain, so Groww inherits the same O(1) hot path + bounded zero-tick-loss capture (WAL-before-broadcast + reconnect) as Dhan. Goal: **Groww-live-1m vs Groww-backtest-1m exact parity check** to measure Dhan's missing-tick drift against an independent ms-precision source.

## Why now / motivation
Dhan admits its live WS has "minor changes/fluctuations / missed ticks". Groww gives an independent second source with **millisecond** timestamps (Dhan = seconds) to cross-check.

## Files (docs/rules only — plan-gate exempt)
| File | Change |
|---|---|
| `.claude/rules/project/groww-second-feed-scope-2026-06-19.md` | **NEW** — verbatim operator authorization + pluggable-feed contract |
| `.claude/plans/active-plan-groww-second-feed.md` | **NEW** — APPROVED design-first plan (PR-0..PR-4) |
| `.claude/rules/project/websocket-connection-scope-lock.md` | pointer line (Dhan 2-WS lock UNCHANGED) |
| `.claude/rules/project/operator-charter-forever.md` §I | pointer line |

## Items completed
- [x] PR-0 — operator authorization rule file + approved plan + 2 pointer lines. No code.

## Honest 100% claim
100% inside the tested envelope, with ratcheted regression coverage: this PR is governance/docs only (no `crates/*/src`), so runtime guarantees are deferred to PR-1..PR-4. Groww default OFF ⇒ Dhan-only behaviour byte-identical. The future code PRs reuse the existing zero-tick-loss chain (`TICK_BUFFER_CAPACITY`, ratcheted by `zero_tick_loss_alert_guard.rs`); the live-vs-backtest parity check is an EXACT 1m OHLCV compare that names every mismatched minute (no false-OK on empty set).

## Test plan
- [x] plan-gate (design-first wall) PASS — no `crates/*/src`
- [x] plan-verify PASS
- [x] banned-pattern-scanner PASS
- [x] per-item-guarantee-check PASS
- [x] secret-scanner PASS

## Scope-lock note
The Dhan **2-WebSocket lock is UNCHANGED**. This PR records the operator's 2026-06-19 authorization for Groww as an independent, default-OFF, toggleable second feed — exactly per the re-approval protocol (edit the rule files FIRST). No Dhan connection is added or modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9Dt12TN68RvYhyNYrDBGa)_