### PR TITLE
fix(storage): add designated `ts` to cross_verify audit DEDUP keys + close meta-guard multi-line blind spot

### DIFF
--- a/.claude/plans/active-plan-fix-audit-dedup-ts.md
+++ b/.claude/plans/active-plan-fix-audit-dedup-ts.md
@@ -1,0 +1,67 @@
+# Implementation Plan: fix audit DEDUP `ts` + close the meta-guard multi-line blind spot
+
+**Status:** VERIFIED (operator AskUserQuestion 2026-06-23: "Fix it now")
+**Date:** 2026-06-23
+**Branch:** `claude/fix-audit-dedup-ts-and-scanner` (off origin/main).
+
+## Design
+
+Two cross_verify audit tables omit the designated timestamp `ts` from their
+`DEDUP UPSERT KEYS(...)`. QuestDB **requires** the designated timestamp in the
+DEDUP key (documented: `dedup_segment_meta_guard.rs` cites the 2026-05-18
+production HTTP-400 incident). The violation was hidden because the meta-guard's
+`collect_dedup_key_declarations` scanner only reads SINGLE-LINE consts, and both
+constants are rustfmt-wrapped across two lines.
+
+Fix = (a) make the scanner multi-line-aware so the guard can SEE these consts
+(turns the latent bug into a build failure that can never hide again), and
+(b) prepend `ts` to both constants + add a `DEDUP ENABLE` self-heal so existing
+on-disk tables get the corrected key.
+
+**Dedup semantics (honest):** `run_ts_ist_nanos` is the run instant. With `ts`
+in the key, two runs on the same day keep DISTINCT rows (accumulate per run) —
+acceptable for a once-a-day forensic audit; WITHIN one run, identical
+`(date, sid, segment, minute, field)` cells collapse (ts constant for that run),
+which is strictly better than today's no-dedup state. (The prior agent's
+"latest run wins" claim was WRONG and is NOT relied upon.)
+
+## Plan Items
+
+- [x] **F1 — multi-line-aware scanner** in `crates/storage/tests/dedup_segment_meta_guard.rs`
+  - Make `collect_dedup_key_declarations` find the `"..."` body on a continuation
+    line; switch the per-feed test back to the shared collector; remove the
+    now-redundant `find_dedup_key_body` helper.
+- [x] **F2 — prepend `ts` to both cross_verify DEDUP keys**
+  - `crates/storage/src/cross_verify_1m_audit_persistence.rs` (`DEDUP_KEY_CROSS_VERIFY_1M_AUDIT`)
+  - `crates/storage/src/groww_cross_verify_audit_persistence.rs` (`DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT`)
+- [x] **F3 — DEDUP ENABLE self-heal** in both `ensure_*` fns (column already exists;
+  re-apply key with `ts` for tables created with the old key). Never drops a table.
+- [x] **F4 — update exact-string DEDUP tests** in both persistence files.
+
+## Edge Cases
+- Existing table created with old key → `DEDUP ENABLE UPSERT KEYS(ts, …)` re-applies in place (no drop, SEBI-safe).
+- Fresh table → CREATE DDL now interpolates the corrected const → valid first time.
+
+## Failure Modes
+- The `every_audit_dedup_key_must_include_designated_timestamp_ts` guard now SEES
+  the multi-line consts → fails the build until F2 lands (intended; both done in this PR).
+- Live QuestDB verification PENDING (Docker offline in this env) — documented honestly.
+
+## Test Plan
+- `cargo test -p tickvault-storage --test dedup_segment_meta_guard` (all guards green, multi-line now scanned)
+- `cargo test -p tickvault-storage --lib cross_verify_1m_audit groww_cross_verify`
+- `cargo clippy -p tickvault-storage -- -D warnings` + `cargo fmt --check`
+- 3-agent adversarial review on the diff (charter §E).
+
+## Rollback
+- Single feature branch; `git revert`. DEDUP-key flips are idempotent + in-place.
+
+## Observability
+- No new metric. Fix restores correct DEDUP on two forensic audit tables.
+
+## Scenarios
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | fresh boot | both tables CREATE successfully with `ts` in the key |
+| 2 | existing table (old key) | `DEDUP ENABLE` self-heal re-applies the `ts` key in place |
+| 3 | meta-guard | multi-line consts are now scanned; missing `ts` fails the build |

