### PR TITLE
test(storage): cover C1 build_tick_row_for_feed column order — restore untested-pub-fn baseline

### DIFF
--- a/crates/storage/src/tick_row_builder.rs
+++ b/crates/storage/src/tick_row_builder.rs
@@ -334,6 +334,73 @@ mod tests {
         }
     }
 
+    /// `build_tick_row_for_feed` must lay the row out in the EXACT legacy Dhan
+    /// order: ALL symbols (`segment`, `feed`) first (ILP requirement), then the
+    /// fixed column sequence `security_id → ltp → open → high → low → close →
+    /// volume → oi → avg_price → last_trade_qty → total_buy_qty →
+    /// total_sell_qty → exchange_timestamp → received_at → payload_hash →
+    /// capture_seq`. The docstring pins this as byte-identical-golden; the other
+    /// tests only assert token PRESENCE, so this is the only check of ORDER.
+    #[test]
+    fn test_build_tick_row_for_feed_dhan_emits_legacy_column_order() {
+        let text = build(&dhan_shape_fields(), Feed::Dhan);
+
+        // Both symbols must appear before ANY `column_*` token. The first
+        // `=`-column token is `security_id=`; everything left of it is the
+        // table + symbol region.
+        let first_col = text
+            .find("security_id=")
+            .expect("security_id column present");
+        let symbol_region = &text[..first_col];
+        assert!(
+            symbol_region.contains("segment=") && symbol_region.contains("feed=dhan"),
+            "both symbols (segment, feed) must precede the first column: {text}"
+        );
+
+        // The 16 columns must appear strictly left-to-right in the legacy order.
+        let ordered = [
+            "security_id=",
+            "ltp=",
+            "open=",
+            "high=",
+            "low=",
+            "close=",
+            "volume=",
+            "oi=",
+            "avg_price=",
+            "last_trade_qty=",
+            "total_buy_qty=",
+            "total_sell_qty=",
+            "exchange_timestamp=",
+            "received_at=",
+            "payload_hash=",
+            "capture_seq=",
+        ];
+        let mut cursor = first_col;
+        for token in ordered {
+            let pos = text[cursor..]
+                .find(token)
+                .map(|rel| cursor + rel)
+                .unwrap_or_else(|| panic!("column {token} missing or out of order: {text}"));
+            assert!(
+                pos >= cursor,
+                "column {token} must not precede the prior column (pos={pos}, cursor={cursor}): {text}"
+            );
+            cursor = pos + token.len();
+        }
+
+        // capture_seq is the LAST column, and the designated timestamp `at(ts)`
+        // closes the line — so no column token may follow capture_seq's value.
+        let cap = text.find("capture_seq=").expect("capture_seq present");
+        let tail = &text[cap..];
+        for following in ["ltp=", "open=", "volume=", "oi=", "received_at="] {
+            assert!(
+                !tail.contains(following),
+                "no column ({following}) may appear after capture_seq: {text}"
+            );
+        }
+    }
+
     /// E1 + NULL-not-0: a Groww row OMITS every Dhan-only column entirely
     /// (→ NULL), and never emits a `=0` placeholder for them.
     #[test]


### PR DESCRIPTION
## Summary

C1 (#1216) added the new pub fn `build_tick_row_for_feed` in `crates/storage/src/tick_row_builder.rs`. It is exercised by 7 inline `#[test]`s, but none of their names match the pub-fn-test-guard's name-substring matcher (`fn test_.*<fn>` / `fn <fn>_` / `test.*<fn>`), so the guard counted it untested and the workspace untested-pub-fn count rose **119 → 120**. This single test restores the baseline to **119**.

## What changed

One test-only addition: `test_build_tick_row_for_feed_dhan_emits_legacy_column_order`. It asserts the EXACT on-wire column ORDER produced by `build_tick_row_for_feed` (symbols-first, then the fixed legacy column sequence ending with `capture_seq` before `at(ts)`). The existing 7 tests only assert token PRESENCE; this is the only test of ordering, which the docstring pins as byte-identical-golden.

Guard count returns to 119; the baseline file is NOT bumped. Zero production logic change.

## PLAN-EXEMPT rationale

Per `.claude/rules/project/design-first-wall.md`, a genuinely trivial ≤1-implementation-file change may use the auditable `PLAN-EXEMPT:` escape. This PR changes exactly ONE `src/*.rs` file and adds ONLY a `#[test]` (no production code path), so the commit body carries:

```
PLAN-EXEMPT: test-only — adds #[test] for build_tick_row_for_feed column order, zero production logic change
```

This is the documented escape hatch, not a bypass — no `--no-verify`, no stash, no force.

## Test plan
- [x] `crates/storage` compiles with the new test
- [x] pub-fn-test-guard count returns to 119
- [x] pre-push gate (plan-gate + pub-fn guard) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ)_