### PR TITLE
refactor(app): converge Dhan+Groww seal routing into shared route_seal (C2, behavior-preserving)

### DIFF
--- a/.claude/plans/active-plan-c2-seal-routing-convergence.md
+++ b/.claude/plans/active-plan-c2-seal-routing-convergence.md
@@ -1,0 +1,168 @@
+# Implementation Plan: C2 — Converge Dhan+Groww seal routing into one shared `route_seal`
+
+**Status:** APPROVED
+**Date:** 2026-06-27
+**Approved by:** coordinator (C2 task)
+**Crate:** `tickvault-app`
+
+> **Guarantee matrix:** this item cross-references the canonical 15-row + 7-row
+> matrices in `.claude/rules/project/per-wave-guarantee-matrix.md`
+> (per-wave-guarantee-matrix.md). This is a **behavior-preserving** pure refactor
+> — no new tick-drop path, no new hot-path allocation, no DEDUP-key change, no
+> new error code, no observability change. The 7-row resilience demand
+> ("Zero ticks lost", "O(1) latency") is preserved by construction: the shared
+> function is the UNION of the two existing seal-routing closure bodies with the
+> per-feed differences hoisted into explicit parameters; each feed's emitted
+> output (counters / drops / `BufferedSeal` fields / D1-drop / pct-stamp) is
+> byte-identical to today.
+
+## Design
+
+Today the per-seal routing logic is duplicated as two inline `on_seal` closures
+passed to `MultiTfAggregator::consume_tick`:
+
+- **Dhan** — `crates/app/src/main.rs::spawn_engine_b_aggregator` (the
+  `|tf, mut state| { … }` closure, ~lines 3631-3676): DROPS the `TfIndex::D1`
+  seal; looks up `prev_day_cache` + overrides `refs.prev_day_close` from
+  `state.prev_day_close` + calls `stamp_seal_pct_fields`; computes
+  `close_pct_nonzero`; builds `BufferedSeal::new(…, Feed::Dhan)`; sends via
+  `global_seal_sender()`; on send-error increments `tv_seal_mpsc_dropped_total`
+  (NO `feed` label) + `heartbeat.record_drop()`; on success increments
+  `tv_aggregator_seals_emitted_total` + `heartbeat.record_emit()` + (if
+  close_pct_nonzero) `tv_aggregator_close_pct_nonzero_total` +
+  `heartbeat.record_close_pct_nonzero()`.
+
+- **Groww** — `crates/app/src/groww_bridge.rs` inline `on_seal` (~lines 518-534):
+  NO D1 drop; NO pct-stamp; builds `BufferedSeal::new(…, Feed::Groww)`; sends via
+  `global_seal_sender()`; on send-error increments
+  `tv_seal_mpsc_dropped_total{feed="groww"}` (HAS `feed` label); on success, if
+  `tf == TfIndex::M1`, calls `feed_health.record_candle(Feed::Groww)`.
+
+**Extraction:** a new `crates/app/src/seal_routing.rs` with a single
+`pub fn route_seal(...)` that is the UNION of both bodies. The per-feed
+differences become explicit parameters carried in a borrowed, `Copy`,
+zero-alloc `SealRouteParams<'a>`:
+
+| Param | Dhan value | Groww value | Controls |
+|---|---|---|---|
+| `feed: Feed` | `Feed::Dhan` | `Feed::Groww` | `BufferedSeal.feed` + the drop-counter label (Dhan = no label, Groww = `feed=groww`) — byte-identical to today |
+| `drop_d1: bool` | `true` | `false` | the `if tf == D1 { return }` early-return |
+| `prev_day_cache: Option<&PrevDayCache>` | `Some(&cache)` | `None` | the lookup + `prev_day_close` override + `stamp_seal_pct_fields` |
+| `heartbeat: Option<&AggregatorHeartbeatCounters>` | `Some(&hb)` | `None` | the Dhan emit/drop/close-pct heartbeat + `tv_aggregator_*` counters |
+| `feed_health_on_m1: Option<&FeedHealthRegistry>` | `None` | `Some(&fh)` | the Groww `record_candle` on the M1 seal |
+
+`route_seal` signature (zero-alloc — only references + `&'static str` labels, no
+`format!`/`String`/`Vec`/`clone`):
+
+```rust
+pub fn route_seal(
+    params: SealRouteParams<'_>,
+    security_id: u32,
+    exchange_segment_code: u8,
+    tf: TfIndex,
+    mut state: LiveCandleState,
+    sender: &mpsc::Sender<BufferedSeal>,
+)
+```
+
+The two call sites resolve `global_seal_sender()` once (as today: the
+`let Some(sender) = global_seal_sender() else { return/continue }` guard stays at
+the call site so the `&'static` borrow lifetime is unchanged) and pass `sender`
+in. The Dhan call site passes `drop_d1=true, prev_day_cache=Some, heartbeat=Some,
+feed_health_on_m1=None`; the Groww call site passes
+`drop_d1=false, prev_day_cache=None, heartbeat=None, feed_health_on_m1=Some`.
+The result is byte-identical to today for BOTH feeds.
+
+**Why a shared `mut state` param (not `&mut`):** the closure receives
+`LiveCandleState` by value (`F: FnMut(TfIndex, LiveCandleState)`), and the Dhan
+path mutates it via `stamp_seal_pct_fields(&mut state, refs)`. `route_seal` takes
+`state` by value (`mut`) and `BufferedSeal::new` consumes it — identical move
+semantics to both current closures.
+
+## Edge Cases
+
+- `tf == D1` with `drop_d1=true` (Dhan): early-return BEFORE build/send — no seal
+  emitted, no counter touched. Identical to today's `if tf == TfIndex::D1 { return; }`.
+- `tf == D1` with `drop_d1=false` (Groww): the D1 seal is routed (Groww has never
+  dropped D1). Preserved.
+- `prev_day_cache=None` (Groww): no lookup, no pct-stamp — `state` is sent as-is.
+  Preserved.
+- `prev_day_cache.lookup` miss (Dhan): `.unwrap_or_default()` → zero refs, then
+  `refs.prev_day_close = state.prev_day_close` override — identical to today.
+- Send-error (mpsc full): Dhan → unlabeled drop counter + heartbeat drop; Groww →
+  `feed=groww` labeled drop counter. The drop-counter label is selected by
+  `params.feed` inside `route_seal` to reproduce each EXACTLY. No panic — the
+  ring→spill→DLQ chain downstream is the durable absorber (unchanged).
+- `tf != M1` with `feed_health_on_m1=Some` (Groww): no `record_candle` — matches
+  today's `else if tf == TfIndex::M1` guard.
+
+## Failure Modes
+
+- This is a pure refactor: NO new failure mode is introduced. The only seal-loss
+  path remains the AGGREGATOR-DROP-01 ring→spill→DLQ exhaustion (storage crate,
+  untouched here). The `tv_seal_mpsc_dropped_total` increment on a full mpsc is
+  preserved per-feed exactly.
+- If `route_seal` ever diverged from a call site (regression), the new
+  source-scan ratchet (`seal_routing_convergence_guard`) fails the build: it
+  asserts BOTH call sites invoke `route_seal` and NEITHER hand-builds the routing
+  inline outside `seal_routing.rs`.
+
+## Test Plan
+
+- Unit test `route_seal` in `seal_routing.rs` (pub-fn-test-guard): drive
+  `route_seal` for both feeds with a real bounded `mpsc::channel`, assert the
+  `BufferedSeal` reaches the receiver with the correct `feed` / `tf` / ids, and
+  assert the D1-drop param suppresses the D1 seal (Dhan) while a non-D1 TF is
+  routed; Groww (drop_d1=false) routes D1.
+- Source-scan ratchet `crates/app/tests/seal_routing_convergence_guard.rs`:
+  asserts exactly ONE seal-routing body — both `main.rs` (Dhan) and
+  `groww_bridge.rs` (Groww) call `route_seal`, and neither file hand-builds the
+  inline routing (`BufferedSeal::new(` + `global_seal_sender(` + D1-drop pattern)
+  outside `seal_routing.rs`. Mirrors `test_run_groww_bridge_routes_seals_through_shared_writer`.
+- `cargo test -p tickvault-app`, `cargo fmt`, `cargo clippy -p tickvault-app -- -D warnings`.
+- banned-pattern-scanner, pub-fn-test-guard, per-item-guarantee-check all green.
+- Behavior-preservation confirmation: re-read the diff and confirm Dhan + Groww
+  seal outputs (counters / drop labels / keep / `BufferedSeal` fields) are
+  byte-identical to before — pure refactor, no behavior change.
+
+## Rollback
+
+Single-commit, self-contained: revert the commit to restore both inline
+closures. No schema change, no DEDUP key change, no config flag, no migration.
+`route_seal` is internal to `tickvault-app`; nothing else depends on it.
+
+## Observability
+
+NONE changed. The exact same counters fire from the same conditions:
+`tv_seal_mpsc_dropped_total` (Dhan unlabeled / Groww `feed=groww`),
+`tv_aggregator_seals_emitted_total`, `tv_aggregator_close_pct_nonzero_total`
+(Dhan only, via `heartbeat`), and `FeedHealthRegistry::record_candle` (Groww M1
+only). No new metric, no new `error!`/`warn!`/`info!`, no new ErrorCode. The
+shared function relocates WHERE the emit happens, never WHETHER/HOW MUCH.
+
+## Plan Items
+
+- [x] Write `crates/app/src/seal_routing.rs` with `SealRouteParams` + `route_seal`
+      (union of both bodies, per-feed params, zero-alloc) + `#[test]`
+  - Files: crates/app/src/seal_routing.rs, crates/app/src/main.rs (mod decl)
+  - Tests: test_route_seal_dhan_routes_non_d1_and_drops_d1, test_route_seal_groww_routes_all_tfs
+- [x] Rewire the Dhan call site (`spawn_engine_b_aggregator`) to call `route_seal`
+  - Files: crates/app/src/main.rs
+  - Tests: seal_routing_convergence_guard
+- [x] Rewire the Groww call site (`groww_bridge.rs` inline `on_seal`) to call `route_seal`
+  - Files: crates/app/src/groww_bridge.rs
+  - Tests: seal_routing_convergence_guard
+- [x] Source-scan ratchet asserting exactly ONE seal-routing body
+  - Files: crates/app/tests/seal_routing_convergence_guard.rs
+  - Tests: test_dhan_call_site_uses_route_seal, test_groww_call_site_uses_route_seal, test_no_inline_seal_routing_outside_seal_routing_module
+
+## Scenarios
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Dhan D1 seal | dropped (drop_d1=true), no counter touched |
+| 2 | Dhan M1 seal, mpsc OK | `BufferedSeal{feed=Dhan}` sent + seals_emitted++ + heartbeat emit |
+| 3 | Dhan seal, mpsc full | unlabeled `tv_seal_mpsc_dropped_total`++ + heartbeat drop |
+| 4 | Groww D1 seal | routed (drop_d1=false) |
+| 5 | Groww M1 seal, mpsc OK | `BufferedSeal{feed=Groww}` sent + `record_candle(Groww)` |
+| 6 | Groww seal, mpsc full | `tv_seal_mpsc_dropped_total{feed=groww}`++ |

