### PR TITLE
feat(feeds): enable Groww live feed on staging for dry-run + per-feed status read

### DIFF
--- a/.github/workflows/aws-control.yml
+++ b/.github/workflows/aws-control.yml
@@ -176,6 +176,8 @@ jobs:
               "docker ps --format \"{{.Names}} {{.Status}}\" 2>/dev/null || echo none",
               "echo ===ROWS===",
               "for t in ticks candles_1m option_chain_minute_snapshot instrument_lifecycle; do c=$(curl -s \"http://localhost:9000/exec?query=select%20count(*)%20from%20$t\" 2>/dev/null | grep -oE \"\\[\\[[0-9]+\" | grep -oE \"[0-9]+\" | head -1); echo \"$t=${c:-NA}\"; done",
+              "echo ===FEED_SPLIT===",
+              "fs=$(curl -s \"http://localhost:9000/exec?query=select%20feed%2C%20count(*)%20from%20ticks%20group%20by%20feed\" 2>/dev/null | grep -oE \"\\[\\\"[^\\\"]+\\\",[0-9]+\\]\" | sed -E \"s/\\[\\\"([^\\\"]+)\\\",([0-9]+)\\]/\\1=\\2/\"); if [ -n \"$fs\" ]; then echo \"$fs\"; else echo no-feed-rows; fi",
               "echo ===LOGS===",
               "journalctl -u tickvault -n 12 --no-pager 2>/dev/null | tail -12 || echo no-logs",
               "echo ===ERRORS===",
@@ -199,7 +201,8 @@ jobs:
           # Parse sections.
           app=$(echo "$OUT" | awk '/===APP===/{f=1;next}/===DOCKER===/{f=0}f' | tr -d '[:space:]')
           docker=$(echo "$OUT" | awk '/===DOCKER===/{f=1;next}/===ROWS===/{f=0}f')
-          rows=$(echo "$OUT" | awk '/===ROWS===/{f=1;next}/===LOGS===/{f=0}f')
+          rows=$(echo "$OUT" | awk '/===ROWS===/{f=1;next}/===FEED_SPLIT===/{f=0}f')
+          feedsplit=$(echo "$OUT" | awk '/===FEED_SPLIT===/{f=1;next}/===LOGS===/{f=0}f')
           logs=$(echo "$OUT" | awk '/===LOGS===/{f=1;next}/===ERRORS===/{f=0}f')
           errs=$(echo "$OUT" | awk '/===ERRORS===/{f=1;next}f')
 
@@ -225,6 +228,12 @@ jobs:
           echo "## 📈 Data captured (QuestDB row counts)" >> "$S"
           echo '```' >> "$S"; echo "$rows" >> "$S"; echo '```' >> "$S"
           echo "_ticks/candles climb during market hours; 0 off-market or pre-deploy is normal._" >> "$S"
+          echo "" >> "$S"
+
+          # ---- Per-feed tick split (Dhan vs Groww) ----
+          echo "## 🔀 Ticks captured per feed" >> "$S"
+          echo '```' >> "$S"; echo "$feedsplit" >> "$S"; echo '```' >> "$S"
+          echo "_dhan=… is the primary feed; groww=… appears only when the Groww second feed is enabled (staging dry-run)._" >> "$S"
           echo "" >> "$S"
 
           # ---- Recent logs ----

--- a/config/staging.toml
+++ b/config/staging.toml
@@ -42,3 +42,14 @@ format = "json"
 [api]
 # Different port so staging + prod can coexist on the same machine.
 port = 3002
+
+[feeds]
+# Enable the Groww second feed on staging for the tonight's dry-run.
+# Dhan (feed #1) stays ON; Groww (feed #2) is flipped ON here ONLY for staging
+# per the operator-locked per-feed enable/disable contract
+# (.claude/rules/project/groww-second-feed-scope-2026-06-19.md §2). Groww is a
+# SEPARATE, isolated live-feed lane (default-OFF in base.toml) that cannot crash
+# Dhan — deploying staging with this flag is the dry-run. Live-feed-only per §33
+# (no Groww historical/backtest pull).
+dhan_enabled = true
+groww_enabled = true

--- a/deploy/systemd/tickvault.service
+++ b/deploy/systemd/tickvault.service
@@ -68,6 +68,14 @@ Environment=RUST_LOG=info
 # real api.dhan.co + requires the registered static EIP (enable_eip=true). See
 # config/production.toml + config/staging.toml.
 Environment=TV_ENVIRONMENT=staging