--- a/crates/storage/src/cross_verify_1m_audit_persistence.rs
+++ b/crates/storage/src/cross_verify_1m_audit_persistence.rs
@@ -23,7 +23,7 @@
 //!     our_value        DOUBLE,
 //!     dhan_value       DOUBLE
 //! ) timestamp(ts) PARTITION BY DAY
-//!   DEDUP UPSERT KEYS(trading_date_ist, security_id, segment, minute_ts_ist, field);
+//!   DEDUP UPSERT KEYS(ts, trading_date_ist, security_id, segment, minute_ts_ist, field);
 //! ```
 //!
 //! DEDUP key includes `(security_id, segment)` per I-P1-11 plus the
@@ -48,11 +48,13 @@ use tickvault_common::config::QuestDbConfig;
 /// QuestDB table name. One row per mismatched (instrument, minute, field).
 pub const CROSS_VERIFY_1M_AUDIT_TABLE: &str = "cross_verify_1m_audit";
 
-/// DEDUP UPSERT key — includes the designated timestamp-partition discriminators
-/// plus `(security_id, segment)` per I-P1-11. The `dedup_segment_meta_guard`
-/// workspace test scans this constant; it MUST mention `segment`.
+/// DEDUP UPSERT key — the designated timestamp `ts` FIRST (QuestDB requires the
+/// designated timestamp column in every DEDUP key — 2026-05-18 production HTTP-400
+/// regression), then the discriminators + `(security_id, segment)` per I-P1-11.
+/// The `dedup_segment_meta_guard` workspace test scans this constant; it MUST
+/// mention `ts` AND `segment`.
 pub const DEDUP_KEY_CROSS_VERIFY_1M_AUDIT: &str =
-    "trading_date_ist, security_id, segment, minute_ts_ist, field";
+    "ts, trading_date_ist, security_id, segment, minute_ts_ist, field";
 
 const QUESTDB_DDL_TIMEOUT_SECS: u64 = 10;
 
@@ -229,6 +231,31 @@ pub async fn ensure_cross_verify_1m_audit_table(questdb_config: &QuestDbConfig) 
             "cross_verify_1m_audit: ALTER ADD COLUMN feed request failed"
         ),
     }
+
+    // Self-heal the DEDUP key on tables created BEFORE the designated-timestamp
+    // fix (2026-06-23): the old key omitted `ts`, which QuestDB rejects. Re-apply
+    // the corrected key in place. Idempotent; never drops the table (SEBI).
+    let dedup_reenable_ddl = format!(
+        "ALTER TABLE {CROSS_VERIFY_1M_AUDIT_TABLE} DEDUP ENABLE UPSERT KEYS({DEDUP_KEY_CROSS_VERIFY_1M_AUDIT})"
+    );
+    match client
+        .get(&base_url)
+        .query(&[("query", dedup_reenable_ddl.as_str())])
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            error!(%status, body = %body.chars().take(200).collect::<String>(),
+                "cross_verify_1m_audit: DEDUP ENABLE UPSERT KEYS returned non-2xx");
+        }
+        Err(err) => error!(
+            ?err,
+            "cross_verify_1m_audit: DEDUP ENABLE UPSERT KEYS request failed"
+        ),
+    }
 }
 
 /// Lazy-connect ILP writer for the `cross_verify_1m_audit` table. Mirrors
@@ -372,6 +399,15 @@ mod tests {
         assert!(DEDUP_KEY_CROSS_VERIFY_1M_AUDIT.contains("security_id"));
         assert!(DEDUP_KEY_CROSS_VERIFY_1M_AUDIT.contains("minute_ts_ist"));
         assert!(DEDUP_KEY_CROSS_VERIFY_1M_AUDIT.contains("field"));
+        // QuestDB requires the designated timestamp `ts` in every DEDUP key
+        // (2026-05-18 HTTP-400 regression). Pin it as the first token.
+        assert!(
+            DEDUP_KEY_CROSS_VERIFY_1M_AUDIT
+                .split([',', ' '])
+                .map(str::trim)
+                .any(|t| t == "ts"),
+            "DEDUP key must include the designated timestamp `ts`: {DEDUP_KEY_CROSS_VERIFY_1M_AUDIT}"
+        );
     }
 
     #[test]