--- a/crates/app/src/groww_bridge.rs
+++ b/crates/app/src/groww_bridge.rs
@@ -51,7 +51,7 @@ use tickvault_common::tick_types::ParsedTick;
 use tickvault_common::types::ExchangeSegment;
 use tickvault_storage::groww_persistence::{GrowwLiveTickRow, GrowwLiveTickWriter};
 use tickvault_storage::seal_writer_runner::global_seal_sender;
-use tickvault_trading::candles::{BufferedSeal, FeedStrategy, MultiTfAggregator, TfIndex};
+use tickvault_trading::candles::{FeedStrategy, MultiTfAggregator};
 
 /// Capacity hint for the Groww feed's own [`MultiTfAggregator`] instance —
 /// matches the NTM-union universe headroom (operator §31). The container grows
@@ -519,18 +519,26 @@ pub async fn run_groww_bridge(
                     let Some(sender) = global_seal_sender() else {
                         return;
                     };
-                    let seal = BufferedSeal::new(pt.security_id, seg_code, tf, state, Feed::Groww);
-                    if sender.try_send(seal).is_err() {
-                        // Mirror the Dhan path: the seal mpsc is full (writer
-                        // behind). Counter only — the ring→spill→DLQ chain
-                        // downstream is the durable absorber; never panic.
-                        metrics::counter!("tv_seal_mpsc_dropped_total", "feed" => "groww")
-                            .increment(1);
-                    } else if tf == TfIndex::M1 {
-                        // Live-feed health: count one Groww candle per sealed
-                        // 1-minute bar (the cross-verified slice).
-                        feed_health.record_candle(Feed::Groww);
-                    }
+                    // C2 (behavior-preserving): the per-seal routing body now
+                    // lives in the shared `route_seal`. Groww policy: route EVERY
+                    // TF (no D1-drop), NO pct-stamp, the `feed=groww`-labeled drop
+                    // counter, and `record_candle(Groww)` on the M1 seal. The
+                    // emitted output is byte-identical to the pre-C2 inline
+                    // closure.
+                    crate::seal_routing::route_seal(
+                        crate::seal_routing::SealRouteParams {
+                            feed: Feed::Groww,
+                            drop_d1: false,
+                            prev_day_cache: None,
+                            heartbeat: None,
+                            feed_health_on_m1: Some(feed_health.as_ref()),
+                        },
+                        pt.security_id,
+                        seg_code,
+                        tf,
+                        state,
+                        sender,
+                    );
                 },
             );
             // A lazily-missing instrument cannot happen here (we pre_populate on

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -50,6 +50,9 @@ pub mod groww_bridge;
 /// Groww Python-sidecar auto-launcher + supervisor (operator lock §32 +
 /// "no manual commands" 2026-06-19). Default-OFF.
 pub mod groww_sidecar_supervisor;
