### PR TITLE
fix(api): tokenless feed-toggle in dev/sandbox so the /feeds ON/OFF flip works

### DIFF
--- a/.claude/plans/active-plan-feed-followups.md
+++ b/.claude/plans/active-plan-feed-followups.md
@@ -1,0 +1,59 @@
+# Implementation Plan: feed-control follow-ups (toggle / option-chain / per-feed identity)
+
+**Status:** APPROVED
+**Date:** 2026-06-23
+**Approved by:** Parthiban — chat 2026-06-23 (AskUserQuestion answers below).
+**Branch:** `claude/cool-noether-3liwxc`
+
+## Consolidated queue (everything captured, nothing dropped)
+
+| # | Item | Decision | Size | Status |
+|---|---|---|---|---|
+| **A** | **Feed ON/OFF not working in `/feeds` webpage** | Tokenless toggle in dev/sandbox (operator approved) | small | **THIS PR** |
+| **B** | Remove `option_chain_minute_snapshot` table + its writer/scheduler ONLY | Keep the prev-day-OI fetch so candle `oi_pct_from_prev_day` survives (operator approved "remove only the snapshot table") | medium | next PR |
+| **C** | Per-feed instrument identity + `feed` on data+master tables | Dedicated design PR (operator approved). **Correction:** Groww `exchange_token` max = 1,175,236 → fits u32; NO ID-width change. Per-feed native ID in `security_id`, `feed` distinguishes, `isin` bridges. | large | design PR |
+| Q5 | WS-GAP-06 illiquid-SID tick gaps | investigate (likely market reality) | — | queued |
+| Q6 | Telegram egress failures | environment (network) | — | queued |
+
+## Item A — Design (THIS PR)
+
+The `/feeds` page loads (read is public). But flipping a feed = `POST /api/feeds/{feed}`,
+which is bearer-protected; the page sends no token, and on the operator's Mac auth IS
+enabled (SSM token exists) → 401 `GAP-SEC-01: API auth failed — missing Authorization header`.
+
+**Fix:** in dry-run/sandbox (no real orders), the mutating feed-toggle route is PUBLIC so
+the operator flips feeds tokenless on localhost. In live trading (`dry_run=false`) it stays
+bearer-protected. Threaded via a `dry_run`/`feed_toggle_public` arg into
+`build_router_with_auth`; the Dhan-disable safety gate (`can_disable_dhan`) is UNCHANGED.
+
+## Edge Cases
+- dry_run=true → POST public (200, tokenless); GET already public.
+- dry_run=false (live) → POST still 401 without token (security preserved).
+- Dhan-disable while live trading → still 409 via existing `can_disable_dhan` gate.
+
+## Failure Modes
+- If the flag is mis-threaded false in dev → operator just can't toggle (same as today, no regression).
+- No new panic/alloc; cold-path boot wiring only.
+
+## Test Plan
+- `test_feeds_post_public_200_without_token_in_dry_run` (new)
+- `test_feeds_post_requires_auth_401_without_token` (live mode — keep, pass dry_run=false)
+- `cargo test -p tickvault-api --lib`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`
+
+## Rollback
+- Single api-crate change; `git revert`. Item is independent.
+
+## Observability
+- No new ERROR codes. The 401 WARN simply stops firing in dev because the route is public.
+
+## Scenarios
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | dev: flip Dhan/Groww on page, no token | toggles, applies live |
+| 2 | live: flip without token | 401 (protected) |
+| 3 | live: disable Dhan with token while trading | 409 (safety gate) |
+
+## Per-item guarantee matrix
+Cross-references `.claude/rules/project/per-wave-guarantee-matrix.md`. Honest envelope: this
+PR fixes one bounded auth-UX issue with regression tests both directions (dev public / live
+authed); no hot-path change; O(1) route wiring.

--- a/.claude/plans/active-plan-feed-followups.md
+++ b/.claude/plans/active-plan-feed-followups.md
@@ -12,8 +12,32 @@
 | **A** | **Feed ON/OFF not working in `/feeds` webpage** | Tokenless toggle in dev/sandbox (operator approved) | small | **THIS PR** |
 | **B** | Remove `option_chain_minute_snapshot` table + its writer/scheduler ONLY | Keep the prev-day-OI fetch so candle `oi_pct_from_prev_day` survives (operator approved "remove only the snapshot table") | medium | next PR |
 | **C** | Per-feed instrument identity + `feed` on data+master tables | Dedicated design PR (operator approved). **Correction:** Groww `exchange_token` max = 1,175,236 → fits u32; NO ID-width change. Per-feed native ID in `security_id`, `feed` distinguishes, `isin` bridges. | large | design PR |
+| **D** | **Fully-dynamic per-feed lifecycle (no restart)** | Operator approved 2026-06-23: flip ON in `/feeds` → LIVE-start that feed's auth + instrument fetch + subscription; OFF → tear down. No restart ever. | **LARGE (design PR)** | queued (priority after #1191) |
 | Q5 | WS-GAP-06 illiquid-SID tick gaps | investigate (likely market reality) | — | queued |
 | Q6 | Telegram egress failures | environment (network) | — | queued |
+
+## Item D — Fully-dynamic per-feed lifecycle (design notes)
+
+**Already true (verified in `main.rs`):** per-feed *boot* isolation — a feed OFF at boot
+touches NO auth/instruments (Dhan skip L261/L436/L1224; Groww gate L277; both-off halt L270).
+So "OFF = nothing runs" already holds at startup.
+
+**Gap D closes:** the runtime `/feeds` toggle today only pauses/resumes a lane started at
+boot. D makes the toggle drive the FULL lifecycle:
+
+| Flip | Dhan lane | Groww lane |
+|---|---|---|
+| ON (was OFF at boot) | auth (TOTP→JWT) → daily-universe instrument fetch → main-feed WS subscribe + order-update WS | access-token auth → master CSV + NTM ISIN join → bridge/sidecar |
+| OFF (was ON) | close WS(es), stop storing, drop token-renewal; keep audit | pause bridge, stop sidecar, stop storing |
+
+**Honest envelope:** NOT "never fails / all permutations" — a bounded, ratcheted per-feed
+`LaneState {Off→Starting→Running→Stopping}` driven by the runtime flag; each transition
+idempotent + audited; Dhan-disable safety gate (`can_disable_dhan`, no live orders)
+preserved; ON-transition reuses the EXISTING boot fns (refactored callable post-boot — no
+duplicate logic); a failed ON (auth/CSV fail) leaves the lane OFF + errors, never half-started
+(Rule 14). 3-agent review (auth + WS + instruments). **Split:** D1 = Groww lane (lower risk,
+default-OFF, no orders); D2 = Dhan lane (higher risk — token + universe + 2 WS). Ships AFTER
+#1191 merges, serial.
 
 ## Item A — Design (THIS PR)
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -66,7 +66,8 @@ pub fn build_router(state: SharedAppState, allowed_origins: &[String], dry_run: 
     // In dry_run mode: missing token = passthrough (dev mode).
     // In live mode: missing token = auto-generated token, auth still enforced.
     let auth_config = ApiAuthConfig::from_env(dry_run);
-    build_router_with_auth(state, allowed_origins, auth_config)
+    // dry-run → tokenless feed-toggle (operator flips feeds on the page without a token).
+    build_router_with_auth(state, allowed_origins, auth_config, dry_run)
 }
 
 /// Builds the router with a pre-resolved [`ApiAuthConfig`].
@@ -83,11 +84,17 @@ pub fn build_router(state: SharedAppState, allowed_origins: &[String], dry_run: 
 /// * `state` — shared application state for handlers
 /// * `allowed_origins` — list of allowed CORS origin URLs (from config)
 /// * `auth_config` — pre-resolved auth config (SSM-fetched in prod, env-fallback in dev)
+/// * `auth_config` — pre-resolved auth config (SSM-fetched in prod, env-fallback in dev)
+/// * `feed_toggle_public` — when `true` (dry-run/sandbox, no real orders) the mutating
+///   `POST /api/feeds/{feed}` is PUBLIC so the operator flips feeds tokenless on
+///   localhost; when `false` (live trading) it stays bearer-protected. The
+///   Dhan-disable safety gate (`can_disable_dhan`) is unchanged either way.
 // O(1) EXEMPT: begin — cold path, called once at boot
 pub fn build_router_with_auth(
     state: SharedAppState,
     allowed_origins: &[String],
     auth_config: ApiAuthConfig,
+    feed_toggle_public: bool,
 ) -> Router {
     let cors = build_cors_layer(allowed_origins);
 
@@ -99,20 +106,27 @@ pub fn build_router_with_auth(
     // runtime per-feed enable/disable. `GET /api/feeds` reports state;
     // `POST /api/feeds/{feed}` flips it (Groww only — slice 1). Behind bearer
     // auth so only the operator can change the live feed topology.
-    // Only the MUTATING flip stays bearer-protected (operator AskUserQuestion
-    // 2026-06-23: "public read, authed toggle"). The read-only status + health
-    // GETs carry no secrets (FeedHealthRow is &'static str only) and move to the
-    // PUBLIC router below so the /feeds page renders with no token; disabling or
-    // enabling a feed still requires the bearer token.
-    let protected_routes: Router<SharedAppState> = Router::new()
-        .route(
-            "/api/feeds/{feed}",
+    // The read-only status + health GETs carry no secrets (FeedHealthRow is
+    // &'static str only) → always PUBLIC (below) so the /feeds page renders with
+    // no token. The MUTATING flip `POST /api/feeds/{feed}`:
+    //   • dry-run/sandbox (feed_toggle_public=true, no real orders) → PUBLIC, so
+    //     the operator flips feeds tokenless on localhost (operator 2026-06-23);
+    //   • live trading (false) → bearer-protected.
+    // The Dhan-disable safety gate (can_disable_dhan) is unchanged either way.
+    // `auth_config` is consumed by the layer below regardless of branch (so no
+    // unused-variable lint when the toggle is public and the router is empty).
+    const FEED_TOGGLE_PATH: &str = "/api/feeds/{feed}";
+    let protected_base: Router<SharedAppState> = if feed_toggle_public {
+        Router::new()
+    } else {
+        Router::new().route(
+            FEED_TOGGLE_PATH,
             axum::routing::post(handlers::feeds::set_feed),
         )
-        .layer(axum::middleware::from_fn_with_state(
-            auth_config,
-            require_bearer_auth,
-        ));
+    };
+    let protected_routes: Router<SharedAppState> = protected_base.layer(
+        axum::middleware::from_fn_with_state(auth_config, require_bearer_auth),
+    );
 
     // Public routes — read-only GET endpoints (no auth required).
     //
@@ -174,6 +188,18 @@ pub fn build_router_with_auth(
             "/api/debug/cross-verify/latest",
             axum::routing::get(handlers::debug::cross_verify_latest),
         );
+
+    // dry-run/sandbox: the mutating feed-toggle is PUBLIC (tokenless) so the
+    // /feeds page can flip feeds without a token on localhost. In live trading
+    // this branch is skipped and the toggle lives in `protected_routes` above.
+    let public_routes = if feed_toggle_public {
+        public_routes.route(
+            FEED_TOGGLE_PATH,
+            axum::routing::post(handlers::feeds::set_feed),
+        )
+    } else {
+        public_routes
+    };
 
     // PR #2 (2026-05-18): conditional `/api/movers/v2` route + the
     // `cascade_fanout` accessor on AppState retired. See above comment
@@ -316,7 +342,7 @@ mod tests {
         let token = SecretString::from("ssm-fetched-token-test".to_string());
         let auth_config = ApiAuthConfig::from_token(token);
         assert!(auth_config.enabled, "from_token must enable auth");
-        let _router = build_router_with_auth(state, &[], auth_config);
+        let _router = build_router_with_auth(state, &[], auth_config, false);
     }
 
     #[test]
@@ -489,7 +515,7 @@ mod tests {
         // mutating POST /api/feeds/{feed} is bearer-gated (next test). Regression
         // ratchet: this must stay 200 without a token.
         let auth = ApiAuthConfig::from_token(SecretString::from("secret-tok".to_string()));
-        let router = build_router_with_auth(auth_test_state(), &[], auth);
+        let router = build_router_with_auth(auth_test_state(), &[], auth, false);
 
         let response = router
             .oneshot(
@@ -514,7 +540,7 @@ mod tests {
         // FeedHealthRow is &'static str only) so the operator can watch live-feed
         // health without a token.
         let auth = ApiAuthConfig::from_token(SecretString::from("secret-tok".to_string()));
-        let router = build_router_with_auth(auth_test_state(), &[], auth);
+        let router = build_router_with_auth(auth_test_state(), &[], auth, false);
 
         let response = router
             .oneshot(
@@ -536,7 +562,7 @@ mod tests {
         use tower::ServiceExt;
 
         let auth = ApiAuthConfig::from_token(SecretString::from("secret-tok".to_string()));
-        let router = build_router_with_auth(auth_test_state(), &[], auth);
+        let router = build_router_with_auth(auth_test_state(), &[], auth, false);
 
         let response = router
             .oneshot(
@@ -553,6 +579,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_feeds_post_public_200_without_token_in_dry_run() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use secrecy::SecretString;
+        use tower::ServiceExt;
+
+        // operator AskUserQuestion 2026-06-23 ("tokenless toggle in dev"): with
+        // feed_toggle_public=true (dry-run/sandbox, no real orders) the mutating
+        // POST /api/feeds/{feed} is PUBLIC so the operator flips feeds on the page
+        // with no token. Auth is still ENABLED (token present) — proving the route
+        // is public, not that auth is off. Regression ratchet: must stay 200.
+        let auth = ApiAuthConfig::from_token(SecretString::from("secret-tok".to_string()));
+        let router = build_router_with_auth(auth_test_state(), &[], auth, true);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/api/feeds/groww")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"enabled":true}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn test_feeds_page_is_public_200_without_auth() {
         use axum::body::Body;
         use axum::http::Request;
@@ -563,7 +618,7 @@ mod tests {
         // public route — only the data/toggle `/api/feeds` calls it issues are
         // bearer-gated. The page must load so the operator can paste their token.
         let auth = ApiAuthConfig::from_token(SecretString::from("secret-tok".to_string()));
-        let router = build_router_with_auth(auth_test_state(), &[], auth);
+        let router = build_router_with_auth(auth_test_state(), &[], auth, false);
 
         let response = router
             .oneshot(

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -2015,6 +2015,9 @@ async fn main() -> Result<()> {
             api_state,
             &config.api.allowed_origins,
             api_auth_config_fast,
+            // dry-run/sandbox → tokenless feed-toggle so the /feeds page flips feeds
+            // without a token; live trading keeps the toggle bearer-protected.
+            config.strategy.dry_run,
         );
         let bind_addr: SocketAddr = format_bind_addr(&config.api.host, config.api.port)
             .parse()
@@ -4867,6 +4870,9 @@ async fn main() -> Result<()> {
         api_state,
         &config.api.allowed_origins,
         api_auth_config,
+        // dry-run/sandbox → tokenless feed-toggle so the /feeds page flips feeds
+        // without a token; live trading keeps the toggle bearer-protected.
+        config.strategy.dry_run,
     );
 
     let bind_addr: SocketAddr = format_bind_addr(&config.api.host, config.api.port)


### PR DESCRIPTION
## Summary

After #1190 the `/feeds` page **loads** (read is public), but flipping a feed ON/OFF was still rejected — every click logged `GAP-SEC-01: API auth failed — missing Authorization header` (401). Root cause: `POST /api/feeds/{feed}` is bearer-protected, the page sends no token, and on the operator's Mac auth IS enabled (SSM token present) → the operator literally cannot enable/disable feeds.

## Fix (operator-approved: "tokenless toggle in dev")

Thread `feed_toggle_public` into `build_router_with_auth`:
- **dry-run / sandbox** (no real orders) → the mutating `POST /api/feeds/{feed}` is **PUBLIC**, so the operator flips feeds tokenless on localhost.
- **live trading** (`dry_run = false`) → the toggle stays **bearer-protected**.
- The Dhan-disable safety gate (`can_disable_dhan`) is **unchanged** — you still can't kill Dhan mid-live-trade.
- Read endpoints (`GET /api/feeds` + `/api/feeds/health`) remain public either way.

Both `main.rs` call sites pass `config.strategy.dry_run`; the `build_router` wrapper passes its `dry_run`.

## Honest envelope
This is a bounded auth-routing change with regression tests both directions; no hot-path/alloc change; O(1) route wiring. It does NOT relax the SSM-token model — in live mode the toggle is still authed.

## Test plan
- [x] `test_feeds_post_public_200_without_token_in_dry_run` (new) → 200 with auth ENABLED but `feed_toggle_public=true`
- [x] `test_feeds_post_requires_auth_401_without_token` (live, `feed_toggle_public=false`) → still 401
- [x] `cargo test -p tickvault-api --lib` → 227 passed
- [x] `cargo clippy -p tickvault-api -p tickvault-app -- -D warnings` → clean
- [x] `cargo fmt --check` → clean

## Runtime check (operator, Mac)
Re-run the app → open `http://localhost:3001/feeds` → flip Dhan/Groww ON/OFF with the token box **blank** → it toggles (no 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVujrL7UacwQaB346GoJKh)_