@@ -388,7 +424,7 @@ mod tests {
             "our_value        DOUBLE",
             "dhan_value       DOUBLE",
             "PARTITION BY DAY",
-            "DEDUP UPSERT KEYS(trading_date_ist, security_id, segment, minute_ts_ist, field)",
+            "DEDUP UPSERT KEYS(ts, trading_date_ist, security_id, segment, minute_ts_ist, field)",
         ] {
             assert!(ddl.contains(needle), "DDL missing: {needle}\n{ddl}");
         }

--- a/crates/storage/src/groww_cross_verify_audit_persistence.rs
+++ b/crates/storage/src/groww_cross_verify_audit_persistence.rs
@@ -28,7 +28,7 @@
 //!     live_value       DOUBLE,      -- our candles_1m (feed='groww') value
 //!     backtest_value   DOUBLE       -- Groww's authoritative backtest value
 //! ) timestamp(ts) PARTITION BY DAY
-//!   DEDUP UPSERT KEYS(trading_date_ist, security_id, segment, minute_ts_ist, field);
+//!   DEDUP UPSERT KEYS(ts, trading_date_ist, security_id, segment, minute_ts_ist, field);
 //! ```
 //!
 //! DEDUP key includes `(security_id, segment)` per I-P1-11 plus the
@@ -48,11 +48,13 @@ use tickvault_common::config::QuestDbConfig;
 /// QuestDB table name. One row per mismatched (instrument, minute, field).
 pub const GROWW_CROSS_VERIFY_1M_AUDIT_TABLE: &str = "groww_cross_verify_1m_audit";
 
-/// DEDUP UPSERT key — the designated timestamp-partition discriminators plus
-/// `(security_id, segment)` per I-P1-11. The `dedup_segment_meta_guard`
-/// workspace test scans this constant; it MUST mention `segment`.
+/// DEDUP UPSERT key — the designated timestamp `ts` FIRST (QuestDB requires the
+/// designated timestamp column in every DEDUP key — 2026-05-18 production HTTP-400
+/// regression), then the discriminators + `(security_id, segment)` per I-P1-11.
+/// The `dedup_segment_meta_guard` workspace test scans this constant; it MUST
+/// mention `ts` AND `segment`.
 pub const DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT: &str =
-    "trading_date_ist, security_id, segment, minute_ts_ist, field";
+    "ts, trading_date_ist, security_id, segment, minute_ts_ist, field";
 
 /// Feed-provenance label for the additive `feed` SYMBOL column (operator lock
 /// §32 + 2026-06-19 "all tables"). Every Groww-sourced row carries this.
@@ -195,6 +197,31 @@ pub async fn ensure_groww_cross_verify_1m_audit_table(questdb_config: &QuestDbCo
         Err(err) => error!(
             ?err,
             "groww_cross_verify_1m_audit: ALTER ADD COLUMN feed request failed"
+        ),
+    }
+
+    // Self-heal the DEDUP key on tables created BEFORE the designated-timestamp
+    // fix (2026-06-23): the old key omitted `ts`, which QuestDB rejects. Re-apply
+    // the corrected key in place. Idempotent; never drops the table (SEBI).
+    let dedup_reenable_ddl = format!(
+        "ALTER TABLE {GROWW_CROSS_VERIFY_1M_AUDIT_TABLE} DEDUP ENABLE UPSERT KEYS({DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT})"
+    );
+    match client
+        .get(&base_url)
+        .query(&[("query", dedup_reenable_ddl.as_str())])
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            error!(%status, body = %body.chars().take(200).collect::<String>(),
+                "groww_cross_verify_1m_audit: DEDUP ENABLE UPSERT KEYS returned non-2xx");
+        }
+        Err(err) => error!(
+            ?err,
+            "groww_cross_verify_1m_audit: DEDUP ENABLE UPSERT KEYS request failed"
         ),
     }
 }