+# GROWW_MAX_SUBSCRIBE caps the first-run Groww subscription set. Default in code
+# is 60 (subset-safe); set to 1000 here to subscribe the FULL ~779-instrument
+# Groww universe (NTM-union: indices + F&O underlyings + NIFTY-Total-Market
+# constituents). The builder clamps to GROWW_MAX_SUBSCRIPTIONS=1000 (a max, not
+# a floor — a prefix-take, indices-first then token-ascending), so 1000 cleanly
+# covers the live ~779 count with headroom. Per .claude/rules/project/
+# groww-second-feed-scope-2026-06-19.md.
+Environment=GROWW_MAX_SUBSCRIBE=1000
 
 # Resource limits
 LimitNOFILE=65536


### PR DESCRIPTION
## Summary

Enables the **Groww second feed** on the **staging** runtime so that deploying staging tonight **is** the dry-run. Three config/workflow-only changes — **zero `.rs` files** touched. Groww (feed #2) is an isolated, default-OFF live-feed lane per the operator-locked per-feed enable/disable contract (`groww-second-feed-scope-2026-06-19.md`); it reuses the existing WAL → ring → spill → DLQ → aggregator chain and **cannot crash Dhan** (feed #1, unchanged). Live-feed-only per §33 — no Groww historical/backtest pull.

## Items completed
- [x] **Enable Groww on staging** — `config/staging.toml` gains `[feeds] dhan_enabled=true, groww_enabled=true`. `base.toml` keeps `groww_enabled=false`; this override applies **only** to the `TV_ENVIRONMENT=staging` runtime that the deployed box runs (per `deploy/systemd/tickvault.service`).
- [x] **Raise subscribe cap** — `deploy/systemd/tickvault.service` adds `Environment=GROWW_MAX_SUBSCRIBE=1000` so the full **~779-instrument** Groww NTM-union universe (indices + F&O underlyings + NIFTY-Total-Market constituents) is subscribed. The builder clamps to `GROWW_MAX_SUBSCRIPTIONS=1000` (a prefix-take max, indices-first then token-ascending — not a floor), so 1000 cleanly covers ~779 with headroom. Code default is 60.
- [x] **Per-feed status read** — `.github/workflows/aws-control.yml` `status` action gains a read-only `===FEED_SPLIT===` SSM step (`select feed, count(*) from ticks group by feed`, via the same QuestDB `/exec` curl the existing `===ROWS===` step uses) and a rendered **"🔀 Ticks captured per feed"** block, so status shows `dhan=…` / `groww=…` rows split.

## How this is the dry-run
The deployed box runs `TV_ENVIRONMENT=staging` → figment merges `config/staging.toml` over `base.toml` → Groww lane spawns. Boot reads the feed flags once (O(1)) and spawns only enabled feeds; Groww's lane is fully isolated from Dhan (separate connection + pipeline instance), distinguished in shared tables by the `feed='groww'` column with `feed` in the `ticks` DEDUP key — so a Groww failure cannot affect Dhan capture.

## Zero-Loss Guarantee Charter check
Config + CI-workflow only; no production Rust path changed.
- Code coverage: N/A — no `.rs` changed.
- Audit / Monitoring / Logging / Alerting: N/A — uses the existing Groww-lane observability (unchanged).
- Performance / hot path: N/A — no hot-path code; feed-enable is a one-time O(1) boot config read (existing).
- Recovery: rescue→spill→DLQ + reconnect path UNCHANGED (Groww reuses the same chain).
- Uniqueness/dedup: UNCHANGED — `feed` already in the `ticks` DEDUP key.
- Scope-lock: respects `groww-second-feed-scope-2026-06-19.md` (default-OFF in base; per-feed toggle; native Rust; live-feed-only §33). Dhan 2-WS lock untouched.
- Evidence: `git diff origin/main --name-only | grep '\.rs$'` → none; staging.toml + workflow YAML parse OK; banned-pattern scanner exit 0.

## Honest 100% claim
100% inside the tested envelope: this PR only flips a config flag + an env var + adds a read-only status query. Groww inherits the existing ratcheted zero-tick-loss chain (ring → NDJSON spill → DLQ, `TICK_BUFFER_CAPACITY`, `zero_tick_loss_alert_guard.rs`). No new tick-drop path, no new hot-path allocation, no schema change. Beyond the envelope, the DLQ catches every payload as recoverable text.

## Test plan
- [x] 0 `.rs` files changed (`git diff origin/main --stat`)
- [x] `config/staging.toml` parses → `feeds = {dhan_enabled: true, groww_enabled: true}`
- [x] `.github/workflows/aws-control.yml` parses as valid YAML
- [x] banned-pattern scanner exit 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ)_