### PR TITLE
refactor(storage): converge Dhan+Groww ticks row build into shared build_tick_row_for_feed (C1)

### DIFF
--- a/.claude/plans/active-plan-c1c2-feed-convergence.md
+++ b/.claude/plans/active-plan-c1c2-feed-convergence.md
@@ -1,8 +1,9 @@
 # Implementation Plan: C1+C2 — Feed-Writer / Consumer-Loop Convergence
 
-**Status:** DRAFT
+**Status:** IN_PROGRESS
 **Date:** 2026-06-27
-**Approved by:** pending
+**Approved by:** pending (C1 implemented as a DRAFT PR — code shipped behind the
+shared builder; C2 still design-only)
 
 > **Scope:** This is a DESIGN document (docs-only). It plans, but does NOT yet
 > implement, the convergence of the two remaining per-feed code duplications
@@ -32,9 +33,64 @@
 
 ---
 
+## Design-review corrections (folded into C1, 2026-06-27)
+
+A 6-point adversarial design review of the C1 plan above produced these
+corrections. They are now the authoritative C1 contract (the prose above the
+line is the original DRAFT and is superseded where it conflicts):
+
+1. **Headline deliverable = the shared BUILDER fn, not a facade.** C1 ships ONE
+   `tick_row_builder::build_tick_row_for_feed(&mut Buffer, &RawTickFields, Feed)`
+   — the single source of the `ticks` ILP wire bytes for BOTH feeds. The facade
+   is incidental, NOT the precedent — only the shared row builder eliminates the
+   duplicated ILP append. (The `GenericTickWriter`-facade framing in the original
+   §C1 is dropped; the resilience tiers stay as-is per correction #5.)
+2. **First task = define `RawTickFields` (i64 volume + f64 LTP carrier), proven
+   BEFORE the builder lands.** The widen/passthrough test (E3) asserts Dhan
+   `u32` volume → `i64` in `RawTickFields` and Groww `i64` volume passes through
+   unchanged, and the f32→f64-clean LTP widen (E4) is proven, BEFORE asserting
+   any row bytes.
+3. **`received_at` is per-feed-OMITTED.** Add it to the Groww-NULL list: Dhan
+   writes `received_at`; Groww does NOT. A test asserts NO `received_at=` token
+   on a Groww row.
+4. **Corrected column inventory (recounted against the real `tick_persistence.rs`
+   source, NOT the original "19/9" claim):** the Dhan row is **2 SYMBOLs
+   (`segment`, `feed`) + 16 columns** (security_id, ltp, open, high, low, close,
+   volume, oi, avg_price, last_trade_qty, total_buy_qty, total_sell_qty,
+   exchange_timestamp, received_at, payload_hash, capture_seq) = 18
+   `new_unchecked` literals. The Groww row is **2 SYMBOLs + 5 columns**
+   (security_id, ltp, volume, exchange_timestamp, capture_seq). The remaining 11
+   columns are NULL for Groww.
+5. **Honest envelope:** C1 removes ~25 lines of duplicated ILP-append; it does
+   NOT unify the resilience tier. Dhan keeps ring→spill→DLQ; Groww keeps its
+   lazy-connect buffer (durable floor = sidecar capture-at-receipt file, §32).
+6. **What STAYS per-feed:** the pull/parse adapter; the `FeedStrategy` constant;
+   the per-feed numeric source typing (f32→f64-clean applied for Dhan at the
+   call site, skipped for Groww); the resilience tier; AND the **`capture_seq`
+   SOURCE** (Dhan = WAL `frame_seq`; Groww = `next_capture_seq` seeded from
+   `ts_ist_nanos`). Only the row STRING build is shared.
+
+**C1 shipped (DRAFT PR):**
+- `crates/storage/src/tick_row_builder.rs` — `RawTickFields` + `build_tick_row_for_feed`.
+- `crates/storage/src/tick_persistence.rs::build_tick_row_seq` — rewired to build
+  `RawTickFields` (all columns `Some`) + call the shared builder; byte-identical.
+- `crates/storage/src/groww_persistence.rs::append_row` — rewired to build
+  `RawTickFields` (Dhan-only columns `None` → NULL) + call the shared builder.
+- Tests: `tick_row_builder::tests` (E1 NULL-not-0, E3 widen, E4 ltp-widen,
+  feed-symbol, capture_seq, unchecked-name validity), the Dhan golden
+  byte-preservation test in `tick_persistence.rs`, the one-builder source guard
+  `crates/storage/tests/feed_tick_writer_convergence_guard.rs`, and the DHAT
+  zero-alloc test `crates/storage/tests/dhat_tick_row_builder.rs`.
+
+---
+
 ## Plan Items
 
-- [ ] **Item C1 — Sub-PR #1: unify the raw-tick WRITER (feed-parameterized)**
+- [x] **Item C1 — Sub-PR #1: unify the raw-tick WRITER row-builder (feed-parameterized)**
+  - Files: `crates/storage/src/tick_row_builder.rs` (new), `crates/storage/src/tick_persistence.rs`, `crates/storage/src/groww_persistence.rs`, `crates/storage/src/lib.rs`, `crates/storage/tests/feed_tick_writer_convergence_guard.rs` (new), `crates/storage/tests/dhat_tick_row_builder.rs` (new)
+  - Tests: `volume_carrier_dhan_u32_widens_and_groww_i64_passes_through`, `ltp_carrier_dhan_f32_widens_exactly`, `groww_row_omits_dhan_only_columns_null_not_zero`, `groww_row_has_no_received_at_token`, `dhan_row_contains_every_column`, `dhan_tick_row_is_byte_identical_golden`, `exactly_one_ticks_row_builder_function_exists`, `dhat_build_tick_row_for_feed_zero_alloc`, `shared_builder_unchecked_ilp_names_pass_validation`
+
+- [ ] **Item C1 (ORIGINAL DRAFT) — Sub-PR #1: unify the raw-tick WRITER (feed-parameterized)**
   - Files: `crates/storage/src/tick_persistence.rs`, `crates/storage/src/groww_persistence.rs`, `crates/storage/src/lib.rs`, `crates/app/src/groww_bridge.rs` (call-site swap), `crates/storage/tests/feed_tick_writer_convergence_guard.rs` (new)
   - Tests: `test_generic_tick_writer_dhan_full_columns`, `test_generic_tick_writer_groww_subset_columns_null_not_zero`, `test_generic_tick_writer_dedup_key_unchanged`, `test_generic_tick_writer_dhan_uses_f32_to_f64_clean`, `test_generic_tick_writer_groww_native_f64`, `test_one_raw_tick_writer_path_guard`, DHAT `dhat_generic_tick_writer_zero_alloc`
 

--- a/crates/storage/src/groww_persistence.rs
+++ b/crates/storage/src/groww_persistence.rs
@@ -42,10 +42,13 @@
 //! is NOT a stored column (the canonical ms is the nanos `ts`).
 
 use anyhow::{Context, Result};
-use questdb::ingress::{Buffer, ProtocolVersion, Sender, TimestampNanos};
+use questdb::ingress::{Buffer, ProtocolVersion, Sender};
 use tracing::warn;
 
 use tickvault_common::config::QuestDbConfig;
+use tickvault_common::feed::Feed;
+
+use crate::tick_row_builder::{RawTickFields, build_tick_row_for_feed};
 
 /// The SHARED `ticks` table — Groww writes here too (operator decision
 /// 2026-06-19, "same tables + feed column"), distinguished by `feed='groww'`.
@@ -168,27 +171,38 @@ impl GrowwLiveTickWriter {
     /// are BOTH kept. Symbols (`segment`, `feed`) precede all columns per ILP.
     /// O(1), zero alloc beyond the buffer's internal growth.
     pub fn append_row(&mut self, row: &GrowwLiveTickRow) -> Result<()> {
-        self.buffer
-            .table(SHARED_TICKS_TABLE)
-            .with_context(|| "groww ticks append: table() failed")?
-            .symbol("segment", row.segment)
-            .with_context(|| "groww ticks append: symbol(segment) failed")?
-            .symbol("feed", GROWW_FEED_LABEL)
-            .with_context(|| "groww ticks append: symbol(feed) failed")?
-            .column_i64("security_id", row.security_id)
-            .with_context(|| "groww ticks append: column_i64(security_id) failed")?
-            .column_f64("ltp", row.ltp)
-            .with_context(|| "groww ticks append: column_f64(ltp) failed")?
-            .column_i64("volume", row.volume)
-            .with_context(|| "groww ticks append: column_i64(volume) failed")?
+        // C1 convergence: emit the row via the ONE shared `ticks` builder. Groww
+        // is an LTP-only feed, so every Dhan-only column is `None` → the builder
+        // OMITS its token → the cell is NULL (never `0`). The designated `ts` is
+        // `row.ts_ist_nanos` verbatim, so Groww's MILLISECOND precision is
+        // preserved. `ltp` is native f64 (no f32→f64 widening — that is a
+        // Dhan-WebSocket-f32 concern, not Groww's; `data-integrity.md`).
+        let fields = RawTickFields {
+            security_id: row.security_id,
+            segment: row.segment,
+            ltp: row.ltp,
+            volume: row.volume,
+            ts_ist_nanos: row.ts_ist_nanos,
+            capture_seq: row.capture_seq,
             // `exchange_timestamp` LONG = IST epoch SECONDS (mirrors the Dhan
-            // column); the full ms lives in the designated `ts` below.
-            .column_i64("exchange_timestamp", row.ts_ist_nanos / 1_000_000_000)
-            .with_context(|| "groww ticks append: column_i64(exchange_timestamp) failed")?
-            .column_i64("capture_seq", row.capture_seq)
-            .with_context(|| "groww ticks append: column_i64(capture_seq) failed")?
-            .at(TimestampNanos::new(row.ts_ist_nanos))
-            .with_context(|| "groww ticks append: at(ts) failed")?;
+            // column); the full ms lives in the designated `ts`.
+            exchange_timestamp: Some(row.ts_ist_nanos / 1_000_000_000),
+            // Groww supplies none of the OHLC / OI / qty / avg_price /
+            // payload_hash / received_at columns → NULL (not 0).
+            open: None,
+            high: None,
+            low: None,
+            close: None,
+            oi: None,
+            avg_price: None,
+            last_trade_qty: None,
+            total_buy_qty: None,
+            total_sell_qty: None,
+            received_at_ist_nanos: None,
+            payload_hash: None,
+        };
+        build_tick_row_for_feed(&mut self.buffer, &fields, Feed::Groww)
+            .with_context(|| "groww ticks append: shared row build failed")?;
         self.pending = self.pending.saturating_add(1);
         Ok(())
     }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -159,6 +159,7 @@ pub mod shadow_candle_writer;
 pub mod shadow_persistence;
 pub mod shadow_seal_columns;
 pub mod tick_persistence;
+pub mod tick_row_builder;
 pub mod tick_spill_drain;
 // `valkey_cache` module DELETED in #O4 (2026-05-24) — no production caller
 // remained after PR #764 migrated the dual-instance lock to SSM.

--- a/crates/storage/src/tick_persistence.rs
+++ b/crates/storage/src/tick_persistence.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
-use questdb::ingress::{Buffer, Sender, TimestampNanos};
+use questdb::ingress::{Buffer, Sender};
 use reqwest::Client;
 use tracing::{debug, error, info, warn};
 
@@ -37,6 +37,8 @@ use tickvault_common::constants::{
 };
 use tickvault_common::segment::segment_code_to_str;
 use tickvault_common::tick_types::ParsedTick;
+
+use crate::tick_row_builder::{RawTickFields, build_tick_row_for_feed};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1483,114 +1485,40 @@ pub(crate) fn build_tick_row_seq(
     tick: &ParsedTick,
     capture_seq: i64,
 ) -> Result<()> {
-    use questdb::ingress::{ColumnName, TableName};
+    // C1 convergence: construct the feed-agnostic `RawTickFields` and emit the
+    // ILP row via the ONE shared builder. The Dhan branch fills EVERY column
+    // (none NULL); the per-feed-optional columns therefore all carry `Some(...)`,
+    // so the on-wire bytes are byte-IDENTICAL to the pre-C1 hand-written row.
+    // The f32→f64-clean + 2dp price conversion stays HERE (per-feed) so Groww's
+    // native f64 is never widened through the Dhan path.
+    //
+    // Dhan WebSocket `exchange_timestamp` is already IST epoch seconds → ×1e9
+    // for the designated `ts`, NO offset (`data-integrity.md`). `received_at`
+    // comes from `Utc::now()` (UTC) → +IST offset to align with IST `ts`.
+    let fields = RawTickFields {
+        security_id: i64::from(tick.security_id),
+        segment: segment_code_to_str(tick.exchange_segment_code),
+        ltp: round_to_2dp(f32_to_f64_clean(tick.last_traded_price)),
+        // Dhan ParsedTick.volume is u32; widens losslessly to the i64 carrier.
+        volume: i64::from(tick.volume),
+        ts_ist_nanos: i64::from(tick.exchange_timestamp).saturating_mul(1_000_000_000),
+        capture_seq,
+        open: Some(round_to_2dp(f32_to_f64_clean(tick.day_open))),
+        high: Some(round_to_2dp(f32_to_f64_clean(tick.day_high))),
+        low: Some(round_to_2dp(f32_to_f64_clean(tick.day_low))),
+        close: Some(round_to_2dp(f32_to_f64_clean(tick.day_close))),
+        oi: Some(i64::from(tick.open_interest)),
+        avg_price: Some(round_to_2dp(f32_to_f64_clean(tick.average_traded_price))),
+        last_trade_qty: Some(i64::from(tick.last_trade_quantity)),
+        total_buy_qty: Some(i64::from(tick.total_buy_quantity)),
+        total_sell_qty: Some(i64::from(tick.total_sell_quantity)),
+        exchange_timestamp: Some(i64::from(tick.exchange_timestamp)),
+        received_at_ist_nanos: Some(tick.received_at_nanos.saturating_add(IST_UTC_OFFSET_NANOS)),
+        // DEDUP tiebreaker content fingerprint (2026-06-08). Stored column only.
+        payload_hash: Some(tick_payload_hash(tick)),
+    };
 
-    // Dhan WebSocket exchange_timestamp is already IST epoch seconds.
-    // Store directly — no offset needed.
-    let ts_nanos =
-        TimestampNanos::new(i64::from(tick.exchange_timestamp).saturating_mul(1_000_000_000));
-    let received_nanos =
-        TimestampNanos::new(tick.received_at_nanos.saturating_add(IST_UTC_OFFSET_NANOS));
-
-    buffer
-        .table(TableName::new_unchecked(QUESTDB_TABLE_TICKS))
-        .context("table name")?
-        // QuestDB ILP requires ALL symbols before any column_*. `segment`
-        // is the only SYMBOL column on the `ticks` table after the #T1c
-        // table cleanup retired the `phase` SYMBOL column.
-        .symbol(
-            ColumnName::new_unchecked("segment"),
-            segment_code_to_str(tick.exchange_segment_code),
-        )
-        .context("segment")?
-        // `feed` SYMBOL — broker source, part of the DEDUP key (operator 2026-06-19).
-        // ILP requires ALL symbols before any column_*, so it sits with `segment`.
-        // Constant 'dhan' here (Dhan writer); future Groww path stamps 'groww'.
-        .symbol(ColumnName::new_unchecked("feed"), TICK_FEED_DHAN)
-        .context("feed")?
-        .column_i64(
-            ColumnName::new_unchecked("security_id"),
-            i64::from(tick.security_id),
-        )
-        .context("security_id")?
-        .column_f64(
-            ColumnName::new_unchecked("ltp"),
-            round_to_2dp(f32_to_f64_clean(tick.last_traded_price)),
-        )
-        .context("ltp")?
-        .column_f64(
-            ColumnName::new_unchecked("open"),
-            round_to_2dp(f32_to_f64_clean(tick.day_open)),
-        )
-        .context("open")?
-        .column_f64(
-            ColumnName::new_unchecked("high"),
-            round_to_2dp(f32_to_f64_clean(tick.day_high)),
-        )
-        .context("high")?
-        .column_f64(
-            ColumnName::new_unchecked("low"),
-            round_to_2dp(f32_to_f64_clean(tick.day_low)),
-        )
-        .context("low")?
-        .column_f64(
-            ColumnName::new_unchecked("close"),
-            round_to_2dp(f32_to_f64_clean(tick.day_close)),
-        )
-        .context("close")?
-        .column_i64(ColumnName::new_unchecked("volume"), i64::from(tick.volume))
-        .context("volume")?
-        .column_i64(
-            ColumnName::new_unchecked("oi"),
-            i64::from(tick.open_interest),
-        )
-        .context("oi")?
-        .column_f64(
-            ColumnName::new_unchecked("avg_price"),
-            round_to_2dp(f32_to_f64_clean(tick.average_traded_price)),
-        )
-        .context("avg_price")?
-        .column_i64(
-            ColumnName::new_unchecked("last_trade_qty"),
-            i64::from(tick.last_trade_quantity),
-        )
-        .context("last_trade_qty")?
-        .column_i64(
-            ColumnName::new_unchecked("total_buy_qty"),
-            i64::from(tick.total_buy_quantity),
-        )
-        .context("total_buy_qty")?
-        .column_i64(
-            ColumnName::new_unchecked("total_sell_qty"),
-            i64::from(tick.total_sell_quantity),
-        )
-        .context("total_sell_qty")?
-        .column_i64(
-            ColumnName::new_unchecked("exchange_timestamp"),
-            i64::from(tick.exchange_timestamp),
-        )
-        .context("exchange_timestamp")?
-        .column_ts(ColumnName::new_unchecked("received_at"), received_nanos)
-        .context("received_at")?
-        // DEDUP tiebreaker (2026-06-08): deterministic content fingerprint so
-        // distinct same-second ticks are both kept and true duplicates/replays
-        // collapse. See `tick_payload_hash` + the `DEDUP_KEY_TICKS` doc.
-        .column_i64(
-            ColumnName::new_unchecked("payload_hash"),
-            tick_payload_hash(tick),
-        )
-        .context("payload_hash")?
-        // TICK-SEQ-01: replay-stable capture sequence. On the live path this is
-        // the WS read-loop `frame_seq`; on WAL replay it is the SAME value read
-        // back from the v2 record — so a true duplicate collapses and distinct
-        // ticks are kept. Still a stored column only in this slice; the DEDUP key
-        // flip to capture_seq lands in PR-2b. See `.claude/plans/active-plan.md`.
-        .column_i64(ColumnName::new_unchecked("capture_seq"), capture_seq)
-        .context("capture_seq")?
-        .at(ts_nanos)
-        .context("designated timestamp")?;
-
-    Ok(())
+    build_tick_row_for_feed(buffer, &fields, tickvault_common::feed::Feed::Dhan)
 }
 
 /// Lifecycle values produced by `crates/core/src/pipeline/tick_enricher.rs`
@@ -2084,7 +2012,7 @@ fn current_time_ms() -> u64 {
 #[allow(clippy::arithmetic_side_effects)] // APPROVED: test-only arithmetic is not on hot path
 mod tests {
     use super::*;
-    use questdb::ingress::ProtocolVersion;
+    use questdb::ingress::{ProtocolVersion, TimestampNanos};
     use tickvault_common::constants::{
         EXCHANGE_SEGMENT_BSE_CURRENCY, EXCHANGE_SEGMENT_BSE_EQ, EXCHANGE_SEGMENT_BSE_FNO,
         EXCHANGE_SEGMENT_IDX_I, EXCHANGE_SEGMENT_MCX_COMM, EXCHANGE_SEGMENT_NSE_CURRENCY,
@@ -2134,6 +2062,42 @@ mod tests {
         }
     }
 
+    /// C1 byte-preservation golden test — the Dhan `build_tick_row_seq` output
+    /// (now routed through the shared `build_tick_row_for_feed`) must be
+    /// byte-IDENTICAL to the pre-C1 hand-written row for a representative Dhan
+    /// tick. The golden string below is the exact ILP line the hand-written
+    /// builder produced (captured from the pre-refactor code); any drift in the
+    /// converged builder fails the build, not the live ILP stream.
+    #[test]
+    fn dhan_tick_row_is_byte_identical_golden() {
+        use questdb::ingress::ProtocolVersion;
+        // NSE_FNO tick, ltp 21000.0; payload_hash + received_at are deterministic.
+        let tick = make_test_tick(49081, 21_000.0);
+        let mut buf = Buffer::new(ProtocolVersion::V1);
+        build_tick_row_seq(&mut buf, &tick, 777).expect("build");
+        let got = String::from_utf8_lossy(buf.as_bytes()).into_owned();
+
+        // received_at = (received_at_nanos + IST offset), serialized by ILP
+        // `column_ts` as MICROSECONDS (nanos / 1000, `t` suffix) — exactly as the
+        // pre-C1 hand-written row did. payload_hash from tick_payload_hash(tick).
+        // Both computed here to keep the golden self-checking rather than a frozen
+        // magic string for those two fields.
+        let received = tick.received_at_nanos.saturating_add(IST_UTC_OFFSET_NANOS) / 1_000;
+        let phash = tick_payload_hash(&tick);
+        let ts = i64::from(tick.exchange_timestamp).saturating_mul(1_000_000_000);
+        let expected = format!(
+            "ticks,segment=NSE_FNO,feed=dhan \
+             security_id=49081i,ltp=21000.0,open=20950.0,high=21020.0,low=20920.0,\
+             close=20900.0,volume=50000i,oi=120000i,avg_price=20990.0,last_trade_qty=75i,\
+             total_buy_qty=25000i,total_sell_qty=25000i,exchange_timestamp=1740556500i,\
+             received_at={received}t,payload_hash={phash}i,capture_seq=777i {ts}\n"
+        );
+        assert_eq!(
+            got, expected,
+            "Dhan ILP row must be byte-identical to golden"
+        );
+    }
+
     /// Spawn a background TCP server that accepts one connection and drains
     /// all data until EOF. Returns the port. Consolidates 10 identical
     /// spawn-accept-drain patterns into one site.
@@ -2178,14 +2142,19 @@ mod tests {
         port
     }
 
-    /// Latency-hunt 2026-06-10 ratchet: `build_tick_row_seq` uses
-    /// `TableName::new_unchecked` / `ColumnName::new_unchecked` to skip
-    /// questdb-rs per-row name validation (−262 ns/row measured). That is
-    /// sound ONLY while every literal passed to `new_unchecked` is a valid
-    /// ILP identifier — this test extracts every string literal passed to
-    /// `new_unchecked` in THIS source file and runs the CHECKED validators
-    /// over it, so an invalid name added later fails the build, not the
-    /// live ILP stream.
+    /// Latency-hunt 2026-06-10 ratchet (UPDATED by C1 convergence): the
+    /// `new_unchecked` ILP-name literals that this test originally scanned in
+    /// `build_tick_row_seq` MOVED into the shared
+    /// `tick_row_builder::build_tick_row_for_feed` (C1). Their CHECKED-validator
+    /// ratchet now lives there
+    /// (`tick_row_builder::tests::shared_builder_unchecked_ilp_names_pass_validation`).
+    ///
+    /// This test is retained to mechanically prove the literals are GONE from
+    /// `tick_persistence.rs` (the Dhan row build delegates), AND to keep the
+    /// "no non-literal `new_unchecked(`" hardening for any `new_unchecked` calls
+    /// that might be re-introduced into this file later — every such call must
+    /// still be a string literal (validated below) or the allowlisted
+    /// `QUESTDB_TABLE_TICKS` constant.
     #[test]
     fn test_tick_row_unchecked_ilp_names_pass_validation() {
         let source = include_str!("tick_persistence.rs");
@@ -2196,7 +2165,9 @@ mod tests {
             .split("mod tests {")
             .next()
             .unwrap_or_else(|| panic!("tests module marker missing"));
-        let mut found = 0_usize;
+        // Every `new_unchecked("…")` literal still in the production region must
+        // be a valid ILP identifier (defence-in-depth for a future re-introduced
+        // hand-built row). Zero is expected post-C1 (all moved to the builder).
         for chunk in production_region.split("new_unchecked(\"").skip(1) {
             let Some(end) = chunk.find('"') else {
                 panic!("unterminated new_unchecked literal");
@@ -2206,25 +2177,14 @@ mod tests {
                 .unwrap_or_else(|e| panic!("invalid ILP column name {name:?}: {e}"));
             questdb::ingress::TableName::new(name)
                 .unwrap_or_else(|e| panic!("invalid ILP table name {name:?}: {e}"));
-            found += 1;
         }
-        // 16 wrapped column names in build_tick_row_seq (the `segment`
-        // symbol + 15 columns); the table name goes through the
-        // QUESTDB_TABLE_TICKS constant, validated below. The count is a
-        // floor, not an exact pin, so doc-comment mentions don't break it.
-        assert!(
-            found >= 16,
-            "expected ≥16 new_unchecked literals in tick_persistence.rs, found {found}"
-        );
         questdb::ingress::TableName::new(QUESTDB_TABLE_TICKS)
             .unwrap_or_else(|e| panic!("invalid ILP table name {QUESTDB_TABLE_TICKS:?}: {e}"));
 
-        // Hostile-review MEDIUM #2 hardening: a future
-        // `new_unchecked(SOME_CONST)` call would silently dodge the
-        // literal scanner above. In the production region every
-        // `new_unchecked(` call must be either a double-quoted literal
-        // or the one allowlisted QUESTDB_TABLE_TICKS constant — any
-        // other shape fails here.
+        // Hostile-review MEDIUM #2 hardening (retained): any `new_unchecked(`
+        // call in the production region must be either a double-quoted literal
+        // (validated above) or the one allowlisted QUESTDB_TABLE_TICKS constant
+        // — any other shape fails here.
         let total_calls = production_region.matches("new_unchecked(").count();
         let literal_calls = production_region.matches("new_unchecked(\"").count();
         let allowlisted_const_calls = production_region

--- a/crates/storage/src/tick_row_builder.rs
+++ b/crates/storage/src/tick_row_builder.rs
@@ -1,0 +1,510 @@
+//! Shared `ticks` ILP **row builder** — the single source of the wire bytes for
+//! BOTH live feeds (C1 of the C1/C2 feed-convergence plan,
+//! `.claude/plans/active-plan-c1c2-feed-convergence.md`).
+//!
+//! ## Why this exists (the convergence)
+//!
+//! Before C1 the Dhan writer (`tick_persistence::build_tick_row_seq`) and the
+//! Groww writer (`groww_persistence::GrowwLiveTickWriter::append_row`) each
+//! HAND-WROTE a near-duplicate `ticks` ILP row (~25 lines of duplicated
+//! `.symbol(...)` / `.column_*(...)` / `.at(...)` calls). Two hand-written row
+//! paths into ONE shared table is exactly the drift risk the audit flagged: a
+//! future column/DEDUP-key change could land on one path and not the other.
+//!
+//! C1 converges ONLY that duplicated **row-string build** into the single
+//! [`build_tick_row_for_feed`] below. The deliverable is the shared BUILDER, not
+//! a facade — both writers now construct a [`RawTickFields`] and call this one
+//! function, so the table name, the DEDUP key columns, the SYMBOL-before-column
+//! ILP ordering, and the NULL-not-0 policy can NEVER diverge between feeds.
+//!
+//! ## Honest envelope (operator-charter §F)
+//!
+//! C1 removes ~25 lines of duplicated ILP-append; it does NOT unify the
+//! resilience tier. Dhan keeps its ring→spill→DLQ rescue chain
+//! (`tick_persistence`); Groww keeps its lazy-connect buffer whose durable floor
+//! is the sidecar capture-at-receipt file (lock §32). Only the row STRING build
+//! is shared. `capture_seq` SOURCES stay per-feed (Dhan = WAL `frame_seq`; Groww
+//! = `next_capture_seq` seeded from `ts_ist_nanos`).
+//!
+//! ## The NULL-not-0 contract (load-bearing)
+//!
+//! For every `Option` column that is `None`, the builder **OMITS the column
+//! token entirely** so QuestDB stores NULL — it NEVER writes `0`. A Groww LTP
+//! feed supplies no OHLC / OI / avg_price / qty fields / payload_hash /
+//! received_at, so those stay NULL (not a misleading `0`). Pinned by the
+//! NULL-not-0 wire-byte tests.
+//!
+//! ## Pre-validated ILP names (latency, inherited from `build_tick_row_seq`)
+//!
+//! questdb-rs re-validates every `&str` table/column name char-by-char on EVERY
+//! row; passing `TableName`/`ColumnName::new_unchecked` wrappers skips that. It is
+//! sound because every literal below is a static lowercase-ASCII identifier —
+//! mechanically proven by `tick_persistence::tests::
+//! test_tick_row_unchecked_ilp_names_pass_validation`, whose unchecked-name
+//! literal-scan over `tick_persistence.rs` is unaffected (the Dhan caller still
+//! routes through this builder, the literals live here now but are equally
+//! static), AND by [`tests::shared_builder_unchecked_ilp_names_pass_validation`]
+//! in this module.
+
+use anyhow::{Context, Result};
+use questdb::ingress::{Buffer, ColumnName, TableName, TimestampNanos};
+
+use tickvault_common::constants::QUESTDB_TABLE_TICKS;
+use tickvault_common::feed::Feed;
+
+/// Feed-agnostic input to [`build_tick_row_for_feed`], wide enough for BOTH
+/// feeds. Required-for-both fields are plain; per-feed-OPTIONAL columns are
+/// `Option<T>` so a feed that does not supply a value yields a NULL cell (the
+/// builder omits the token), never `0`.
+///
+/// ### Numeric carriers (E3 / E4)
+///
+/// - `volume: i64` — Groww keeps cumulative day volume as `i64` (it exceeds
+///   `u32` intraday). Dhan's `ParsedTick.volume` is `u32`; the caller widens it
+///   losslessly (`i64::from(u32)`) BEFORE building this struct. A Groww `i64`
+///   passes through unchanged — it is NEVER funnelled through a `u32` field.
+/// - `ltp: f64` — the common LTP carrier. Dhan's WebSocket LTP is `f32`; the
+///   caller applies `round_to_2dp(f32_to_f64_clean(f32))` so the `f32` widens to
+///   `f64` EXACTLY (shortest-decimal, no IEEE-754 widening artifact — see
+///   `data-integrity.md`) BEFORE building this struct. Groww's native `f64` is
+///   carried verbatim. Selecting `f64` as the carrier means the conversion +
+///   rounding stays a per-feed concern at the CALL site, not in this builder.
+///
+/// All fields are `Copy`; no heap allocation. `segment` + `feed` are
+/// `&'static str` so the SYMBOL writes are zero-alloc O(1).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RawTickFields {
+    // --- required for both feeds ---
+    /// Composite-key part 1 (I-P1-11), widened to `i64` for the LONG column.
+    pub security_id: i64,
+    /// Composite-key part 2 (I-P1-11) — `&'static` segment string
+    /// (`IDX_I` / `NSE_EQ` / `NSE_FNO` / …) for the `segment` SYMBOL.
+    pub segment: &'static str,
+    /// Last traded price (common `f64` carrier — see struct docs).
+    pub ltp: f64,
+    /// Cumulative day volume (`i64` — Groww-wide, Dhan widened from `u32`).
+    pub volume: i64,
+    /// Designated timestamp: IST epoch nanoseconds (NO offset applied here — the
+    /// caller normalises Dhan `exchange_timestamp × 1e9` / Groww `ts_ist_nanos`).
+    pub ts_ist_nanos: i64,
+    /// Replay-stable dedup tiebreaker (TICK-SEQ-01). Per-feed SOURCE; this
+    /// builder takes it as a value and never generates one.
+    pub capture_seq: i64,
+
+    // --- per-feed OPTIONAL columns: None => NULL cell (never 0) ---
+    /// Day open price. `None` for an LTP-only feed (Groww) → NULL.
+    pub open: Option<f64>,
+    /// Day high price. `None` → NULL.
+    pub high: Option<f64>,
+    /// Day low price. `None` → NULL.
+    pub low: Option<f64>,
+    /// Previous-session close (the Quote/Full `close` field). `None` → NULL.
+    pub close: Option<f64>,
+    /// Open interest. `None` → NULL.
+    pub oi: Option<i64>,
+    /// Average traded price (VWAP). `None` → NULL.
+    pub avg_price: Option<f64>,
+    /// Last trade quantity. `None` → NULL.
+    pub last_trade_qty: Option<i64>,
+    /// Total buy quantity. `None` → NULL.
+    pub total_buy_qty: Option<i64>,
+    /// Total sell quantity. `None` → NULL.
+    pub total_sell_qty: Option<i64>,
+    /// Raw exchange timestamp LONG = IST epoch SECONDS (verbatim audit column).
+    /// `None` → NULL. Both feeds today supply it, but it is optional so a future
+    /// feed without a wall-second stamp leaves NULL rather than a misleading 0.
+    pub exchange_timestamp: Option<i64>,
+    /// Local receive timestamp as IST nanoseconds (the `received_at` TIMESTAMP
+    /// column). Dhan supplies it; Groww does NOT (`None` → NULL).
+    pub received_at_ist_nanos: Option<i64>,
+    /// Deterministic content fingerprint (`payload_hash` LONG). Dhan supplies it;
+    /// Groww does NOT (`None` → NULL).
+    pub payload_hash: Option<i64>,
+}
+
+/// Writes ONE `ticks` ILP row for `feed` from `fields` into `buffer` (no flush).
+///
+/// The single converged row-string builder for BOTH live feeds (C1). `feed` is a
+/// compile-time `Copy` enum — the SYMBOL `feed=…` is `feed.as_str()` (`&'static
+/// str`, zero-alloc); there is NO `dyn`/trait-object dispatch on this per-tick
+/// path. ILP requires ALL symbols (`segment`, `feed`) before any `column_*`, so
+/// they are written first. For every `Option` column that is `None`, the
+/// matching `column_*` call is SKIPPED → the cell is NULL (never `0`).
+///
+/// O(1); zero heap allocation beyond the ILP buffer's own internal growth.
+#[inline]
+pub fn build_tick_row_for_feed(
+    buffer: &mut Buffer,
+    fields: &RawTickFields,
+    feed: Feed,
+) -> Result<()> {
+    let ts = TimestampNanos::new(fields.ts_ist_nanos);
+
+    // SYMBOLS first (ILP requires all symbols before any column_*).
+    buffer
+        .table(TableName::new_unchecked(QUESTDB_TABLE_TICKS))
+        .context("table name")?
+        .symbol(ColumnName::new_unchecked("segment"), fields.segment)
+        .context("segment")?
+        // `feed` is the broker source, part of the DEDUP key (operator
+        // 2026-06-19). `feed.as_str()` is the stable wire label ('dhan'/'groww').
+        .symbol(ColumnName::new_unchecked("feed"), feed.as_str())
+        .context("feed")?;
+
+    // Required-for-both columns.
+    buffer
+        .column_i64(ColumnName::new_unchecked("security_id"), fields.security_id)
+        .context("security_id")?
+        .column_f64(ColumnName::new_unchecked("ltp"), fields.ltp)
+        .context("ltp")?;
+
+    // Per-feed OPTIONAL price/qty columns — each omitted (NULL) when None.
+    // Written in the SAME order as the legacy Dhan path so the on-wire byte
+    // sequence is byte-identical for a fully-populated (Dhan) row.
+    if let Some(v) = fields.open {
+        buffer
+            .column_f64(ColumnName::new_unchecked("open"), v)
+            .context("open")?;
+    }
+    if let Some(v) = fields.high {
+        buffer
+            .column_f64(ColumnName::new_unchecked("high"), v)
+            .context("high")?;
+    }
+    if let Some(v) = fields.low {
+        buffer
+            .column_f64(ColumnName::new_unchecked("low"), v)
+            .context("low")?;
+    }
+    if let Some(v) = fields.close {
+        buffer
+            .column_f64(ColumnName::new_unchecked("close"), v)
+            .context("close")?;
+    }
+
+    // volume is required-for-both; in the legacy Dhan order it sits after
+    // close and before oi.
+    buffer
+        .column_i64(ColumnName::new_unchecked("volume"), fields.volume)
+        .context("volume")?;
+
+    if let Some(v) = fields.oi {
+        buffer
+            .column_i64(ColumnName::new_unchecked("oi"), v)
+            .context("oi")?;
+    }
+    if let Some(v) = fields.avg_price {
+        buffer
+            .column_f64(ColumnName::new_unchecked("avg_price"), v)
+            .context("avg_price")?;
+    }
+    if let Some(v) = fields.last_trade_qty {
+        buffer
+            .column_i64(ColumnName::new_unchecked("last_trade_qty"), v)
+            .context("last_trade_qty")?;
+    }
+    if let Some(v) = fields.total_buy_qty {
+        buffer
+            .column_i64(ColumnName::new_unchecked("total_buy_qty"), v)
+            .context("total_buy_qty")?;
+    }
+    if let Some(v) = fields.total_sell_qty {
+        buffer
+            .column_i64(ColumnName::new_unchecked("total_sell_qty"), v)
+            .context("total_sell_qty")?;
+    }
+    if let Some(v) = fields.exchange_timestamp {
+        buffer
+            .column_i64(ColumnName::new_unchecked("exchange_timestamp"), v)
+            .context("exchange_timestamp")?;
+    }
+    if let Some(v) = fields.received_at_ist_nanos {
+        buffer
+            .column_ts(
+                ColumnName::new_unchecked("received_at"),
+                TimestampNanos::new(v),
+            )
+            .context("received_at")?;
+    }
+    if let Some(v) = fields.payload_hash {
+        buffer
+            .column_i64(ColumnName::new_unchecked("payload_hash"), v)
+            .context("payload_hash")?;
+    }
+
+    // capture_seq is required-for-both and is the LAST column before `at(ts)`
+    // (matches the legacy Dhan order).
+    buffer
+        .column_i64(ColumnName::new_unchecked("capture_seq"), fields.capture_seq)
+        .context("capture_seq")?
+        .at(ts)
+        .context("designated timestamp")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use questdb::ingress::ProtocolVersion;
+
+    /// A fully-populated (Dhan-shape) `RawTickFields` — every Option is Some.
+    fn dhan_shape_fields() -> RawTickFields {
+        RawTickFields {
+            security_id: 13,
+            segment: "IDX_I",
+            ltp: 23_146.45,
+            volume: 1_234_567,
+            ts_ist_nanos: 1_780_000_000_000_000_000,
+            capture_seq: 42,
+            open: Some(23_100.00),
+            high: Some(23_200.00),
+            low: Some(23_050.00),
+            close: Some(23_090.00),
+            oi: Some(987_654),
+            avg_price: Some(23_145.10),
+            last_trade_qty: Some(50),
+            total_buy_qty: Some(10_000),
+            total_sell_qty: Some(9_000),
+            exchange_timestamp: Some(1_780_000_000),
+            received_at_ist_nanos: Some(1_780_000_000_111_000_000),
+            payload_hash: Some(-987_654_321),
+        }
+    }
+
+    /// A Groww-shape `RawTickFields` — only the required-for-both columns are
+    /// populated; every Dhan-only column is None (→ NULL on the wire).
+    fn groww_shape_fields() -> RawTickFields {
+        RawTickFields {
+            security_id: 1_333,
+            segment: "NSE_EQ",
+            ltp: 2_847.55,
+            volume: 1_234_567,
+            ts_ist_nanos: 1_780_000_000_123_000_000,
+            capture_seq: 42,
+            open: None,
+            high: None,
+            low: None,
+            close: None,
+            oi: None,
+            avg_price: None,
+            last_trade_qty: None,
+            total_buy_qty: None,
+            total_sell_qty: None,
+            exchange_timestamp: Some(1_780_000_000),
+            received_at_ist_nanos: None,
+            payload_hash: None,
+        }
+    }
+
+    fn build(fields: &RawTickFields, feed: Feed) -> String {
+        let mut buf = Buffer::new(ProtocolVersion::V1);
+        build_tick_row_for_feed(&mut buf, fields, feed).expect("build");
+        String::from_utf8_lossy(buf.as_bytes()).into_owned()
+    }
+
+    #[test]
+    fn dhan_row_contains_every_column() {
+        let text = build(&dhan_shape_fields(), Feed::Dhan);
+        assert!(text.starts_with("ticks,"), "shared ticks table: {text}");
+        assert!(text.contains("feed=dhan"), "dhan feed tag: {text}");
+        assert!(text.contains("IDX_I"), "segment");
+        for token in [
+            "security_id=",
+            "ltp=",
+            "open=",
+            "high=",
+            "low=",
+            "close=",
+            "volume=",
+            "oi=",
+            "avg_price=",
+            "last_trade_qty=",
+            "total_buy_qty=",
+            "total_sell_qty=",
+            "exchange_timestamp=",
+            "received_at=",
+            "payload_hash=",
+            "capture_seq=",
+        ] {
+            assert!(
+                text.contains(token),
+                "dhan row must contain {token}: {text}"
+            );
+        }
+    }
+
+    /// E1 + NULL-not-0: a Groww row OMITS every Dhan-only column entirely
+    /// (→ NULL), and never emits a `=0` placeholder for them.
+    #[test]
+    fn groww_row_omits_dhan_only_columns_null_not_zero() {
+        let text = build(&groww_shape_fields(), Feed::Groww);
+        assert!(text.starts_with("ticks,"), "shared ticks table: {text}");
+        assert!(text.contains("feed=groww"), "groww feed tag: {text}");
+        // present subset
+        for token in [
+            "security_id=",
+            "ltp=",
+            "volume=",
+            "exchange_timestamp=",
+            "capture_seq=",
+        ] {
+            assert!(
+                text.contains(token),
+                "groww row must contain {token}: {text}"
+            );
+        }
+        // absent columns — NO token at all (NULL), never =0
+        for token in [
+            "open=",
+            "high=",
+            "low=",
+            "close=",
+            "oi=",
+            "avg_price=",
+            "last_trade_qty=",
+            "total_buy_qty=",
+            "total_sell_qty=",
+            "received_at=",
+            "payload_hash=",
+        ] {
+            assert!(
+                !text.contains(token),
+                "groww row must NOT contain {token} (must be NULL, not 0): {text}"
+            );
+        }
+    }
+
+    /// E3 — the volume carrier is `i64`: a Dhan `u32` widens losslessly and a
+    /// Groww `i64` (which exceeds `u32` intraday) passes through unchanged.
+    /// `RawTickFields.volume` is `i64`, so neither can truncate.
+    #[test]
+    fn volume_carrier_dhan_u32_widens_and_groww_i64_passes_through() {
+        // Dhan: u32::MAX widens to i64 with no loss.
+        let dhan_vol_u32: u32 = u32::MAX;
+        let widened: i64 = i64::from(dhan_vol_u32);
+        assert_eq!(widened, 4_294_967_295_i64, "u32 widens losslessly to i64");
+        let mut f = dhan_shape_fields();
+        f.volume = widened;
+        assert!(build(&f, Feed::Dhan).contains("volume=4294967295i"));
+
+        // Groww: an i64 cum_volume larger than u32::MAX is carried verbatim — it
+        // is NEVER funnelled through a u32 (which would truncate it).
+        let groww_vol_i64: i64 = 5_000_000_000; // > u32::MAX
+        assert!(
+            groww_vol_i64 > i64::from(u32::MAX),
+            "value exceeds u32 range"
+        );
+        let mut g = groww_shape_fields();
+        g.volume = groww_vol_i64;
+        assert!(build(&g, Feed::Groww).contains("volume=5000000000i"));
+    }
+
+    /// E4 — the LTP carrier is `f64`: the Dhan caller pre-applies
+    /// `round_to_2dp(f32_to_f64_clean(f32))`, so a Dhan `f32` widens EXACTLY
+    /// (`10.20_f32` → `10.2`, not `10.19999980926514`). This builder carries the
+    /// already-converted `f64` verbatim (Groww's native f64 is likewise verbatim).
+    #[test]
+    fn ltp_carrier_dhan_f32_widens_exactly() {
+        let raw_f32: f32 = 10.20;
+        let clean = tickvault_common::price_precision::round_to_2dp(
+            tickvault_common::price_precision::f32_to_f64_clean(raw_f32),
+        );
+        assert!(
+            (clean - 10.2).abs() < f64::EPSILON,
+            "f32 10.20 must widen to exactly 10.2, got {clean}"
+        );
+        let mut f = dhan_shape_fields();
+        f.ltp = clean;
+        let text = build(&f, Feed::Dhan);
+        assert!(
+            text.contains("ltp=10.2"),
+            "clean-widened ltp on wire: {text}"
+        );
+        assert!(
+            !text.contains("10.19999"),
+            "no IEEE-754 widening artifact: {text}"
+        );
+    }
+
+    /// Explicit `received_at=` absence assertion (task requirement #3).
+    #[test]
+    fn groww_row_has_no_received_at_token() {
+        let text = build(&groww_shape_fields(), Feed::Groww);
+        assert!(
+            !text.contains("received_at="),
+            "Groww row must NOT carry received_at (Dhan-only): {text}"
+        );
+    }
+
+    /// The feed SYMBOL is driven by the `Feed` enum, not a literal.
+    #[test]
+    fn feed_symbol_matches_feed_enum_label() {
+        assert!(
+            build(&dhan_shape_fields(), Feed::Dhan)
+                .contains(&format!("feed={}", Feed::Dhan.as_str()))
+        );
+        assert!(
+            build(&groww_shape_fields(), Feed::Groww)
+                .contains(&format!("feed={}", Feed::Groww.as_str()))
+        );
+    }
+
+    /// Two distinct `capture_seq` values for otherwise-identical Groww rows are
+    /// BOTH emitted (the zero-loss tiebreaker — TICK-SEQ-01 `45→75→45` class).
+    #[test]
+    fn distinct_capture_seq_both_emitted() {
+        let mut buf = Buffer::new(ProtocolVersion::V1);
+        let mut a = groww_shape_fields();
+        a.capture_seq = 100;
+        let mut b = groww_shape_fields();
+        b.capture_seq = 101;
+        build_tick_row_for_feed(&mut buf, &a, Feed::Groww).expect("a");
+        build_tick_row_for_feed(&mut buf, &b, Feed::Groww).expect("b");
+        let text = String::from_utf8_lossy(buf.as_bytes());
+        assert!(text.contains("capture_seq=100"));
+        assert!(text.contains("capture_seq=101"));
+    }
+
+    /// Latency ratchet mirror: every `new_unchecked("…")` literal in THIS file's
+    /// production region is a valid ILP identifier under the CHECKED validators.
+    /// (`build_tick_row_seq`'s own ratchet still scans `tick_persistence.rs`;
+    /// this one covers the converged builder that moved here.)
+    #[test]
+    fn shared_builder_unchecked_ilp_names_pass_validation() {
+        let source = include_str!("tick_row_builder.rs");
+        let production_region = source
+            .split("mod tests {")
+            .next()
+            .unwrap_or_else(|| panic!("tests module marker missing"));
+        let mut found = 0_usize;
+        for chunk in production_region.split("new_unchecked(\"").skip(1) {
+            let Some(end) = chunk.find('"') else {
+                panic!("unterminated new_unchecked literal");
+            };
+            let name = &chunk[..end];
+            ColumnName::new(name)
+                .unwrap_or_else(|e| panic!("invalid ILP column name {name:?}: {e}"));
+            found += 1;
+        }
+        // 2 SYMBOLs (segment, feed) + 16 columns = 18 literal names.
+        assert_eq!(
+            found, 18,
+            "expected 18 new_unchecked literals, found {found}"
+        );
+        TableName::new(QUESTDB_TABLE_TICKS)
+            .unwrap_or_else(|e| panic!("invalid ILP table name {QUESTDB_TABLE_TICKS:?}: {e}"));
+        // Every new_unchecked( call must be a string literal or the allowlisted
+        // QUESTDB_TABLE_TICKS const (mirrors the tick_persistence ratchet).
+        let total = production_region.matches("new_unchecked(").count();
+        let literal = production_region.matches("new_unchecked(\"").count();
+        let allowlisted = production_region
+            .matches("new_unchecked(QUESTDB_TABLE_TICKS)")
+            .count();
+        assert_eq!(
+            total,
+            literal + allowlisted,
+            "non-literal new_unchecked arg present"
+        );
+    }
+}

--- a/crates/storage/tests/dhat_tick_row_builder.rs
+++ b/crates/storage/tests/dhat_tick_row_builder.rs
@@ -1,0 +1,73 @@
+//! DHAT zero-allocation test for the C1 shared `ticks` ILP row builder.
+//!
+//! Separate binary because DHAT allows only one profiler per process.
+//! Verifies Principle #1: the converged `build_tick_row_for_feed` adds NO heap
+//! allocation on the per-tick path beyond the ILP buffer's own internal growth.
+//! The buffer is pre-warmed (first row may grow its internal Vec), then 1000 rows
+//! are built into the SAME reused buffer — exactly how the production writer
+//! reuses its buffer between flushes.
+
+use questdb::ingress::{Buffer, ProtocolVersion};
+use tickvault_storage::tick_row_builder::{RawTickFields, build_tick_row_for_feed};
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+/// A fully-populated Dhan-shape `RawTickFields` (every Option Some → widest row).
+fn dhan_fields(capture_seq: i64) -> RawTickFields {
+    RawTickFields {
+        security_id: 49081,
+        segment: "NSE_FNO",
+        ltp: 21_000.0,
+        volume: 50_000,
+        ts_ist_nanos: 1_740_556_500_000_000_000,
+        capture_seq,
+        open: Some(20_950.0),
+        high: Some(21_020.0),
+        low: Some(20_920.0),
+        close: Some(20_900.0),
+        oi: Some(120_000),
+        avg_price: Some(20_990.0),
+        last_trade_qty: Some(75),
+        total_buy_qty: Some(25_000),
+        total_sell_qty: Some(25_000),
+        exchange_timestamp: Some(1_740_556_500),
+        received_at_ist_nanos: Some(1_740_576_300_123_456_789),
+        payload_hash: Some(-2_154_897_302_305_733_279),
+    }
+}
+
+#[test]
+fn dhat_build_tick_row_for_feed_zero_alloc() {
+    use tickvault_common::feed::Feed;
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let mut buffer = Buffer::new(ProtocolVersion::V1);
+    // Pre-warm: the very first row grows the buffer's internal Vec. Build one
+    // widest row then `clear()` (which drops length, keeps capacity) so the
+    // buffer's internal Vec is at its steady-state capacity before measuring —
+    // exactly how the production writer reuses one buffer and `flush` drains it.
+    build_tick_row_for_feed(&mut buffer, &dhan_fields(0), Feed::Dhan).expect("prewarm");
+    buffer.clear();
+
+    let stats_before = dhat::HeapStats::get();
+
+    // Build one widest row per iteration, clearing between rows (mirrors a
+    // flush). With capacity already at steady state, no allocation should occur.
+    for i in 0..1000 {
+        build_tick_row_for_feed(&mut buffer, &dhan_fields(i), Feed::Dhan).expect("build dhan");
+        buffer.clear();
+    }
+
+    let stats_after = dhat::HeapStats::get();
+    let allocs_during = stats_after
+        .total_blocks
+        .saturating_sub(stats_before.total_blocks);
+
+    assert_eq!(
+        allocs_during, 0,
+        "build_tick_row_for_feed allocated {allocs_during} blocks over 1000 rows into a \
+         pre-grown buffer — PRINCIPLE #1 VIOLATED. The converged builder must be zero-alloc \
+         beyond the ILP buffer's one-time internal growth."
+    );
+}

--- a/crates/storage/tests/feed_tick_writer_convergence_guard.rs
+++ b/crates/storage/tests/feed_tick_writer_convergence_guard.rs
@@ -1,0 +1,83 @@
+//! C1 convergence ratchet — there is EXACTLY ONE function that builds the
+//! `ticks` ILP row, shared by BOTH live feeds (Dhan + Groww).
+//!
+//! Before C1 the Dhan writer (`tick_persistence::build_tick_row_seq`) and the
+//! Groww writer (`groww_persistence::GrowwLiveTickWriter::append_row`) each
+//! hand-wrote a near-duplicate `ticks` ILP row. C1 converged that into the one
+//! `tick_row_builder::build_tick_row_for_feed`. This source-scan guard fails the
+//! build if a second hand-written `ticks` row-build path is re-introduced — the
+//! mechanical proof that the two feeds can never silently diverge on the table
+//! name, the DEDUP key columns, the ILP SYMBOL-before-column ordering, or the
+//! NULL-not-0 policy.
+//!
+//! Mirrors the `GrowwCandle1mWriter`-deleted-style source guards already in the
+//! repo: it scans the storage crate's two tick-writer source files and asserts
+//! that the `.table(... "ticks" ...)` ILP entry point appears in EXACTLY ONE
+//! place — the shared builder.
+
+use std::fs;
+use std::path::Path;
+
+/// Read a storage `src` file by name. Panics with a clear message if missing so
+/// a future rename surfaces loudly rather than silently passing.
+fn read_src(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src").join(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// Strip the `#[cfg(test)] mod tests { ... }` tail so the scan only sees the
+/// PRODUCTION region (test bodies legitimately mention these patterns in
+/// assertions on the buffer bytes).
+fn production_region(src: &str) -> &str {
+    src.split("mod tests {")
+        .next()
+        .expect("file always has a head before any tests module")
+}
+
+#[test]
+fn exactly_one_ticks_row_builder_function_exists() {
+    // The shared builder is THE one ILP row-build entry point for the `ticks`
+    // table. It is the only production site allowed to open an ILP row whose
+    // table is the `ticks` table constant.
+    let shared = read_src("tick_row_builder.rs");
+    let shared_prod = production_region(&shared);
+    let shared_table_opens = shared_prod
+        .matches("TableName::new_unchecked(QUESTDB_TABLE_TICKS)")
+        .count();
+    assert_eq!(
+        shared_table_opens, 1,
+        "expected exactly ONE `.table(TableName::new_unchecked(QUESTDB_TABLE_TICKS))` in the \
+         shared builder, found {shared_table_opens}"
+    );
+
+    // The Dhan writer MUST delegate — its production region must NOT contain a
+    // raw `.table(TableName::new_unchecked(QUESTDB_TABLE_TICKS))` ILP open of
+    // its own anymore (that moved into the shared builder).
+    let dhan = read_src("tick_persistence.rs");
+    let dhan_prod = production_region(&dhan);
+    let dhan_table_opens = dhan_prod
+        .matches("TableName::new_unchecked(QUESTDB_TABLE_TICKS)")
+        .count();
+    assert_eq!(
+        dhan_table_opens, 0,
+        "Dhan tick_persistence.rs must NOT hand-build a `ticks` ILP row — it must call the \
+         shared `build_tick_row_for_feed`; found {dhan_table_opens} raw table-opens"
+    );
+    assert!(
+        dhan_prod.contains("build_tick_row_for_feed"),
+        "Dhan writer must delegate to the shared `build_tick_row_for_feed`"
+    );
+
+    // The Groww writer MUST delegate too — no `.table("ticks")` of its own.
+    let groww = read_src("groww_persistence.rs");
+    let groww_prod = production_region(&groww);
+    assert!(
+        !groww_prod.contains(".table(SHARED_TICKS_TABLE)"),
+        "Groww groww_persistence.rs must NOT hand-build a `ticks` ILP row — it must call the \
+         shared `build_tick_row_for_feed`"
+    );
+    assert!(
+        groww_prod.contains("build_tick_row_for_feed"),
+        "Groww writer must delegate to the shared `build_tick_row_for_feed`"
+    );
+}

--- a/crates/storage/tests/price_2dp_guard.rs
+++ b/crates/storage/tests/price_2dp_guard.rs
@@ -44,44 +44,33 @@ fn code_only(content: &str) -> String {
         .join("\n")
 }
 
-/// The live tick-persist price columns. Each must be written as
-/// `column_f64("<name>", round_to_2dp(...))` in the production append path.
+/// The live tick-persist price columns. Each must have its VALUE constructed
+/// through `round_to_2dp(...)` at the `RawTickFields` build site in
+/// `tick_persistence.rs::build_tick_row_seq` (C1 convergence moved the literal
+/// `column_f64(...)` writes into the shared `tick_row_builder`, but the operator
+/// 2-decimal contract is applied here, at value-construction time, BEFORE the
+/// value enters the feed-agnostic `RawTickFields`).
 const TICK_PRICE_COLUMNS: &[&str] = &["ltp", "open", "high", "low", "close", "avg_price"];
 
 #[test]
 fn tick_persistence_price_columns_are_rounded_to_2dp() {
     let code = code_only(&storage_src("tick_persistence.rs"));
-    // The production append fn lives before the `#[cfg(test)]` mod; the
-    // test-helper writers (raw column_f64 literals) live after it. We pin
-    // the PRODUCTION write path by requiring the `round_to_2dp(` token to
-    // appear on the same logical statement as each price column there.
-    //
-    // Pragmatic source-scan: require that for each price column, a
-    // `column_f64("<col>", round_to_2dp(` occurrence exists. Whitespace
-    // between args is normalised away by collapsing runs of spaces.
+    // Post-C1 the Dhan `build_tick_row_seq` constructs a `RawTickFields` whose
+    // price values are pre-rounded, then delegates to the shared builder. The
+    // 2-decimal contract lives at this value-construction site. Accepted shapes
+    // (whitespace normalised) for each price column `<col>`:
+    //   <col>: round_to_2dp(                  — required-for-both field (ltp)
+    //   <col>: Some(round_to_2dp(             — per-feed Option field (open/…/avg_price)
     let normalised: String = code.split_whitespace().collect::<Vec<_>>().join(" ");
     for col in TICK_PRICE_COLUMNS {
-        // Two accepted write-site shapes (both rounded):
-        //   column_f64("ltp", round_to_2dp(            — plain &str name
-        //   column_f64(ColumnName::new_unchecked("ltp"), round_to_2dp(
-        //     — pre-validated name (latency-hunt 2026-06-10; the name
-        //       literal itself is pinned by
-        //       test_tick_row_unchecked_ilp_names_pass_validation)
-        let plain = format!("column_f64(\"{col}\", round_to_2dp(");
-        let plain_spaced = format!("column_f64( \"{col}\", round_to_2dp(");
-        let prevalidated =
-            format!("column_f64( ColumnName::new_unchecked(\"{col}\"), round_to_2dp(");
-        let prevalidated_tight =
-            format!("column_f64(ColumnName::new_unchecked(\"{col}\"), round_to_2dp(");
+        let required_field = format!("{col}: round_to_2dp(");
+        let optional_field = format!("{col}: Some(round_to_2dp(");
         assert!(
-            normalised.contains(&plain)
-                || normalised.contains(&plain_spaced)
-                || normalised.contains(&prevalidated)
-                || normalised.contains(&prevalidated_tight),
-            "tick_persistence.rs production append must write price column \
+            normalised.contains(&required_field) || normalised.contains(&optional_field),
+            "tick_persistence.rs::build_tick_row_seq must construct the price field \
              `{col}` through `round_to_2dp(...)` (operator 2-decimal contract \
-             2026-05-29). Found a `column_f64` write for `{col}` that is not \
-             wrapped. Wrap it: round_to_2dp(f32_to_f64_clean(...)). Greeks/IV \
+             2026-05-29) before it enters RawTickFields. Found a `{col}:` field set \
+             without rounding. Wrap it: round_to_2dp(f32_to_f64_clean(...)). Greeks/IV \
              are exempt; this guard covers PRICE columns only."
         );
     }


### PR DESCRIPTION
## Summary

C1 of the C1/C2 feed-convergence plan. The audit found Dhan and Groww each
hand-write a near-duplicate `ticks` ILP row (~25 lines of duplicated
`.symbol(...)`/`.column_*(...)`/`.at(...)` calls). Two hand-written paths into
ONE shared table is exactly the drift risk: a future column/DEDUP-key change
could land on one path and not the other.

**Before:** `tick_persistence::build_tick_row_seq` (Dhan) and
`groww_persistence::GrowwLiveTickWriter::append_row` (Groww) each open and write
their own `ticks` ILP row.

**After:** ONE shared **builder** `tick_row_builder::build_tick_row_for_feed(&mut
Buffer, &RawTickFields, Feed)` is the single source of the `ticks` wire bytes for
BOTH feeds. Both writers now construct a feed-agnostic `RawTickFields` and call
it. The deliverable is the shared **builder**, not a facade.

In plain language: there used to be two slightly-different recipes for writing
one row into the same database table — one for the Dhan price board, one for the
Groww price board. Now there is exactly ONE recipe both feeds use, so the table
name, the uniqueness key, and the "leave a missing value blank, never write 0"
rule can never drift apart between feeds.

### What stays per-feed (only the row STRING build is shared)
- The resilience tier: Dhan keeps ring→spill→DLQ; Groww keeps its lazy-connect
  buffer (durable floor = sidecar capture-at-receipt file).
- The `capture_seq` SOURCE: Dhan = WAL `frame_seq`; Groww = `next_capture_seq`
  seeded from `ts_ist_nanos`.
- The numeric source typing: Dhan's `round_to_2dp(f32_to_f64_clean(f32))` is
  applied at the Dhan call site; Groww's native f64 is carried verbatim.

### NULL-not-0 (load-bearing)
`RawTickFields` per-feed columns are `Option<T>`. For every `None` the builder
OMITS the column token entirely → QuestDB stores NULL, never `0`. Groww (LTP
feed) supplies no `open/high/low/close/oi/avg_price/last_trade_qty/total_buy_qty/
total_sell_qty/received_at/payload_hash`, so those stay NULL.

### Carriers (E3 / E4)
- `volume: i64` — Groww keeps cumulative volume as i64 (exceeds u32 intraday);
  Dhan's `u32` widens losslessly (`i64::from`). Never funnelled through u32.
- `ltp: f64` — common carrier; Dhan's f32 widens EXACTLY at the call site.

### Hard constraints — verified
- `ticks` DDL UNCHANGED. `DEDUP_KEY_TICKS = (ts, security_id, segment,
  capture_seq, feed)` UNCHANGED.
- Dhan emitted ILP row is **byte-identical** to pre-C1 (golden test).
- Groww keeps exactly its present-columns subset; Dhan-only columns now
  explicitly NULL.
- Dhan ring→spill→DLQ resilience untouched (C1 converges only the row-string
  builder).

### Items completed
- [x] Item C1 — unify the raw-tick WRITER row-builder (feed-parameterized)

### Real column inventory (recounted against source, corrects the plan's "19/9")
- Dhan: 2 SYMBOLs (`segment`,`feed`) + **16 columns** = 18 `new_unchecked` literals.
- Groww: 2 SYMBOLs + **5 columns** (security_id, ltp, volume, exchange_timestamp,
  capture_seq); the other 11 are NULL.

## Honest 100% claim (envelope qualifier)

100% inside the tested envelope, with ratcheted regression coverage: C1 introduces
NO new tick-drop path — the Dhan ring→spill→DLQ chain (`TICK_BUFFER_CAPACITY`,
ratcheted by `crates/storage/tests/zero_tick_loss_alert_guard.rs`) is unchanged
and the Groww durable floor (sidecar capture-at-receipt file, §32) is unchanged;
the converged per-tick path is DHAT zero-alloc
(`dhat_build_tick_row_for_feed_zero_alloc`) so it stays O(1); the `ticks` schema,
the `(ts, security_id, segment, capture_seq, feed)` DEDUP key, and the NULL-not-0
Groww-column semantics are byte-preserved (pinned by `dedup_segment_meta_guard.rs`
+ the byte-identical Dhan golden test + the NULL-not-0 wire-byte test). C1 removes
~25 lines of duplicated ILP-append; it does NOT unify the resilience tier.

## Zero-Loss Guarantee Charter check

### Coverage
- [x] Code coverage: tests added (E1/E3/E4/golden/one-builder/DHAT); delta ≥ 0
- [x] Audit coverage: N/A — no new event/audit table; `ticks` is the system of record
- [x] Testing coverage: unit, golden/snapshot, DHAT zero-alloc, source-scan guard
- [x] Security: N/A — no secret/auth surface; `new_unchecked` ILP-name validity ratcheted
- [x] Monitoring: N/A — no new failure mode (pure de-dup); existing telemetry preserved
- [x] Logging: N/A — no new `error!` site
- [x] Alerting: N/A — no new failure mode
- [x] Scenarios/edge: E1 NULL-not-0, E3/E4 widen/passthrough, feed-mismatch via Feed enum
- [x] Performance: DHAT zero-alloc on the converged per-tick builder
- [x] Recovery: ring→spill→DLQ unchanged; Groww durable floor unchanged
- [x] Functionalities: `build_tick_row_for_feed` has 2 call sites + tests (pub-fn-test + wiring guards pass)
- [x] Extreme check: `feed_tick_writer_convergence_guard` fails build if a 2nd row-builder is re-introduced

### Zero-loss / resilience
- [x] No new tick-drop path; ring→spill→DLQ unchanged
- [x] WS SubscribeRxGuard + pool watchdog unchanged (not touched)
- [x] No new hot-path allocation (DHAT clean) — O(1)
- [x] No inherently-O(N) step introduced
- [x] QuestDB schema self-heal preserved (DDL + ALTER unchanged)
- [x] Composite (security_id, segment) + feed DEDUP key unchanged

### Evidence (no hallucination — real test output)
- `tickvault-storage --lib`: `test result: ok. 594 passed; 0 failed`
- `feed_tick_writer_convergence_guard`: `test result: ok. 1 passed; 0 failed`
- `dhat_tick_row_builder`: `test result: ok. 1 passed; 0 failed`
- `price_2dp_guard`: `test result: ok. 4 passed; 0 failed`
- `dedup_segment_meta_guard`: `test result: ok. 6 passed; 0 failed`
- All 47 storage test binaries green; `cargo clippy -p tickvault-storage --lib -- -D warnings`: 0 errors
- `cargo fmt --check`: clean; banned-pattern-scanner: clean
- `tickvault-app --lib groww_bridge`: `test result: ok. 22 passed; 0 failed`

### Review
- [ ] Adversarial 3-agent review (hot-path + security + hostile) — pending (DRAFT)

## Test plan
- [x] `cargo test -p tickvault-storage` green (47 binaries)
- [x] `cargo test -p tickvault-app --lib groww_bridge` green
- [x] banned-pattern scanner clean
- [x] pub-fn-test-guard + pub-fn-wiring-guard clean
- [x] plan-gate (design-first) PASS
- [ ] CI all green (DRAFT — not yet enabled for auto-merge)

## Status
**DRAFT** — not marked ready, auto-merge NOT enabled, per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ)_