@@ -344,6 +371,15 @@ mod tests {
         assert!(DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT.contains("security_id"));
         assert!(DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT.contains("minute_ts_ist"));
         assert!(DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT.contains("field"));
+        // QuestDB requires the designated timestamp `ts` in every DEDUP key
+        // (2026-05-18 HTTP-400 regression). Pin it as the first token.
+        assert!(
+            DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT
+                .split([',', ' '])
+                .map(str::trim)
+                .any(|t| t == "ts"),
+            "DEDUP key must include the designated timestamp `ts`: {DEDUP_KEY_GROWW_CROSS_VERIFY_1M_AUDIT}"
+        );
     }
 
     #[test]
@@ -360,7 +396,7 @@ mod tests {
             "live_value       DOUBLE",
             "backtest_value   DOUBLE",
             "PARTITION BY DAY",
-            "DEDUP UPSERT KEYS(trading_date_ist, security_id, segment, minute_ts_ist, field)",
+            "DEDUP UPSERT KEYS(ts, trading_date_ist, security_id, segment, minute_ts_ist, field)",
         ] {
             assert!(ddl.contains(needle), "DDL missing: {needle}\n{ddl}");
         }

--- a/crates/storage/tests/dedup_segment_meta_guard.rs
+++ b/crates/storage/tests/dedup_segment_meta_guard.rs
@@ -40,27 +40,23 @@ fn read_rust_files(dir: &Path) -> Vec<(PathBuf, String)> {
 
 /// Returns every line that declares a `DEDUP_KEY_*` constant with its
 /// `"..."` body, across all storage src files.
+/// Returns every `DEDUP_KEY_*` constant with its `"..."` body, across all
+/// storage src files. Robust to rustfmt wrapping the declaration across lines
+/// (`const X: &str =\n    "...";`): when the declaration line has no quote, the
+/// body is found on a following continuation line.
 fn collect_dedup_key_declarations() -> Vec<(PathBuf, usize, String, String)> {
     let mut out = Vec::new();
     for (path, content) in read_rust_files(&storage_src_dir()) {
-        for (idx, line) in content.lines().enumerate() {
+        let lines: Vec<&str> = content.lines().collect();
+        for (idx, line) in lines.iter().enumerate() {
             let trimmed = line.trim_start();
             if !trimmed.contains("DEDUP_KEY_") {
                 continue;
             }
-            // Only match declarations: `const DEDUP_KEY_X: &str = "..."`
+            // Only match declarations: `const DEDUP_KEY_X: &str = "..."`.
             if !trimmed.contains("const ") || !trimmed.contains(": &str") {
                 continue;
             }
-            // Extract the quoted body.
-            let start = match line.find('"') {
-                Some(p) => p + 1,
-                None => continue,
-            };
-            let end = match line[start..].find('"') {
-                Some(p) => start + p,
-                None => continue,
-            };
             // Extract the constant name — between `const ` and `:`.
             let after_const = line.split("const ").nth(1).unwrap_or("");
             let name = after_const
@@ -69,33 +65,24 @@ fn collect_dedup_key_declarations() -> Vec<(PathBuf, usize, String, String)> {
                 .unwrap_or("")
                 .trim()
                 .to_string();
-            let body = line[start..end].to_string();
-            out.push((path.clone(), idx.saturating_add(1), name, body));
-        }
-    }
-    out
-}
-
-/// Find a DEDUP-key constant's quoted body by NAME, robust to rustfmt wrapping
-/// the declaration across lines (`const X: &str =\n    "...";`). Used by the
-/// per-feed guard so it can see multi-line constants (e.g.
-/// `DEDUP_KEY_WS_EVENT_AUDIT`) WITHOUT changing the shared single-line collector
-/// the other guards rely on. Returns `(file, body)`.
-fn find_dedup_key_body(const_name: &str) -> Option<(PathBuf, String)> {
-    for (path, content) in read_rust_files(&storage_src_dir()) {
-        let marker = format!("const {const_name}:");
-        if let Some(decl_pos) = content.find(&marker) {
-            // First string literal after the declaration start.
-            let rest = &content[decl_pos..];
-            if let Some(s) = rest.find('"') {
-                let after = &rest[s + 1..];
-                if let Some(e) = after.find('"') {
-                    return Some((path, after[..e].to_string()));
+            // The quoted body may be on this line OR a continuation line. Scan
+            // forward up to a few lines until the first `"..."` literal appears.
+            let mut body: Option<String> = None;
+            for probe in lines.iter().skip(idx).take(4) {
+                if let Some(s) = probe.find('"') {
+                    let start = s + 1;
+                    if let Some(e) = probe[start..].find('"') {
+                        body = Some(probe[start..start + e].to_string());
+                        break;
+                    }
                 }
+            }
+            if let Some(body) = body {
+                out.push((path.clone(), idx.saturating_add(1), name, body));
             }
         }
     }
-    None
+    out
 }
 
 // ============================================================================
@@ -291,8 +278,10 @@ const FEED_KEYED_MARKET_DATA_KEYS: &[&str] = &[
 
 #[test]
 fn per_feed_market_data_dedup_keys_must_include_feed() {
+    let decls = collect_dedup_key_declarations();
     for expected in FEED_KEYED_MARKET_DATA_KEYS {
-        let (path, body) = find_dedup_key_body(expected).unwrap_or_else(|| {
+        let found = decls.iter().find(|(_, _, name, _)| name == expected);
+        let (path, line, _name, body) = found.unwrap_or_else(|| {
             panic!(
                 "per-feed DEDUP key `{expected}` not found in storage src — was it \
                  renamed/removed? It MUST exist and include `feed` (operator \
@@ -301,11 +290,12 @@ fn per_feed_market_data_dedup_keys_must_include_feed() {
         });
         assert!(
             body.contains("feed"),
-            "{} — {} = \"{}\" MUST include `feed` in its DEDUP key so a Dhan \
+            "{}:{} — {} = \"{}\" MUST include `feed` in its DEDUP key so a Dhan \
              and a Groww row for the same instrument/minute stay DISTINCT rows \
              (per-feed identity, operator 2026-06-23). Removing `feed` would \
              collapse the two feeds into one row.",
             path.display(),
+            line,
             expected,
             body
         );


### PR DESCRIPTION
## Summary

Fixes a **real pre-existing latent bug** found while reviewing the meta-guard during PR #1194: `cross_verify_1m_audit` + `groww_cross_verify_1m_audit` omit the designated timestamp `ts` from their `DEDUP UPSERT KEYS(...)`. QuestDB **requires** the designated timestamp in every DEDUP key (documented 2026-05-18 HTTP-400 production regression), so these tables were either rejecting the dedup clause at CREATE or silently running without dedup (accumulating duplicate audit rows).

**Why it hid:** the `dedup_segment_meta_guard` scanner only read **single-line** const declarations; both constants are rustfmt-wrapped across two lines, so the guard never saw them.

## Items completed
- [x] **F1** — meta-guard scanner is now **multi-line-aware** → `every_audit_dedup_key_must_include_designated_timestamp_ts` + `every_dedup_key_with_security_id_must_include_segment` now see these consts; the latent bug becomes a build failure that can never hide again. (Per-feed guard switched back to the shared collector; temporary `find_dedup_key_body` helper removed.)
- [x] **F2** — prepended `ts` to both DEDUP key constants
- [x] **F3** — `DEDUP ENABLE UPSERT KEYS(ts, …)` self-heal in both `ensure_*` fns (re-applies the corrected key in place on existing tables — never a drop, SEBI-safe; mirrors ticks/prev_day/ws_event)
- [x] **F4** — updated exact-string DDL + DEDUP tests in both files (incl. a `ts`-token assertion)

## Honest notes (no hallucination)
- **Dedup semantics:** `run_ts` differs per run, so with `ts` in the key two same-day runs keep distinct rows (accumulate per run) — acceptable for a once-a-day forensic audit; within one run, identical `(date,sid,segment,minute,field)` cells collapse. *(The earlier investigation's "latest run wins" claim was wrong and is NOT relied upon.)*
- **Live-QuestDB confirmation is PENDING** — Docker/QuestDB is offline in this environment (`http_code=000`). The fix is grounded in the documented QuestDB requirement + the meta-guard's own cited precedent, and is low-risk (the self-heal only logs on error, never drops a table).

## Test plan
- [x] `dedup_segment_meta_guard` 6 ✅ (multi-line consts now scanned; `ts` present)
- [x] cross_verify suites 19 ✅
- [x] `cargo fmt --check` + `cargo clippy -p tickvault-storage -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVujrL7UacwQaB346GoJKh)_