+/// Shared per-seal routing for BOTH feeds (Dhan + Groww) — the single
+/// `route_seal` body the two `on_seal` call sites invoke (C2, behavior-preserving).
+pub mod seal_routing;
 // PR #4 (2026-05-19): depth-20 / depth-200 modules DELETED (operator-locked
 // per websocket-connection-scope-lock.md — 4-IDX_I uses 1 main-feed conn
 // + 1 order-update conn only).

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -3588,10 +3588,10 @@ fn spawn_engine_b_aggregator(
     trading_calendar: std::sync::Arc<TradingCalendar>,
 ) {
     use tickvault_storage::seal_writer_runner::global_seal_sender;
-    use tickvault_trading::candles::{
-        AggregatorHeartbeatCounters, BufferedSeal, MultiTfAggregator, TfIndex,
-        stamp_seal_pct_fields,
-    };
+    // C2: `BufferedSeal` / `TfIndex` / `stamp_seal_pct_fields` are no longer used
+    // directly here — the per-seal routing body moved into
+    // `tickvault_app::seal_routing::route_seal` (behavior-preserving).
+    use tickvault_trading::candles::{AggregatorHeartbeatCounters, MultiTfAggregator};
 
     // 11K-instrument capacity (matches MAX_TOTAL_SUBSCRIPTIONS headroom
     // per `aws-budget.md`). HashMap grows lazily so this is a hint.
@@ -3628,51 +3628,30 @@ fn spawn_engine_b_aggregator(
                         // pre-FeedStrategy Dhan behaviour.
                         tickvault_trading::candles::FeedStrategy::DHAN,
                         None,
-                        |tf, mut state| {
-                            // 1d historical-only (operator directive 2026-06-02):
-                            // the 1d timeframe is NEVER tick-calculated. It is
-                            // pulled once each morning from Dhan historical into
-                            // `prev_day_ohlcv`. Drop any D1 seal the aggregator
-                            // emits so it never reaches `candles_1d`. The
-                            // aggregator still seals all 21 TFs internally
-                            // (fixed 21-slot arrays + `42 = 2×21` unit test
-                            // intact); only this write boundary skips D1.
-                            if tf == TfIndex::D1 {
-                                return;
-                            }
-                            let mut refs = prev_day_cache_for_agg
-                                .lookup(tick.security_id, tick.exchange_segment_code)
-                                .unwrap_or_default();
-                            // Operator decision 2026-05-28: take the prev-day
-                            // close straight from the live ticks `close`
-                            // column (captured into the candle state), not the
-                            // QuestDB PrevDayCache (which is empty in the
-                            // Engine-B runtime). Drives close_pct_from_prev_day.
-                            refs.prev_day_close = state.prev_day_close;
-                            stamp_seal_pct_fields(&mut state, refs);
-                            // G3 real-time proof: capture the % BEFORE `state`
-                            // is moved into the seal. A non-zero value proves
-                            // the percentage-change column is populating live.
-                            let close_pct_nonzero = state.close_pct_from_prev_day != 0.0;
-                            let seal = BufferedSeal::new(
+                        |tf, state| {
+                            // C2 (behavior-preserving): the per-seal routing body
+                            // now lives in the shared `route_seal`. Dhan policy:
+                            // drop the D1 seal (1d is historical-only per
+                            // `live-feed-purity.md` rule 10), stamp the prev-day
+                            // pct fields from `prev_day_cache_for_agg`, and drive
+                            // the heartbeat + `tv_aggregator_*` counters. The
+                            // emitted output (counters, drop label, BufferedSeal
+                            // fields, D1-drop, pct-stamp) is byte-identical to the
+                            // pre-C2 inline closure.
+                            tickvault_app::seal_routing::route_seal(
+                                tickvault_app::seal_routing::SealRouteParams {
+                                    feed: tickvault_common::feed::Feed::Dhan,
+                                    drop_d1: true,
+                                    prev_day_cache: Some(prev_day_cache_for_agg.as_ref()),
+                                    heartbeat: Some(&heartbeat_writer),
+                                    feed_health_on_m1: None,
+                                },
                                 tick.security_id,
                                 tick.exchange_segment_code,
                                 tf,
                                 state,
-                                tickvault_common::feed::Feed::Dhan,
+                                sender,
                             );
-                            if sender.try_send(seal).is_err() {
-                                metrics::counter!("tv_seal_mpsc_dropped_total").increment(1);
-                                heartbeat_writer.record_drop();
-                            } else {
-                                metrics::counter!("tv_aggregator_seals_emitted_total").increment(1);
-                                heartbeat_writer.record_emit();
-                                if close_pct_nonzero {
-                                    metrics::counter!("tv_aggregator_close_pct_nonzero_total")
-                                        .increment(1);
-                                    heartbeat_writer.record_close_pct_nonzero();
-                                }
-                            }
                         },
                     );
                     if stats.late_count > 0 {
@@ -3794,39 +3773,37 @@ fn spawn_engine_b_aggregator(
 
             let mut sealed: u64 = 0;
             let mut dropped: u64 = 0;
-            agg_for_boundary.force_seal_all(|security_id, segment_code, tf, mut state| {
-                // 1d historical-only (operator directive 2026-06-02): D1 is
-                // never tick-sealed — drop it at this write boundary too. See
-                // the per-tick seal site above for the full rationale.
-                if tf == TfIndex::D1 {
-                    return;
-                }
-                let mut refs = prev_day_cache_for_boundary
-                    .lookup(security_id, segment_code)
-                    .unwrap_or_default();
-                // Live prev-day close from the candle state (see per-tick
-                // seal site above) — operator decision 2026-05-28.
-                refs.prev_day_close = state.prev_day_close;
-                stamp_seal_pct_fields(&mut state, refs);
-                // G3 real-time proof (capture before move) — same contract as
-                // the per-tick seal site above.
-                let close_pct_nonzero = state.close_pct_from_prev_day != 0.0;
-                let seal = BufferedSeal::new(
+            agg_for_boundary.force_seal_all(|security_id, segment_code, tf, state| {
+                // C2 (behavior-preserving): the per-seal routing body now lives
+                // in the shared `route_seal`. This IST-midnight Dhan path uses
+                // the SAME Dhan policy as the per-tick site (drop D1, pct-stamp,
+                // fire the `tv_aggregator_*` counters) but carries NO heartbeat —
+                // it keeps its own local `sealed`/`dropped` running counts from
+                // the returned `SealOutcome`. Byte-identical to the pre-C2 inline
+                // closure.
+                match tickvault_app::seal_routing::route_seal(
+                    tickvault_app::seal_routing::SealRouteParams {
+                        feed: tickvault_common::feed::Feed::Dhan,
+                        drop_d1: true,
+                        prev_day_cache: Some(prev_day_cache_for_boundary.as_ref()),
+                        heartbeat: None,
+                        feed_health_on_m1: None,
+                    },
                     security_id,
                     segment_code,
                     tf,
                     state,
-                    tickvault_common::feed::Feed::Dhan,
-                );
-                if sender.try_send(seal).is_err() {
-                    metrics::counter!("tv_seal_mpsc_dropped_total").increment(1);
-                    dropped = dropped.saturating_add(1);
-                } else {
-                    metrics::counter!("tv_aggregator_seals_emitted_total").increment(1);
-                    sealed = sealed.saturating_add(1);
-                    if close_pct_nonzero {
-                        metrics::counter!("tv_aggregator_close_pct_nonzero_total").increment(1);
+                    sender,
+                ) {
+                    tickvault_app::seal_routing::SealOutcome::Sent => {
+                        sealed = sealed.saturating_add(1);
                     }
+                    tickvault_app::seal_routing::SealOutcome::DroppedFull => {
+                        dropped = dropped.saturating_add(1);
+                    }
+                    // D1 is dropped at the write boundary — not counted as a
+                    // mpsc-full drop (matches the pre-C2 early-`return`).
+                    tickvault_app::seal_routing::SealOutcome::DroppedD1 => {}
                 }
             });
             tracing::info!(

--- a/crates/app/src/seal_routing.rs
+++ b/crates/app/src/seal_routing.rs
@@ -1,0 +1,280 @@
+//! Shared per-seal routing for BOTH market-data feeds (Dhan + Groww).
+//!
+//! Before C2 the per-seal `on_seal` closure body was duplicated: one copy inline
+//! in `crates/app/src/main.rs::spawn_engine_b_aggregator` (Dhan) and one inline in
+//! `crates/app/src/groww_bridge.rs` (Groww). The two copies did the SAME core
+//! work — build a [`BufferedSeal`] and route it through the shared seal-writer
+//! channel ([`global_seal_sender`]) — and differed only in a small set of
+//! per-feed policies (D1-drop, prev-day pct-stamp, and the observability sinks).
+//!
+//! [`route_seal`] is the UNION of those two bodies, with the per-feed differences
+//! hoisted into the explicit, borrowed, `Copy`, zero-alloc [`SealRouteParams`].
+//! It is **strictly behavior-preserving**: every counter, drop label,
+//! `BufferedSeal` field, the D1-drop early-return, and the prev-day pct-stamp is
+//! byte-identical to the pre-C2 inline closures for each feed.
+//!
+//! [`global_seal_sender`]: tickvault_storage::seal_writer_runner::global_seal_sender
+
+use tokio::sync::mpsc;
+
+use tickvault_common::feed::Feed;
+use tickvault_common::feed_health::FeedHealthRegistry;
+use tickvault_trading::candles::{
+    AggregatorHeartbeatCounters, BufferedSeal, LiveCandleState, TfIndex, stamp_seal_pct_fields,
+};
+use tickvault_trading::in_mem::PrevDayCache;
+
+/// Per-feed routing policy for [`route_seal`].
+///
+/// Borrowed + `Copy` + zero-alloc — holds only references and the [`Feed`] tag.
+/// The fields express EXACTLY the differences between the pre-C2 Dhan and Groww
+/// `on_seal` closures, so passing the right values reproduces each feed's
+/// behaviour bit-for-bit:
+///
+/// | Field | Dhan | Groww | Controls |
+/// |---|---|---|---|
+/// | `feed` | [`Feed::Dhan`] | [`Feed::Groww`] | the [`BufferedSeal::feed`] stamp AND the drop-counter label (Dhan = no label, Groww = `feed=groww`) |
+/// | `drop_d1` | `true` | `false` | the `if tf == D1 { return }` early-return |
+/// | `prev_day_cache` | `Some(&cache)` | `None` | the prev-day lookup + `prev_day_close` override + [`stamp_seal_pct_fields`] |
+/// | `heartbeat` | `Some(&hb)` | `None` | the Dhan `tv_aggregator_*` counters + heartbeat emit/drop/close-pct |
+/// | `feed_health_on_m1` | `None` | `Some(&fh)` | the Groww `record_candle` on the M1 seal |
+#[derive(Clone, Copy)]
+pub struct SealRouteParams<'a> {
+    /// Source feed — stamped into [`BufferedSeal::feed`] and selects the
+    /// drop-counter label.
+    pub feed: Feed,
+    /// When `true`, a [`TfIndex::D1`] seal is dropped at the write boundary
+    /// (Dhan: 1d is historical-only per `live-feed-purity.md` rule 10). When
+    /// `false`, every TF is routed (Groww never dropped D1).
+    pub drop_d1: bool,
+    /// When `Some`, the seal-time prev-day pct fields are stamped from this
+    /// cache (Dhan). When `None`, the seal is sent as-is (Groww).
+    pub prev_day_cache: Option<&'a PrevDayCache>,
+    /// When `Some`, the Dhan aggregator heartbeat counters + the
+    /// `tv_aggregator_seals_emitted_total` / `tv_aggregator_close_pct_nonzero_total`
+    /// metrics fire (Dhan). When `None`, they do not (Groww).
+    pub heartbeat: Option<&'a AggregatorHeartbeatCounters>,
+    /// When `Some`, `record_candle(feed)` fires on the M1 seal (Groww live-feed
+    /// health). When `None`, it does not (Dhan).
+    pub feed_health_on_m1: Option<&'a FeedHealthRegistry>,
+}
+
+/// Outcome of a [`route_seal`] call — whether the seal was dropped at the D1
+/// write boundary, dropped because the mpsc was full, or sent to the channel.
+///
+/// The IST-midnight force-seal caller uses this to keep its local `sealed` /
+/// `dropped` running counts (the pre-C2 closure mutated them inline). The
+/// per-tick callers ignore the return.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SealOutcome {
+    /// `drop_d1=true` and `tf == D1` — the seal was suppressed at the write
+    /// boundary (never built, never sent).
+    DroppedD1,
+    /// The seal-writer mpsc was full; the seal was dropped (counter only — the
+    /// downstream ring→spill→DLQ chain is the durable absorber).
+    DroppedFull,
+    /// The seal reached the channel.
+    Sent,
+}
+
+/// Routes one sealed bar to the shared seal-writer channel, applying the
+/// per-feed policy in `params`. Returns the [`SealOutcome`] so callers that keep
+/// local running counts (the IST-midnight force-seal) can.
+///
+/// This is the single shared body for BOTH feeds' seal-routing callbacks — the
+/// per-tick Dhan + Groww `on_seal` closures AND the Dhan IST-midnight
+/// `force_seal_all` closure. The caller resolves `global_seal_sender()` ONCE (the
+/// `&'static` borrow stays at the call site so the lifetime is unchanged) and
+/// passes it in. `state` is taken by value (`mut`) — the same move semantics as
+/// the `FnMut(TfIndex, LiveCandleState)` callback — and [`BufferedSeal::new`]
+/// consumes it.
+///
+/// Behaviour is byte-identical to the pre-C2 inline closures:
+/// - Dhan per-tick: `drop_d1=true`, `prev_day_cache=Some`, `heartbeat=Some`,
+///   `feed_health_on_m1=None` (ignores the return).
+/// - Dhan IST-midnight: `drop_d1=true`, `prev_day_cache=Some`, `heartbeat=None`,
+///   `feed_health_on_m1=None` (uses the return for `sealed`/`dropped`).
+/// - Groww: `drop_d1=false`, `prev_day_cache=None`, `heartbeat=None`,
+///   `feed_health_on_m1=Some` (ignores the return).
+///
+/// The `tv_seal_mpsc_dropped_total` / `tv_aggregator_seals_emitted_total` /
+/// `tv_aggregator_close_pct_nonzero_total` metrics are a Dhan-feed concern (both
+/// Dhan paths fired them; Groww fired none of them), so they are gated on
+/// `feed == Feed::Dhan` — reproducing the pre-C2 series EXACTLY. The heartbeat
+/// `record_*` methods are independent and gated on `heartbeat.is_some()` (only
+/// the per-tick Dhan path carries one).
+///
+/// Zero-alloc: references + `&'static str` labels only; no `format!` / `String`
+/// / `Vec` / `clone` on this hot-adjacent (per-seal) path.
+#[inline]
+pub fn route_seal(
+    params: SealRouteParams<'_>,
+    security_id: u32,
+    exchange_segment_code: u8,
+    tf: TfIndex,
+    mut state: LiveCandleState,
+    sender: &mpsc::Sender<BufferedSeal>,
+) -> SealOutcome {
+    // 1d historical-only (operator directive 2026-06-02, `live-feed-purity.md`
+    // rule 10): the 1d timeframe is NEVER tick-calculated for the Dhan feed.
+    // Drop any D1 seal the aggregator emits so it never reaches `candles_1d`.
+    // The aggregator still seals all 21 TFs internally; only this write boundary
+    // skips D1. Groww (drop_d1=false) routes D1.
+    if params.drop_d1 && tf == TfIndex::D1 {
+        return SealOutcome::DroppedD1;
+    }
+
+    // Dhan: stamp the seal-time prev-day pct fields. Operator decision
+    // 2026-05-28: take the prev-day close straight from the live ticks `close`
+    // column (captured into the candle state), not the QuestDB PrevDayCache
+    // (which is empty in the Engine-B runtime). Drives close_pct_from_prev_day.
+    let mut close_pct_nonzero = false;
+    if let Some(cache) = params.prev_day_cache {
+        let mut refs = cache
+            .lookup(security_id, exchange_segment_code)
+            .unwrap_or_default();
+        refs.prev_day_close = state.prev_day_close;
+        stamp_seal_pct_fields(&mut state, refs);
+        // G3 real-time proof: capture the % BEFORE `state` is moved into the
+        // seal. A non-zero value proves the percentage-change column is
+        // populating live.
+        close_pct_nonzero = state.close_pct_from_prev_day != 0.0;
+    }
+
+    let seal = BufferedSeal::new(security_id, exchange_segment_code, tf, state, params.feed);
+
+    if sender.try_send(seal).is_err() {
+        // The seal mpsc is full (writer behind). Counter only — the
+        // ring→spill→DLQ chain downstream is the durable absorber; never panic.
+        // The drop-counter label is per-feed, reproducing the pre-C2 series
+        // EXACTLY: Dhan = NO label, Groww = `feed=groww`.
+        match params.feed {
+            Feed::Dhan => {
+                metrics::counter!("tv_seal_mpsc_dropped_total").increment(1);
+            }
+            Feed::Groww => {
+                metrics::counter!("tv_seal_mpsc_dropped_total", "feed" => "groww").increment(1);
+            }
+        }
+        if let Some(hb) = params.heartbeat {
+            hb.record_drop();
+        }
+        SealOutcome::DroppedFull
+    } else {
+        // Dhan aggregator counters (BOTH Dhan paths fire these — per-tick AND
+        // IST-midnight; Groww fires none of them).
+        if params.feed == Feed::Dhan {
+            metrics::counter!("tv_aggregator_seals_emitted_total").increment(1);
+            if close_pct_nonzero {
+                metrics::counter!("tv_aggregator_close_pct_nonzero_total").increment(1);
+            }
+        }
+        // Per-tick Dhan heartbeat (the IST-midnight path has no heartbeat).
+        if let Some(hb) = params.heartbeat {
+            hb.record_emit();
+            if close_pct_nonzero {
+                hb.record_close_pct_nonzero();
+            }
+        }
+        // Groww live-feed health: count one candle per sealed 1-minute bar
+        // (the cross-verified slice).
+        if let Some(fh) = params.feed_health_on_m1
+            && tf == TfIndex::M1
+        {
+            fh.record_candle(params.feed);
+        }
+        SealOutcome::Sent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Dhan policy: a non-D1 TF is routed to the channel with `feed=Dhan`; a D1
+    /// seal is dropped at the write boundary (`drop_d1=true`).
+    #[tokio::test]
+    async fn test_route_seal_dhan_routes_non_d1_and_drops_d1() {
+        let (tx, mut rx) = mpsc::channel::<BufferedSeal>(8);
+        let params = SealRouteParams {
+            feed: Feed::Dhan,
+            drop_d1: true,
+            prev_day_cache: None, // exercise the None-cache (no pct-stamp) arm
+            heartbeat: None,      // counters are global; we assert routing only
+            feed_health_on_m1: None,
+        };
+
+        // A non-D1 seal is routed.
+        let out = route_seal(params, 13, 0, TfIndex::M1, LiveCandleState::empty(), &tx);
+        assert_eq!(out, SealOutcome::Sent);
+        let got = rx.try_recv().expect("non-D1 seal must be routed");
+        assert_eq!(got.security_id, 13);
+        assert_eq!(got.exchange_segment_code, 0);
+        assert_eq!(got.tf, TfIndex::M1);
+        assert_eq!(got.feed, Feed::Dhan);
+
+        // A D1 seal is dropped (drop_d1=true) — nothing reaches the channel.
+        let out = route_seal(params, 13, 0, TfIndex::D1, LiveCandleState::empty(), &tx);
+        assert_eq!(out, SealOutcome::DroppedD1);
+        assert!(
+            rx.try_recv().is_err(),
+            "D1 seal must be dropped when drop_d1=true"
+        );
+    }
+
+    /// Groww policy: EVERY TF — including D1 — is routed with `feed=Groww`
+    /// (`drop_d1=false`), with no pct-stamp.
+    #[tokio::test]
+    async fn test_route_seal_groww_routes_all_tfs() {
+        let (tx, mut rx) = mpsc::channel::<BufferedSeal>(8);
+        let params = SealRouteParams {
+            feed: Feed::Groww,
+            drop_d1: false,
+            prev_day_cache: None,
+            heartbeat: None,
+            feed_health_on_m1: None,
+        };
+
+        let out = route_seal(params, 1333, 1, TfIndex::M1, LiveCandleState::empty(), &tx);
+        assert_eq!(out, SealOutcome::Sent);
+        let m1 = rx.try_recv().expect("Groww M1 seal must be routed");
+        assert_eq!(m1.feed, Feed::Groww);
+        assert_eq!(m1.security_id, 1333);
+        assert_eq!(m1.tf, TfIndex::M1);
+
+        // D1 is NOT dropped for Groww.
+        let out = route_seal(params, 1333, 1, TfIndex::D1, LiveCandleState::empty(), &tx);
+        assert_eq!(out, SealOutcome::Sent);
+        let d1 = rx
+            .try_recv()
+            .expect("Groww D1 seal must be routed (no drop)");
+        assert_eq!(d1.tf, TfIndex::D1);
+        assert_eq!(d1.feed, Feed::Groww);
+    }
+
+    /// Send failure (full channel) does not panic — the row is dropped (counter
+    /// only) per the ring→spill→DLQ durable-absorber design.
+    #[tokio::test]
+    async fn test_route_seal_full_channel_does_not_panic() {
+        let (tx, _rx) = mpsc::channel::<BufferedSeal>(1);
+        // Fill the single slot.
+        tx.try_send(BufferedSeal::new(
+            1,
+            0,
+            TfIndex::M1,
+            LiveCandleState::empty(),
+            Feed::Dhan,
+        ))
+        .expect("first send fills the channel");
+        let params = SealRouteParams {
+            feed: Feed::Dhan,
+            drop_d1: true,
+            prev_day_cache: None,
+            heartbeat: None,
+            feed_health_on_m1: None,
+        };
+        // Second route hits the full channel — must not panic, returns DroppedFull.
+        let out = route_seal(params, 2, 0, TfIndex::M1, LiveCandleState::empty(), &tx);
+        assert_eq!(out, SealOutcome::DroppedFull);
+    }
+}

--- a/crates/app/tests/close_pct_realtime_proof_guard.rs
+++ b/crates/app/tests/close_pct_realtime_proof_guard.rs
@@ -39,34 +39,53 @@ fn read(rel: &str) -> String {
 }
 
 const MAIN_RS: &str = "crates/app/src/main.rs";
+// C2 (behavior-preserving): the per-seal routing body — including the G3
+// real-time-proof emission — moved out of the two inline `main.rs` closures into
+// the single shared `route_seal`. The signal is STILL emitted at every seal site
+// (both Dhan paths route through `route_seal`); it is just emitted from ONE place
+// now. The wiring scan therefore targets the shared module.
+const SEAL_ROUTING_RS: &str = "crates/app/src/seal_routing.rs";
 const METRIC: &str = "tv_aggregator_close_pct_nonzero_total";
 
 #[test]
 fn seal_site_emits_close_pct_nonzero_prometheus_counter() {
-    let src = read(MAIN_RS);
-    let hits = src.matches(METRIC).count();
+    // The metric is emitted once in the shared `route_seal` (Dhan-feed gate),
+    // which BOTH Dhan seal sites (per-tick + IST-midnight) invoke. Confirm the
+    // shared emit exists AND that both main.rs sites route through it.
+    let routing = read(SEAL_ROUTING_RS);
     assert!(
-        hits >= 2,
-        "main.rs must emit `{METRIC}` at BOTH seal sites (per-tick + \
-         IST-midnight force-seal), found {hits}. This is the G3 real-time \
-         proof that close_pct_from_prev_day populates live — without it a \
+        routing.contains(METRIC),
+        "seal_routing.rs (route_seal) must emit `{METRIC}` — the G3 real-time \
+         proof that close_pct_from_prev_day populates live. Without it a \
          silently-zero % column has no positive operator signal \
          (audit-findings Rule 11)."
+    );
+    let main_rs = read(MAIN_RS);
+    let route_hits = main_rs.matches("seal_routing::route_seal").count();
+    assert!(
+        route_hits >= 2,
+        "main.rs must route BOTH Dhan seal sites (per-tick + IST-midnight \
+         force-seal) through `seal_routing::route_seal`, found {route_hits} — \
+         so the shared G3 emit fires at both."
     );
 }
 
 #[test]
 fn per_tick_seal_site_records_heartbeat_close_pct_nonzero() {
-    let src = read(MAIN_RS);
+    // The heartbeat record now lives in route_seal (gated on the per-tick Dhan
+    // heartbeat param). The per-minute AGGREGATOR-HB-01 `info!` line stays in
+    // main.rs.
+    let routing = read(SEAL_ROUTING_RS);
     assert!(
-        src.contains("record_close_pct_nonzero()"),
-        "main.rs per-tick seal site must call \
-         `heartbeat_writer.record_close_pct_nonzero()` so the per-minute \
-         AGGREGATOR-HB-01 heartbeat carries the positive signal."
+        routing.contains("record_close_pct_nonzero()"),
+        "seal_routing.rs (route_seal) must call \
+         `hb.record_close_pct_nonzero()` so the per-minute AGGREGATOR-HB-01 \
+         heartbeat carries the positive signal for the per-tick Dhan path."
     );
+    let main_rs = read(MAIN_RS);
     assert!(
-        src.contains("close_pct_nonzero = snap.close_pct_nonzero"),
-        "the aggregator heartbeat `info!` line must include \
+        main_rs.contains("close_pct_nonzero = snap.close_pct_nonzero"),
+        "the aggregator heartbeat `info!` line in main.rs must include \
          `close_pct_nonzero = snap.close_pct_nonzero` so the operator can \
          tail it (AGGREGATOR-HB-01)."
     );
@@ -74,15 +93,16 @@ fn per_tick_seal_site_records_heartbeat_close_pct_nonzero() {
 
 #[test]
 fn close_pct_nonzero_is_guarded_by_a_nonzero_check_not_unconditional() {
-    let src = read(MAIN_RS);
+    let routing = read(SEAL_ROUTING_RS);
     // The signal must be conditional on a real non-zero %, not fired on
     // every seal (which would make it a meaningless duplicate of
     // seals_emitted and defeat the false-OK detection).
     assert!(
-        src.contains("state.close_pct_from_prev_day != 0.0"),
-        "the G3 signal must be gated on `state.close_pct_from_prev_day != 0.0` \
-         (captured before the seal move), not emitted unconditionally — \
-         otherwise it cannot distinguish a populating % from a flat one."
+        routing.contains("state.close_pct_from_prev_day != 0.0"),
+        "the G3 signal in seal_routing.rs (route_seal) must be gated on \
+         `state.close_pct_from_prev_day != 0.0` (captured before the seal \
+         move), not emitted unconditionally — otherwise it cannot distinguish \
+         a populating % from a flat one."
     );
 }
 

--- a/crates/app/tests/seal_routing_convergence_guard.rs
+++ b/crates/app/tests/seal_routing_convergence_guard.rs
@@ -1,0 +1,93 @@
+//! C2 convergence guard — exactly ONE seal-routing body.
+//!
+//! Before C2 the per-seal routing logic (build a `BufferedSeal` + route it
+//! through `global_seal_sender`, with the per-feed D1-drop / pct-stamp /
+//! observability policy) was duplicated as inline closures in `main.rs` (Dhan
+//! per-tick + Dhan IST-midnight) and `groww_bridge.rs` (Groww). C2 converged all
+//! three onto the single shared `seal_routing::route_seal`.
+//!
+//! This is a source-scan ratchet (Rule 13 — a method defined but a call site
+//! silently re-inlined IS a regression). It fails the build if either call site
+//! stops calling `route_seal`, OR if the inline routing pattern (`BufferedSeal::new`
+//! + `global_seal_sender` + the D1-drop) reappears OUTSIDE `seal_routing.rs`.
+//! Mirrors `test_run_groww_bridge_routes_seals_through_shared_writer`.
+
+use std::path::PathBuf;
+
+fn read(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .map(|r| r.join(rel))
+        .unwrap_or_else(|| PathBuf::from(rel));
+    std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "seal-routing convergence guard: cannot read {} ({e})",
+            path.display()
+        )
+    })
+}
+
+const MAIN_RS: &str = "crates/app/src/main.rs";
+const GROWW_RS: &str = "crates/app/src/groww_bridge.rs";
+const SEAL_ROUTING_RS: &str = "crates/app/src/seal_routing.rs";
+
+/// The shared `route_seal` body exists in `seal_routing.rs`.
+#[test]
+fn test_shared_route_seal_exists() {
+    let src = read(SEAL_ROUTING_RS);
+    assert!(
+        src.contains("pub fn route_seal("),
+        "seal_routing.rs must define the shared `pub fn route_seal(...)` — the \
+         single seal-routing body both feeds invoke."
+    );
+}
+
+/// The Dhan call sites (per-tick + IST-midnight force-seal) route through
+/// `route_seal`. There are exactly TWO Dhan seal sites; both must call it.
+#[test]
+fn test_dhan_call_sites_use_route_seal() {
+    let src = read(MAIN_RS);
+    let hits = src.matches("seal_routing::route_seal").count();
+    assert!(
+        hits >= 2,
+        "main.rs must route BOTH Dhan seal sites (per-tick + IST-midnight \
+         force-seal) through `seal_routing::route_seal`, found {hits}. A site \
+         that re-inlines the routing diverges from the shared body."
+    );
+}
+
+/// The Groww call site routes through `route_seal`.
+#[test]
+fn test_groww_call_site_uses_route_seal() {
+    let src = read(GROWW_RS);
+    assert!(
+        src.contains("seal_routing::route_seal"),
+        "groww_bridge.rs must route its seal through `seal_routing::route_seal` \
+         (the one shared body) — not a re-inlined Groww-only routing closure."
+    );
+}
+
+/// No call site hand-builds the seal-routing inline OUTSIDE `seal_routing.rs`.
+/// The signature of the inline routing is `BufferedSeal::new(` immediately
+/// fed to `global_seal_sender()`'s `try_send` — the convergence target. Today
+/// the ONLY file that may contain `BufferedSeal::new(` + `try_send` together is
+/// `seal_routing.rs`; the call sites pass `state` to `route_seal`.
+#[test]
+fn test_no_inline_seal_routing_outside_seal_routing_module() {
+    for rel in [MAIN_RS, GROWW_RS] {
+        let src = read(rel);
+        assert!(
+            !src.contains("BufferedSeal::new("),
+            "{rel} hand-builds a `BufferedSeal::new(...)` inline — the per-seal \
+             routing body MUST live ONLY in seal_routing.rs::route_seal (C2 \
+             convergence). Route through `seal_routing::route_seal` instead."
+        );
+    }
+    // The shared module is allowed (and required) to build it.
+    let routing = read(SEAL_ROUTING_RS);
+    assert!(
+        routing.contains("BufferedSeal::new("),
+        "seal_routing.rs must build the `BufferedSeal` (the one shared routing body)."
+    );
+}


### PR DESCRIPTION
## Summary

Extract the duplicated per-seal routing logic into ONE shared
`crates/app/src/seal_routing.rs::route_seal`. **Strictly behavior-preserving** —
a pure refactor. Each feed's emitted output (counters, drop labels, `BufferedSeal`
fields, the D1-drop, the prev-day pct-stamp) is byte-identical to before.

Before C2 the per-seal routing body was duplicated THREE times (the task named
two; a third Dhan body exists):
- **Dhan per-tick** — `main.rs::spawn_engine_b_aggregator` `on_seal` closure
- **Dhan IST-midnight force-seal** — `main.rs` `force_seal_all` closure
- **Groww** — `groww_bridge.rs` inline `on_seal` closure

All three now invoke `route_seal`. Per-feed differences become explicit,
borrowed, `Copy`, zero-alloc `SealRouteParams`.

## Before / after (the two seal-routing bodies)

| Mechanic | Dhan per-tick (before) | Dhan IST-midnight (before) | Groww (before) | route_seal param |
|---|---|---|---|---|
| Drop `D1` seal | yes (`if tf==D1 return`) | yes | no | `drop_d1` |
| prev-day pct-stamp | yes (`prev_day_cache` + override) | yes | no | `prev_day_cache: Option<&PrevDayCache>` |
| Build `BufferedSeal` | `Feed::Dhan` | `Feed::Dhan` | `Feed::Groww` | `feed: Feed` |
| Drop counter label | `tv_seal_mpsc_dropped_total` (no label) | (no label) | `…{feed="groww"}` | selected by `feed` |
| `tv_aggregator_seals_emitted_total` / `…close_pct_nonzero_total` | yes | yes | no | gated `feed==Dhan` |
| Heartbeat `record_emit`/`record_drop`/`record_close_pct_nonzero` | yes | no | no | `heartbeat: Option<&…>` |
| local `sealed`/`dropped` counts | n/a | yes (closure-mutated) | n/a | `SealOutcome` return |
| `record_candle(Groww)` on M1 | no | no | yes (on success) | `feed_health_on_m1: Option<&…>` |

`route_seal` is the UNION of these bodies; each call passes the params that
reproduce its feed exactly.

## Per-feed param table (call sites)

| Site | `feed` | `drop_d1` | `prev_day_cache` | `heartbeat` | `feed_health_on_m1` | return used? |
|---|---|---|---|---|---|---|
| Dhan per-tick | Dhan | true | Some | Some | None | no |
| Dhan IST-midnight | Dhan | true | Some | None | None | yes (sealed/dropped) |
| Groww | Groww | false | None | None | Some | no |

## Behavior-preserving guarantee

Pure refactor: no new tick-drop path, no new hot-path allocation, no DEDUP-key
change, no new error code, no observability change. The signal relocates WHERE
it is emitted, never WHETHER/HOW MUCH. The `tv_aggregator_*` metrics are gated
on `feed==Dhan` (both Dhan paths fired them; Groww fired none); the heartbeat
`record_*` are gated on the optional heartbeat (per-tick Dhan only); the
`feed=groww` drop label + `record_candle` are gated on the Groww params.

## Items completed
- [x] Shared `route_seal` + `SealRouteParams` + `SealOutcome` (`seal_routing.rs`) + unit tests
- [x] Rewire Dhan per-tick call site
- [x] Rewire Dhan IST-midnight force-seal call site (uses the `SealOutcome` return for local counts)
- [x] Rewire Groww call site
- [x] Source-scan ratchet `seal_routing_convergence_guard` (exactly ONE seal-routing body)
- [x] Updated `close_pct_realtime_proof_guard` to scan the relocated emit

## Test evidence (verbatim)
```
seal_routing unit tests:        test result: ok. 3 passed; 0 failed
seal_routing_convergence_guard: test result: ok. 4 passed; 0 failed
close_pct_realtime_proof_guard: test result: ok. 4 passed; 0 failed
sp5_dhan_feed_health_wiring_guard: test result: ok. 4 passed; 0 failed
full app suite:                 test result: ok. 672 passed; 0 failed (+ all integration suites green)
```
- `cargo fmt --check` clean
- `cargo clippy -p tickvault-app` clean for the changed files
- banned-pattern-scanner clean; pub-fn-test-guard PASS (count stable 119)

## Zero-Loss Guarantee Charter check
Cross-references `per-wave-guarantee-matrix.md`. This is a behavior-preserving
pure refactor: no new tick-drop path; ring→spill→DLQ unchanged; no new hot-path
allocation (references + `&'static str` labels only — O(1) per-seal); composite
DEDUP key unchanged; every new pub fn (`route_seal`) has a test AND a call site;
ratchet test fails the build on regression.

## Honest 100% claim
100% inside the tested envelope: the per-seal routing is byte-identical to the
pre-C2 inline closures for all three sites, pinned by the convergence ratchet
(`seal_routing_convergence_guard`) + the G3 real-time-proof guard
(`close_pct_realtime_proof_guard`). The zero-tick-loss envelope is unchanged —
the ring→spill→DLQ chain (`TICK_BUFFER_CAPACITY`, ratcheted by
`zero_tick_loss_alert_guard.rs`) is downstream of this seal-routing and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vq3E9TrMZLusiGvYHwDBJ)_